### PR TITLE
Implement Dimension for slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Slices can now be used used where trait item `Dimension` is required.
+
 ### Changed
 - Dependencies are bumped to newest major versions; `ndarray` users may now
   use both version `0.13` and version `0.14`.

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -19,7 +19,7 @@ pub trait Dimension {
     }
 }
 
-impl<'a, T: Dimension> Dimension for &'a T {
+impl<'a, T: Dimension + ?Sized> Dimension for &'a T {
     fn ndim(&self) -> usize {
         Dimension::ndim(*self)
     }
@@ -94,5 +94,15 @@ impl Dimension for Ix {
 
     fn dims(&self) -> Vec<Ix> {
         vec![*self]
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    // compile-time test
+    #[allow(dead_code)]
+    pub fn slice_as_shape(shape: &[usize]) {
+        let file = crate::File::create("foo.h5").unwrap();
+        file.new_dataset::<u8>().create("Test", shape).unwrap();
     }
 }


### PR DESCRIPTION
Add a `?Sized` bound to the `Dimension` implementation for `&T` to ensure that unsized slices can be used as shape.

I also added a small `slice_as_shape` test function that only compiles with the `?Sized` bound.