### PR TITLE
Fix Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,10 @@ script:
 before_install:
 - |
   if [ `uname` = "Darwin" ] && [ ! -z "$H5_BREW" ]; then
-    brew update >/dev/null;
-    brew install hdf5@${H5_BREW};
+    brew update >/dev/null || true;
+    brew remove --ignore-dependencies hdf5 || true;
+    brew install hdf5@${H5_BREW} || true;
+    true
   fi
 - |
   if [ ! -z "$H5_CONDA" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - name: xenial-stable-conda-1.10.4
       os: linux
       dist: xenial
-      rust: stable
+      rust: 1.37.0
       env:
         - H5_CONDA=1.10.4
     - name: xenial-beta-apt-1.8.13

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ before_install:
 - |
   if [ `uname` = "Darwin" ] && [ ! -z "$H5_BREW" ]; then
     brew update >/dev/null;
-    brew tap homebrew/science;
     brew install hdf5@${H5_BREW};
   fi
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,6 @@ before_install:
     brew update >/dev/null;
     brew tap homebrew/science;
     brew install hdf5@${H5_BREW};
-    # https://github.com/laumann/compiletest-rs/issues/179
-    export DYLD_LIBRARY_PATH="/usr/lib:/usr/local/lib";
-    brew unlink jpeg giflib libpng libtiff
   fi
 - |
   if [ ! -z "$H5_CONDA" ]; then
@@ -80,8 +77,6 @@ before_install:
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
       # note: this is only required for older HDF5 installations on OS X
       export DYLD_FALLBACK_LIBRARY_PATH="$HOME/miniconda/envs/testenv/lib";
-      # https://github.com/laumann/compiletest-rs/issues/179
-      export DYLD_LIBRARY_PATH="$HOME/miniconda/envs/testenv/lib";
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: rust
 notifications:
   email:
@@ -7,17 +6,16 @@ addons:
   apt:
     packages:
       - pkg-config
+os: linux
 
-matrix:
+jobs:
   include:
     - name: xenial-stable-conda-1.10.4
-      os: linux
       dist: xenial
       rust: 1.37.0
       env:
         - H5_CONDA=1.10.4
     - name: xenial-beta-apt-1.8.13
-      os: linux
       dist: xenial
       rust: beta
       addons:
@@ -27,7 +25,6 @@ matrix:
       env:
         - HDF5_VERSION=1.8.16
     - name: trusty-nightly-apt-1.8.11
-      os: linux
       dist: trusty
       rust: nightly
       addons:
@@ -115,9 +112,9 @@ before_deploy:
   - echo '<meta http-equiv=refresh content=0;url=hdf5/index.html>' > target/doc/index.html
 deploy:
   provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN
-  local-dir: target/doc
+  cleanup: true
+  token: $GITHUB_TOKEN
+  local_dir: target/doc
   on:
     branch: master
     condition: "$TRAVIS_RUST_VERSION = stable && $TRAVIS_OS_NAME = linux"


### PR DESCRIPTION
- Update somewhat-outdated Travis config (now passes all of their lints)
- Run at least one env on the minimum-supported Rust version (1.37)
- Fix macOS homebrew builds - it looks like both of them were running 1.10.5, now it's guaranteed to be 1.8.* and 1.10.* (currently 1.8.21 and 1.10.6).