### PR TITLE
hdf5-sys: Add missing H5Dread_chunk and H5Dwrite_chunk functions

### DIFF
--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -229,6 +229,17 @@ mod hdf5_1_10_0 {
 #[cfg(hdf5_1_10_0)]
 pub use self::hdf5_1_10_0::*;
 
+#[cfg(hdf5_1_10_3)]
+extern "C" {
+    pub fn H5Dread_chunk(
+        dset_id: hid_t, dxpl_id: hid_t, offset: *const hsize_t, filters: *mut u32, buf: *mut c_void,
+    ) -> herr_t;
+    pub fn H5Dwrite_chunk(
+        dset_id: hid_t, dxpl_id: hid_t, filters: u32, offset: *const hsize_t, data_size: size_t,
+        buf: *const c_void,
+    ) -> herr_t;
+}
+
 #[cfg(hdf5_1_10_5)]
 extern "C" {
     pub fn H5Dget_chunk_info(


### PR DESCRIPTION
These "optimized functions" are missing from the documentation but have been part of the public API since 1.10.3.
https://www.hdfgroup.org/2018/08/hdf5-1-10-3-release-newsletter-164/