### PR TITLE
File constructor / FileBuilder API rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `File::access_plist()` or `File::fapl()` to get file access plist.
+- `File::create_plist()` or `File::fcpl()` to get file creation plist.
+
+### Changed
+
+- Changed `File` constructors, getting rid of string access modes:
+  - `File::open(path, "r")` is now `File::open(path)`
+  - `File::open(path, "r+")` is now `File::open_rw(path)`
+  - `File::open(path, "w")` is now `File::create(path)`
+  - `File::open(path, "x" | "w-")` is now `File::create_exl(path)`
+  - `File::open(path, "a")` is now `File::append(path)`
+- Also added `File::open_as(path, mode)` which accepts the mode enum.
+- Rewritten `FileBuilder`: it no longer accepts userblock, driver etc;
+  all of these parameters can be set in the corresponding FAPL / FCPL:
+  - `FileBuilder::set_access_plist()` or `FileBuilder::set_fapl()` to
+    set the active file access plist to a given one.
+  - `FileBuilder::access_plist()` or `FileBuilder::fapl()` to get a
+    mutable reference to the FAPL builder - any parameter of it can
+    then be tweaked as desired.
+  - `FileBuilder::with_access_plist()` or `FileBuilder::with_fapl()`
+    to get access to the FAPL builder in an inline way via a closure.
+  - Same as the three above for `create_plist` / `fcpl`.
+- As a result, all of the newly added FAPL / FCPL functionality is
+  fully accessible in the new `FileBuilder`. Also, driver strings
+  are gone, everything is strongly typed now.
+- It's no longer prohibited to set FCPL options when opening a file
+  and not creating it -- it will simply be silently ignored (this
+  simplifies the behavior and allows using a single file builder).
+
 ## 0.5.2
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fn main() -> hdf5::Result<()> {
 
     {
         // write
-        let file = hdf5::File::open("pixels.h5", "w")?;
+        let file = hdf5::File::create("pixels.h5")?;
         let colors = file.new_dataset::<Color>().create("colors", 2)?;
         colors.write(&[RED, BLUE])?;
         let group = file.create_group("dir")?;
@@ -56,7 +56,7 @@ fn main() -> hdf5::Result<()> {
     }
     {
         // read
-        let file = hdf5::File::open("pixels.h5", "r")?;
+        let file = hdf5::File::open("pixels.h5")?;
         let colors = file.dataset("colors")?;
         assert_eq!(colors.read_1d::<Color>()?, arr1(&[RED, BLUE]));
         let pixels = file.dataset("dir/pixels")?;

--- a/hdf5-derive/src/lib.rs
+++ b/hdf5-derive/src/lib.rs
@@ -9,8 +9,8 @@ use std::str::FromStr;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
-    parse_macro_input, AttrStyle, Attribute, Data, DeriveInput, Expr, Fields, Index,
-    Meta, NestedMeta, Type, TypeGenerics, TypePath,
+    parse_macro_input, AttrStyle, Attribute, Data, DeriveInput, Expr, Fields, Index, Meta,
+    NestedMeta, Type, TypeGenerics, TypePath,
 };
 
 #[proc_macro_derive(H5Type)]

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -59,8 +59,7 @@ fn run_command(cmd: &str, args: &[&str]) -> Option<String> {
 
 #[allow(dead_code)]
 fn is_inc_dir<P: AsRef<Path>>(path: P) -> bool {
-    path.as_ref().join("H5pubconf.h").is_file()
-    || path.as_ref().join("H5pubconf-64.h").is_file()
+    path.as_ref().join("H5pubconf.h").is_file() || path.as_ref().join("H5pubconf-64.h").is_file()
 }
 
 #[allow(dead_code)]
@@ -167,7 +166,7 @@ pub struct Header {
 impl Header {
     pub fn parse<P: AsRef<Path>>(inc_dir: P) -> Self {
         let inc_dir = inc_dir.as_ref();
-        
+
         let header = get_conf_header(inc_dir);
         println!("Parsing HDF5 config from:\n    {:?}", header);
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,4 +4,4 @@ use_try_shorthand = true
 empty_item_single_line = true
 edition = "2018"
 unstable_features = true
-fn_args_density = "Compressed"
+fn_args_layout = "Compressed"

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -114,6 +114,12 @@ impl Handle {
     pub fn is_valid_id(&self) -> bool {
         is_valid_id(self.id())
     }
+
+    pub fn decref_full(&self) {
+        while self.is_valid_user_id() {
+            self.decref();
+        }
+    }
 }
 
 impl Clone for Handle {

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -522,7 +522,12 @@ pub mod tests {
     #[test]
     pub fn test_chunks_resizable_zero_size() {
         with_tmp_file(|file| {
-            let ds = file.new_dataset::<u32>().chunk((128,)).resizable(true).create("chunked_empty", (0,)).unwrap();
+            let ds = file
+                .new_dataset::<u32>()
+                .chunk((128,))
+                .resizable(true)
+                .create("chunked_empty", (0,))
+                .unwrap();
             assert_eq!(ds.shape(), vec![0]);
 
             ds.resize((10,)).unwrap();

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -687,11 +687,11 @@ pub mod tests {
 
         with_tmp_path(|path| {
             let mut buf1: Vec<u8> = Vec::new();
-            File::open(&path, "w").unwrap().new_dataset::<u32>().create("foo", 1).unwrap();
+            File::create(&path).unwrap().new_dataset::<u32>().create("foo", 1).unwrap();
             fs::File::open(&path).unwrap().read_to_end(&mut buf1).unwrap();
 
             let mut buf2: Vec<u8> = Vec::new();
-            File::open(&path, "w")
+            File::create(&path)
                 .unwrap()
                 .new_dataset::<u32>()
                 .track_times(false)
@@ -702,7 +702,7 @@ pub mod tests {
             assert_eq!(buf1, buf2);
 
             let mut buf2: Vec<u8> = Vec::new();
-            File::open(&path, "w")
+            File::create(&path)
                 .unwrap()
                 .new_dataset::<u32>()
                 .track_times(true)

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -165,6 +165,7 @@ impl File {
         })
     }
 
+    /// Returns a copy of the file creation property list.
     pub fn get_create_plist(&self) -> Result<FileCreate> {
         h5lock!(FileCreate::from_id(h5try!(H5Fget_create_plist(self.id()))))
     }

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -4,9 +4,10 @@ use std::path::Path;
 
 use hdf5_sys::{
     h5f::{
-        H5Fclose, H5Fcreate, H5Fflush, H5Fget_create_plist, H5Fget_filesize, H5Fget_freespace,
-        H5Fget_intent, H5Fget_obj_count, H5Fget_obj_ids, H5Fopen, H5F_ACC_EXCL, H5F_ACC_RDONLY,
-        H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL, H5F_OBJ_FILE, H5F_SCOPE_LOCAL,
+        H5Fclose, H5Fcreate, H5Fflush, H5Fget_access_plist, H5Fget_create_plist,
+        H5Fget_filesize, H5Fget_freespace, H5Fget_intent, H5Fget_obj_count, H5Fget_obj_ids,
+        H5Fopen, H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL,
+        H5F_OBJ_FILE, H5F_SCOPE_LOCAL,
     },
     h5p::{
         H5Pcreate, H5Pget_userblock, H5Pset_fapl_core, H5Pset_fapl_sec2, H5Pset_fapl_stdio,
@@ -15,6 +16,7 @@ use hdf5_sys::{
 };
 
 use crate::globals::{H5P_FILE_ACCESS, H5P_FILE_CREATE};
+use crate::hl::plist::file_access::FileAccess;
 use crate::hl::plist::file_create::FileCreate;
 use crate::internal_prelude::*;
 
@@ -163,6 +165,11 @@ impl File {
             }
             self.0.decref();
         })
+    }
+
+    /// Returns a copy of the file access property list.
+    pub fn get_access_plist(&self) -> Result<FileAccess> {
+        h5lock!(FileAccess::from_id(h5try!(H5Fget_access_plist(self.id()))))
     }
 
     /// Returns a copy of the file creation property list.

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -9,10 +9,7 @@ use hdf5_sys::{
         H5F_ACC_DEFAULT, H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL,
         H5F_OBJ_FILE, H5F_SCOPE_LOCAL,
     },
-    h5p::{
-        H5Pcreate, H5Pget_userblock, H5Pset_fapl_core, H5Pset_fapl_sec2, H5Pset_fapl_stdio,
-        H5Pset_userblock,
-    },
+    h5p::{H5Pcreate, H5Pset_fapl_core, H5Pset_fapl_sec2, H5Pset_fapl_stdio, H5Pset_userblock},
 };
 
 use crate::globals::{H5P_FILE_ACCESS, H5P_FILE_CREATE};
@@ -96,13 +93,7 @@ impl File {
 
     /// Returns the userblock size in bytes (or 0 if the file handle is invalid).
     pub fn userblock(&self) -> u64 {
-        h5call!(H5Fget_create_plist(self.id()))
-            .map(|fcpl_id| {
-                let userblock: *mut hsize_t = &mut 0;
-                h5lock!(H5Pget_userblock(fcpl_id, userblock));
-                unsafe { *userblock as _ }
-            })
-            .unwrap_or(0)
+        h5lock!(self.fcpl().map(|p| p.userblock()).unwrap_or(0))
     }
 
     /// Flushes the file to the storage medium.

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 
 use hdf5_sys::{
     h5f::{
-        H5Fclose, H5Fcreate, H5Fflush, H5Fget_access_plist, H5Fget_create_plist,
-        H5Fget_filesize, H5Fget_freespace, H5Fget_intent, H5Fget_obj_count, H5Fget_obj_ids,
-        H5Fopen, H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL,
+        H5Fclose, H5Fcreate, H5Fflush, H5Fget_access_plist, H5Fget_create_plist, H5Fget_filesize,
+        H5Fget_freespace, H5Fget_intent, H5Fget_obj_count, H5Fget_obj_ids, H5Fopen,
+        H5F_ACC_DEFAULT, H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL,
         H5F_OBJ_FILE, H5F_SCOPE_LOCAL,
     },
     h5p::{
@@ -91,11 +91,7 @@ impl File {
 
     /// Returns true if the file was opened in a read-only mode.
     pub fn is_read_only(&self) -> bool {
-        unsafe {
-            let mode: *mut c_uint = &mut 0;
-            h5lock!(H5Fget_intent(self.id(), mode));
-            *mode != H5F_ACC_RDWR
-        }
+        h5get!(H5Fget_intent(self.id()): c_uint).unwrap_or(H5F_ACC_DEFAULT) != H5F_ACC_RDWR
     }
 
     /// Returns the userblock size in bytes (or 0 if the file handle is invalid).

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -2,20 +2,27 @@ use std::fmt::{self, Debug};
 use std::ops::Deref;
 use std::path::Path;
 
-use hdf5_sys::{
-    h5f::{
-        H5Fclose, H5Fcreate, H5Fflush, H5Fget_access_plist, H5Fget_create_plist, H5Fget_filesize,
-        H5Fget_freespace, H5Fget_intent, H5Fget_obj_count, H5Fget_obj_ids, H5Fopen,
-        H5F_ACC_DEFAULT, H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL,
-        H5F_OBJ_FILE, H5F_SCOPE_LOCAL,
-    },
-    h5p::{H5Pcreate, H5Pset_fapl_core, H5Pset_fapl_sec2, H5Pset_fapl_stdio, H5Pset_userblock},
+use hdf5_sys::h5f::{
+    H5Fclose, H5Fcreate, H5Fflush, H5Fget_access_plist, H5Fget_create_plist, H5Fget_filesize,
+    H5Fget_freespace, H5Fget_intent, H5Fget_obj_count, H5Fget_obj_ids, H5Fopen, H5F_ACC_DEFAULT,
+    H5F_ACC_EXCL, H5F_ACC_RDONLY, H5F_ACC_RDWR, H5F_ACC_TRUNC, H5F_OBJ_ALL, H5F_OBJ_FILE,
+    H5F_SCOPE_LOCAL,
 };
 
-use crate::globals::{H5P_FILE_ACCESS, H5P_FILE_CREATE};
-use crate::hl::plist::file_access::FileAccess;
-use crate::hl::plist::file_create::FileCreate;
+use crate::hl::plist::{
+    file_access::{FileAccess, FileAccessBuilder},
+    file_create::{FileCreate, FileCreateBuilder},
+};
 use crate::internal_prelude::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenMode {
+    Read,
+    ReadWrite,
+    Create,
+    CreateExcl,
+    Append,
+}
 
 /// Represents the HDF5 file object.
 #[repr(transparent)]
@@ -59,19 +66,37 @@ impl Deref for File {
 }
 
 impl File {
-    /// Create a new file object.
-    ///
-    /// | `mode`    | File access mode
-    /// |-----------|-----------------
-    /// | `r`       | Read-only, file must exist
-    /// | `r+`      | Read/write, file must exist
-    /// | `w`       | Create file, truncate if exists
-    /// | `w-`, `x` | Create file, fail if exists
-    /// | `a`       | Read/write if exists, create otherwise
-    pub fn open<P: AsRef<Path>>(filename: P, mode: &str) -> Result<Self> {
-        FileBuilder::new().mode(mode).open(filename)
+    /// Opens a file as read-only, file must exist.
+    pub fn open<P: AsRef<Path>>(filename: P) -> Result<Self> {
+        Self::open_as(filename, OpenMode::Read)
     }
 
+    /// Opens a file as read/write, file must exist.
+    pub fn open_rw<P: AsRef<Path>>(filename: P) -> Result<Self> {
+        Self::open_as(filename, OpenMode::ReadWrite)
+    }
+
+    /// Creates a file, truncates if exists.
+    pub fn create<P: AsRef<Path>>(filename: P) -> Result<Self> {
+        Self::open_as(filename, OpenMode::Create)
+    }
+
+    /// Creates a file, fails if exists.
+    pub fn create_excl<P: AsRef<Path>>(filename: P) -> Result<Self> {
+        Self::open_as(filename, OpenMode::CreateExcl)
+    }
+
+    /// Opens a file as read/write if exists, creates otherwise.
+    pub fn append<P: AsRef<Path>>(filename: P) -> Result<Self> {
+        Self::open_as(filename, OpenMode::Append)
+    }
+
+    /// Opens a file in a given mode.
+    pub fn open_as<P: AsRef<Path>>(filename: P, mode: OpenMode) -> Result<Self> {
+        FileBuilder::new().open_as(filename, mode)
+    }
+
+    /// Opens a file with custom file-access and file-creation options.
     pub fn with_options() -> FileBuilder {
         FileBuilder::new()
     }
@@ -101,7 +126,7 @@ impl File {
         h5call!(H5Fflush(self.id(), H5F_SCOPE_LOCAL)).and(Ok(()))
     }
 
-    /// Get objects ids of the contained objects. Note: these are borrowed references.
+    /// Returns objects IDs of the contained objects. NOTE: these are borrowed references.
     fn get_obj_ids(&self, types: c_uint) -> Vec<hid_t> {
         h5lock!({
             let count = h5call!(H5Fget_obj_count(self.id(), types)).unwrap_or(0) as size_t;
@@ -163,117 +188,159 @@ impl File {
     }
 }
 
+#[derive(Default, Clone, Debug)]
 pub struct FileBuilder {
-    driver: String,
-    mode: String,
-    userblock: u64,
-    filebacked: bool,
-    increment: u32,
-}
-
-impl Default for FileBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
+    fapl: FileAccessBuilder,
+    fcpl: FileCreateBuilder,
 }
 
 impl FileBuilder {
+    /// Creates a new file builder with default property lists.
     pub fn new() -> Self {
-        Self {
-            driver: "sec2".to_owned(),
-            mode: "r".to_owned(),
-            userblock: 0,
-            filebacked: false,
-            increment: 64 * 1024 * 1024,
-        }
+        Default::default()
     }
 
-    pub fn driver(&mut self, driver: &str) -> &mut Self {
-        self.driver = driver.into();
-        self
-    }
-
-    pub fn mode(&mut self, mode: &str) -> &mut Self {
-        self.mode = mode.into();
-        self
-    }
-
-    pub fn userblock(&mut self, userblock: u64) -> &mut Self {
-        self.userblock = userblock;
-        self
-    }
-
-    pub fn filebacked(&mut self, filebacked: bool) -> &mut Self {
-        self.filebacked = filebacked;
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn increment(&mut self, increment: u32) -> &mut Self {
-        self.increment = increment;
-        self
-    }
-
-    fn make_fapl(&self) -> Result<PropertyList> {
-        h5lock!({
-            let fapl = PropertyList::from_id(h5try!(H5Pcreate(*H5P_FILE_ACCESS)))?;
-            match self.driver.as_ref() {
-                "sec2" => h5try!(H5Pset_fapl_sec2(fapl.id())),
-                "stdio" => h5try!(H5Pset_fapl_stdio(fapl.id())),
-                "core" => {
-                    h5try!(H5Pset_fapl_core(fapl.id(), self.increment as _, self.filebacked as _))
-                }
-                _ => fail!(format!("Invalid file driver: {}", self.driver)),
-            };
-            Ok(fapl)
-        })
-    }
-
-    fn open_file<P: AsRef<Path>>(&self, filename: P, write: bool) -> Result<File> {
-        ensure!(self.userblock == 0, "Cannot specify userblock when opening a file");
-        h5lock!({
-            let fapl = self.make_fapl()?;
-            let flags = if write { H5F_ACC_RDWR } else { H5F_ACC_RDONLY };
-            let filename = filename.as_ref();
-            match filename.to_str() {
-                Some(filename) => {
-                    let filename = to_cstring(filename)?;
-                    File::from_id(h5try!(H5Fopen(filename.as_ptr(), flags, fapl.id())))
-                }
-                None => fail!("Invalid UTF-8 in file name: {:?}", filename),
-            }
-        })
-    }
-
-    fn create_file<P: AsRef<Path>>(&self, filename: P, exclusive: bool) -> Result<File> {
-        h5lock!({
-            let fcpl = PropertyList::from_id(h5try!(H5Pcreate(*H5P_FILE_CREATE)))?;
-            h5try!(H5Pset_userblock(fcpl.id(), self.userblock));
-            let fapl = self.make_fapl()?;
-            let flags = if exclusive { H5F_ACC_EXCL } else { H5F_ACC_TRUNC };
-            let filename = filename.as_ref();
-            match filename.to_str() {
-                Some(filename) => {
-                    let filename = to_cstring(filename)?;
-                    File::from_id(h5try!(H5Fcreate(filename.as_ptr(), flags, fcpl.id(), fapl.id())))
-                }
-                None => fail!("Invalid UTF-8 in file name: {:?}", filename),
-            }
-        })
-    }
-
+    /// Opens a file as read-only, file must exist.
     pub fn open<P: AsRef<Path>>(&self, filename: P) -> Result<File> {
-        match self.mode.as_ref() {
-            "r" => self.open_file(&filename, false),
-            "r+" => self.open_file(&filename, true),
-            "w" => self.create_file(&filename, false),
-            "w-" | "x" => self.create_file(&filename, true),
-            "a" => match self.open_file(&filename, true) {
-                Ok(file) => Ok(file),
-                _ => self.create_file(&filename, true),
-            },
-            _ => fail!("Invalid file access mode, expected r|r+|w|w-|x|a"),
+        self.open_as(filename, OpenMode::Read)
+    }
+
+    /// Opens a file as read/write, file must exist.
+    pub fn open_rw<P: AsRef<Path>>(&self, filename: P) -> Result<File> {
+        self.open_as(filename, OpenMode::ReadWrite)
+    }
+
+    /// Creates a file, truncates if exists.
+    pub fn create<P: AsRef<Path>>(&self, filename: P) -> Result<File> {
+        self.open_as(filename, OpenMode::Create)
+    }
+
+    /// Creates a file, fails if exists.
+    pub fn create_excl<P: AsRef<Path>>(&self, filename: P) -> Result<File> {
+        self.open_as(filename, OpenMode::CreateExcl)
+    }
+
+    /// Opens a file as read/write if exists, creates otherwise.
+    pub fn append<P: AsRef<Path>>(&self, filename: P) -> Result<File> {
+        self.open_as(filename, OpenMode::Append)
+    }
+
+    /// Opens a file in a given mode.
+    pub fn open_as<P: AsRef<Path>>(&self, filename: P, mode: OpenMode) -> Result<File> {
+        let filename = filename.as_ref();
+        if let OpenMode::Append = mode {
+            if let Ok(file) = self.open_as(filename, OpenMode::ReadWrite) {
+                return Ok(file);
+            }
         }
+        let filename = to_cstring(
+            filename
+                .to_str()
+                .ok_or_else(|| format!("Invalid UTF-8 in file name: {:?}", filename))?,
+        )?;
+        let flags = match mode {
+            OpenMode::Read => H5F_ACC_RDONLY,
+            OpenMode::ReadWrite => H5F_ACC_RDWR,
+            OpenMode::Create => H5F_ACC_TRUNC,
+            OpenMode::CreateExcl | OpenMode::Append => H5F_ACC_EXCL,
+        };
+        let fname_ptr = filename.as_ptr();
+        h5lock!({
+            let fapl = self.fapl.finish()?;
+            match mode {
+                OpenMode::Read | OpenMode::ReadWrite => {
+                    File::from_id(h5try!(H5Fopen(fname_ptr, flags, fapl.id())))
+                }
+                _ => {
+                    let fcpl = self.fcpl.finish()?;
+                    File::from_id(h5try!(H5Fcreate(fname_ptr, flags, fcpl.id(), fapl.id())))
+                }
+            }
+        })
+    }
+
+    // File Access Property List
+
+    /// Sets current file access property list to a given one.
+    pub fn set_access_plist(&mut self, fapl: &FileAccess) -> Result<&mut Self> {
+        FileAccessBuilder::from_plist(fapl).map(|fapl| {
+            self.fapl = fapl;
+            self
+        })
+    }
+
+    /// A short alias for `set_access_plist()`.
+    pub fn set_fapl(&mut self, fapl: &FileAccess) -> Result<&mut Self> {
+        self.set_access_plist(fapl)
+    }
+
+    /// Returns the builder object for the file access property list.
+    pub fn access_plist(&mut self) -> &mut FileAccessBuilder {
+        &mut self.fapl
+    }
+
+    /// A short alias for `access_plist()`.
+    pub fn fapl(&mut self) -> &mut FileAccessBuilder {
+        self.access_plist()
+    }
+
+    /// Allows accessing the builder object for the file access property list.
+    pub fn with_access_plist<F>(&mut self, func: F) -> &mut Self
+    where
+        F: Fn(&mut FileAccessBuilder) -> &mut FileAccessBuilder,
+    {
+        func(&mut self.fapl);
+        self
+    }
+
+    /// A short alias for `with_access_plist()`.
+    pub fn with_fapl<F>(&mut self, func: F) -> &mut Self
+    where
+        F: Fn(&mut FileAccessBuilder) -> &mut FileAccessBuilder,
+    {
+        self.with_access_plist(func)
+    }
+
+    // File Creation Property List
+
+    /// Sets current file creation property list to a given one.
+    pub fn set_create_plist(&mut self, fcpl: &FileCreate) -> Result<&mut Self> {
+        FileCreateBuilder::from_plist(fcpl).map(|fcpl| {
+            self.fcpl = fcpl;
+            self
+        })
+    }
+
+    /// A short alias for `set_create_plist()`.
+    pub fn set_fcpl(&mut self, fcpl: &FileCreate) -> Result<&mut Self> {
+        self.set_create_plist(fcpl)
+    }
+
+    /// Returns the builder object for the file creation property list.
+    pub fn create_plist(&mut self) -> &mut FileCreateBuilder {
+        &mut self.fcpl
+    }
+
+    /// A short alias for `create_plist()`.
+    pub fn fcpl(&mut self) -> &mut FileCreateBuilder {
+        self.create_plist()
+    }
+
+    /// Allows accessing the builder object for the file creation property list.
+    pub fn with_create_plist<F>(&mut self, func: F) -> &mut Self
+    where
+        F: Fn(&mut FileCreateBuilder) -> &mut FileCreateBuilder,
+    {
+        func(&mut self.fcpl);
+        self
+    }
+
+    /// A short alias for `with_create_plist()`.
+    pub fn with_fcpl<F>(&mut self, func: F) -> &mut Self
+    where
+        F: Fn(&mut FileCreateBuilder) -> &mut FileCreateBuilder,
+    {
+        self.with_create_plist(func)
     }
 }
 
@@ -285,89 +352,83 @@ pub mod tests {
     use std::io::{Read, Write};
 
     #[test]
-    pub fn test_invalid_mode() {
-        with_tmp_dir(|dir| {
-            assert_err!(File::open(&dir, "foo"), "Invalid file access mode");
-        })
-    }
-
-    #[test]
     pub fn test_is_read_only() {
         with_tmp_path(|path| {
-            assert!(!File::open(&path, "w").unwrap().is_read_only());
-            assert!(File::open(&path, "r").unwrap().is_read_only());
-            assert!(!File::open(&path, "r+").unwrap().is_read_only());
-            assert!(!File::open(&path, "a").unwrap().is_read_only());
+            assert!(!File::create(&path).unwrap().is_read_only());
+            assert!(File::open(&path).unwrap().is_read_only());
+            assert!(!File::open_rw(&path).unwrap().is_read_only());
+            assert!(!File::append(&path).unwrap().is_read_only());
         });
         with_tmp_path(|path| {
-            assert!(!File::open(&path, "a").unwrap().is_read_only());
+            assert!(!File::append(&path).unwrap().is_read_only());
         });
         with_tmp_path(|path| {
-            assert!(!File::open(&path, "x").unwrap().is_read_only());
+            assert!(!File::create_excl(&path).unwrap().is_read_only());
         });
     }
 
     #[test]
     pub fn test_unable_to_open() {
         with_tmp_dir(|dir| {
-            assert_err!(File::open(&dir, "r"), "unable to open file");
-            assert_err!(File::open(&dir, "r+"), "unable to open file");
-            assert_err!(File::open(&dir, "x"), "unable to create file");
-            assert_err!(File::open(&dir, "w-"), "unable to create file");
-            assert_err!(File::open(&dir, "w"), "unable to create file");
-            assert_err!(File::open(&dir, "a"), "unable to create file");
+            assert_err!(File::open(&dir), "unable to open file");
+            assert_err!(File::open_rw(&dir), "unable to open file");
+            assert_err!(File::create_excl(&dir), "unable to create file");
+            assert_err!(File::create(&dir), "unable to create file");
+            assert_err!(File::append(&dir), "unable to create file");
         });
-
         with_tmp_path(|path| {
             fs::File::create(&path).unwrap().write_all(b"foo").unwrap();
             assert!(fs::metadata(&path).is_ok());
-            assert_err!(File::open(&path, "r"), "unable to open file");
+            assert_err!(File::open(&path), "unable to open file");
         })
     }
 
     #[test]
-    pub fn test_access_modes() {
-        // "w" means overwrite
+    pub fn test_file_create() {
         with_tmp_path(|path| {
-            File::open(&path, "w").unwrap().create_group("foo").unwrap();
-            assert_err!(File::open(&path, "w").unwrap().group("foo"), "unable to open group");
+            File::create(&path).unwrap().create_group("foo").unwrap();
+            assert_err!(File::create(&path).unwrap().group("foo"), "unable to open group");
         });
+    }
 
-        // "w-"/"x-" means exclusive write
+    #[test]
+    pub fn test_file_create_excl() {
         with_tmp_path(|path| {
-            File::open(&path, "w-").unwrap();
-            assert_err!(File::open(&path, "w-"), "unable to create file");
+            File::create_excl(&path).unwrap();
+            assert_err!(File::create_excl(&path), "unable to create file");
         });
-        with_tmp_path(|path| {
-            File::open(&path, "x").unwrap();
-            assert_err!(File::open(&path, "x"), "unable to create file");
-        });
+    }
 
-        // "a" means append
+    #[test]
+    pub fn test_file_append() {
         with_tmp_path(|path| {
-            File::open(&path, "a").unwrap().create_group("foo").unwrap();
-            File::open(&path, "a").unwrap().group("foo").unwrap();
+            File::append(&path).unwrap().create_group("foo").unwrap();
+            File::append(&path).unwrap().group("foo").unwrap();
         });
+    }
 
-        // "r" means read-only
+    #[test]
+    pub fn test_file_open() {
         with_tmp_path(|path| {
-            File::open(&path, "w").unwrap().create_group("foo").unwrap();
-            let file = File::open(&path, "r").unwrap();
+            File::create(&path).unwrap().create_group("foo").unwrap();
+            let file = File::open(&path).unwrap();
             file.group("foo").unwrap();
             assert_err!(
                 file.create_group("bar"),
                 "unable to create group: no write intent on file"
             );
-            assert_err!(File::open("/foo/bar/baz", "r"), "unable to open file");
+            assert_err!(File::open("/foo/bar/baz"), "unable to open file");
         });
+    }
 
-        // "r+" means read-write
+    #[test]
+    pub fn test_file_open_rw() {
         with_tmp_path(|path| {
-            File::open(&path, "w").unwrap().create_group("foo").unwrap();
-            let file = File::open(&path, "r+").unwrap();
+            File::create(&path).unwrap().create_group("foo").unwrap();
+            let file = File::open_rw(&path).unwrap();
             file.group("foo").unwrap();
             file.create_group("bar").unwrap();
-            assert_err!(File::open("/foo/bar/baz", "r+"), "unable to open file");
+            assert_err!(File::open_rw("/foo/bar/baz"), "unable to open file");
         });
     }
 
@@ -397,22 +458,14 @@ pub mod tests {
         });
         with_tmp_path(|path| {
             assert_err!(
-                FileBuilder::new().userblock(512).mode("r").open(&path),
-                "Cannot specify userblock when opening a file"
-            );
-            assert_err!(
-                FileBuilder::new().userblock(512).mode("r+").open(&path),
-                "Cannot specify userblock when opening a file"
-            );
-            assert_err!(
-                FileBuilder::new().userblock(1).mode("w").open(&path),
+                FileBuilder::new().with_fcpl(|p| p.userblock(1)).create(&path),
                 "userblock size is non-zero and less than 512"
             );
-            FileBuilder::new().userblock(512).mode("w").open(&path).unwrap();
-            assert_eq!(File::open(&path, "r").unwrap().userblock(), 512);
+            FileBuilder::new().with_fcpl(|p| p.userblock(512)).create(&path).unwrap();
+            assert_eq!(File::open(&path).unwrap().userblock(), 512);
 
             // writing to userblock doesn't corrupt the file
-            File::open(&path, "r+").unwrap().create_group("foo").unwrap();
+            File::open_rw(&path).unwrap().create_group("foo").unwrap();
             {
                 let mut file = fs::OpenOptions::new()
                     .read(true)
@@ -425,10 +478,10 @@ pub mod tests {
                 }
                 file.flush().unwrap();
             }
-            File::open(&path, "r").unwrap().group("foo").unwrap();
+            File::open(&path).unwrap().group("foo").unwrap();
 
             // writing to file doesn't corrupt the userblock
-            File::open(&path, "r+").unwrap().create_group("foo/bar").unwrap();
+            File::open_rw(&path).unwrap().create_group("foo/bar").unwrap();
             {
                 let mut reader = fs::File::open(&path).unwrap().take(512);
                 let mut data: Vec<u8> = Vec::new();
@@ -437,7 +490,7 @@ pub mod tests {
                     assert_eq!(item, (i % 256) as u8);
                 }
             }
-            File::open(&path, "r").unwrap().group("foo/bar").unwrap();
+            File::open(&path).unwrap().group("foo/bar").unwrap();
         })
     }
 
@@ -445,7 +498,7 @@ pub mod tests {
     pub fn test_close_automatic() {
         // File going out of scope should just close its own handle
         with_tmp_path(|path| {
-            let file = File::open(&path, "w").unwrap();
+            let file = File::create(&path).unwrap();
             let group = file.create_group("foo").unwrap();
             let file_copy = group.file().unwrap();
             drop(file);
@@ -458,7 +511,7 @@ pub mod tests {
     pub fn test_close_manual() {
         // File::close() should close handles of all related objects
         with_tmp_path(|path| {
-            let file = File::open(&path, "w").unwrap();
+            let file = File::create(&path).unwrap();
             let group = file.create_group("foo").unwrap();
             let file_copy = group.file().unwrap();
             file.close();
@@ -471,13 +524,13 @@ pub mod tests {
     pub fn test_core_fd_non_filebacked() {
         with_tmp_path(|path| {
             let file =
-                FileBuilder::new().driver("core").filebacked(false).mode("w").open(&path).unwrap();
+                FileBuilder::new().with_fapl(|p| p.core_filebacked(false)).create(&path).unwrap();
             file.create_group("x").unwrap();
             assert!(file.is_valid());
             file.close();
             assert!(fs::metadata(&path).is_err());
             assert_err!(
-                FileBuilder::new().driver("core").mode("r").open(&path),
+                FileBuilder::new().with_fapl(|p| p.core()).open(&path),
                 "unable to open file"
             );
         })
@@ -487,20 +540,20 @@ pub mod tests {
     pub fn test_core_fd_filebacked() {
         with_tmp_path(|path| {
             let file =
-                FileBuilder::new().driver("core").filebacked(true).mode("w").open(&path).unwrap();
+                FileBuilder::new().with_fapl(|p| p.core_filebacked(true)).create(&path).unwrap();
             assert!(file.is_valid());
             file.create_group("bar").unwrap();
             file.close();
             assert!(fs::metadata(&path).is_ok());
-            File::open(&path, "r").unwrap().group("bar").unwrap();
+            File::open(&path).unwrap().group("bar").unwrap();
         })
     }
 
     #[test]
     pub fn test_core_fd_existing_file() {
         with_tmp_path(|path| {
-            File::open(&path, "w").unwrap().create_group("baz").unwrap();
-            FileBuilder::new().driver("core").mode("r").open(&path).unwrap().group("baz").unwrap();
+            File::create(&path).unwrap().create_group("baz").unwrap();
+            FileBuilder::new().with_fapl(|p| p.core()).open(&path).unwrap().group("baz").unwrap();
         })
     }
 
@@ -508,13 +561,12 @@ pub mod tests {
     pub fn test_sec2_fd() {
         with_tmp_path(|path| {
             FileBuilder::new()
-                .driver("sec2")
-                .mode("w")
-                .open(&path)
+                .with_fapl(|p| p.sec2())
+                .create(&path)
                 .unwrap()
                 .create_group("foo")
                 .unwrap();
-            FileBuilder::new().driver("sec2").mode("r").open(&path).unwrap().group("foo").unwrap();
+            FileBuilder::new().with_fapl(|p| p.sec2()).open(&path).unwrap().group("foo").unwrap();
         })
     }
 
@@ -522,13 +574,12 @@ pub mod tests {
     pub fn test_stdio_fd() {
         with_tmp_path(|path| {
             FileBuilder::new()
-                .driver("stdio")
-                .mode("w")
-                .open(&path)
+                .with_fapl(|p| p.stdio())
+                .create(&path)
                 .unwrap()
                 .create_group("qwe")
                 .unwrap();
-            FileBuilder::new().driver("stdio").mode("r").open(&path).unwrap().group("qwe").unwrap();
+            FileBuilder::new().with_fapl(|p| p.stdio()).open(&path).unwrap().group("qwe").unwrap();
         })
     }
 
@@ -536,12 +587,12 @@ pub mod tests {
     pub fn test_debug() {
         with_tmp_dir(|dir| {
             let path = dir.join("qwe.h5");
-            let file = File::open(&path, "w").unwrap();
+            let file = File::create(&path).unwrap();
             assert_eq!(format!("{:?}", file), "<HDF5 file: \"qwe.h5\" (read/write)>");
             let root = file.file().unwrap();
             file.close();
             assert_eq!(format!("{:?}", root), "<HDF5 file: invalid id>");
-            let file = File::open(&path, "r").unwrap();
+            let file = File::open(&path).unwrap();
             assert_eq!(format!("{:?}", file), "<HDF5 file: \"qwe.h5\" (read-only)>");
         })
     }

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -172,9 +172,19 @@ impl File {
         h5lock!(FileAccess::from_id(h5try!(H5Fget_access_plist(self.id()))))
     }
 
+    /// A short alias for `get_access_plist()`.
+    pub fn fapl(&self) -> Result<FileAccess> {
+        self.get_access_plist()
+    }
+
     /// Returns a copy of the file creation property list.
     pub fn get_create_plist(&self) -> Result<FileCreate> {
         h5lock!(FileCreate::from_id(h5try!(H5Fget_create_plist(self.id()))))
+    }
+
+    /// A short alias for `get_create_plist()`.
+    pub fn fcpl(&self) -> Result<FileCreate> {
+        self.get_create_plist()
     }
 }
 

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -86,12 +86,7 @@ impl File {
 
     /// Returns the free space in the file in bytes (or 0 if the file handle is invalid).
     pub fn free_space(&self) -> u64 {
-        let freespace = h5lock!(H5Fget_freespace(self.id()));
-        if freespace < 0 {
-            0
-        } else {
-            freespace as _
-        }
+        h5lock!(H5Fget_freespace(self.id())).max(0) as _
     }
 
     /// Returns true if the file was opened in a read-only mode.

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -144,19 +144,13 @@ impl File {
             let file_ids = self.get_obj_ids(H5F_OBJ_FILE);
             let object_ids = self.get_obj_ids(H5F_OBJ_ALL & !H5F_OBJ_FILE);
             for file_id in &file_ids {
-                let handle = Handle::try_new(*file_id);
-                if let Ok(handle) = handle {
-                    while handle.is_valid_user_id() {
-                        handle.decref();
-                    }
+                if let Ok(handle) = Handle::try_new(*file_id) {
+                    handle.decref_full();
                 }
             }
             for object_id in &object_ids {
-                let handle = Handle::try_new(*object_id);
-                if let Ok(handle) = handle {
-                    while handle.is_valid_user_id() {
-                        handle.decref();
-                    }
+                if let Ok(handle) = Handle::try_new(*object_id) {
+                    handle.decref_full();
                 }
             }
             H5Fclose(self.id());

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -144,23 +144,23 @@ impl File {
     }
 
     /// Returns a copy of the file access property list.
-    pub fn get_access_plist(&self) -> Result<FileAccess> {
+    pub fn access_plist(&self) -> Result<FileAccess> {
         h5lock!(FileAccess::from_id(h5try!(H5Fget_access_plist(self.id()))))
     }
 
-    /// A short alias for `get_access_plist()`.
+    /// A short alias for `access_plist()`.
     pub fn fapl(&self) -> Result<FileAccess> {
-        self.get_access_plist()
+        self.access_plist()
     }
 
     /// Returns a copy of the file creation property list.
-    pub fn get_create_plist(&self) -> Result<FileCreate> {
+    pub fn create_plist(&self) -> Result<FileCreate> {
         h5lock!(FileCreate::from_id(h5try!(H5Fget_create_plist(self.id()))))
     }
 
-    /// A short alias for `get_create_plist()`.
+    /// A short alias for `create_plist()`.
     pub fn fcpl(&self) -> Result<FileCreate> {
-        self.get_create_plist()
+        self.create_plist()
     }
 }
 

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -98,7 +98,6 @@ impl File {
 
     /// Flushes the file to the storage medium.
     pub fn flush(&self) -> Result<()> {
-        // TODO: &mut self?
         h5call!(H5Fflush(self.id(), H5F_SCOPE_LOCAL)).and(Ok(()))
     }
 

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -15,16 +15,22 @@ use crate::hl::plist::{
 };
 use crate::internal_prelude::*;
 
+/// File opening mode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpenMode {
+    /// Open a file as read-only, file must exist.
     Read,
+    /// Open a file as read/write, file must exist.
     ReadWrite,
+    /// Create a file, truncate if exists.
     Create,
+    /// Create a file, fail if exists.
     CreateExcl,
+    /// Open a file as read/write if exists, create otherwise.
     Append,
 }
 
-/// Represents the HDF5 file object.
+/// HDF5 file object.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct File(Handle);
@@ -188,6 +194,7 @@ impl File {
     }
 }
 
+/// File builder allowing to customize file access/creation property lists.
 #[derive(Default, Clone, Debug)]
 pub struct FileBuilder {
     fapl: FileAccessBuilder,

--- a/src/hl/location.rs
+++ b/src/hl/location.rs
@@ -94,7 +94,7 @@ pub mod tests {
     #[test]
     pub fn test_filename() {
         with_tmp_path(|path| {
-            assert_eq!(File::open(&path, "w").unwrap().filename(), path.to_str().unwrap());
+            assert_eq!(File::create(&path).unwrap().filename(), path.to_str().unwrap());
         })
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -17,7 +17,7 @@ pub fn with_tmp_path<F: Fn(PathBuf)>(func: F) {
 
 pub fn with_tmp_file<F: Fn(File)>(func: F) {
     with_tmp_path(|path| {
-        let file = File::open(&path, "w").unwrap();
+        let file = File::create(&path).unwrap();
         func(file);
     })
 }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -6,5 +6,5 @@ pub fn random_filename() -> String {
 
 pub fn new_in_memory_file() -> hdf5::Result<hdf5::File> {
     let filename = random_filename();
-    hdf5::File::with_options().mode("w").driver("core").filebacked(false).open(&filename)
+    hdf5::File::with_options().with_fapl(|p| p.core_filebacked(false)).create(&filename)
 }


### PR DESCRIPTION
This is certainly a breaking change, but better sooner than later (initial discussion with @Enet4 a while ago in #14).

Main points:

- FAPL and FCPL bindings are pretty much 100% complete, it's a shame they couldn't have been used until now; this is now fixed, the new FileBuilder has full access to those (!).
- String-based modes like "r" and "w" are gone. Instead, you can just use `File::open()`, `File::open_rw()`, `File::create()`, `File::create_excl()` and `File::append()` (FileBuilder has those methods two as finishers).
- In case of need, there's also `File::open_as()` which mimics previous behaviour, but is strongly typed and doesn't use string-based modes either (FileBuilder has it too).
- Special cases like driver strings etc are gone from the new FileBuilder, instead you can access FAPL and FCPL builders from it in a few different ways (by importing an existing plist, by getting a mutable reference, or by providing a closure that does something).

Example 1:

```rust
// before
File::open("foo.h5", "r+")

// after
File::open_rw("foo.h5")
```

Example 2:

```rust
// before
File::with_options().mode("w").driver("core").filebacked(false).open(&filename)

// after
File::with_options().with_fapl(|p| p.core_filebacked(false)).create(&filename)
```