### PR TITLE
Add 1.12.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,31 @@ jobs:
           command: ${{matrix.command}}
           args: "${{matrix.command == 'fmt' && '--all -- --check' || '-- -D warnings'}}"
 
+  brew:
+    name: brew
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {version: hdf5@1.8}
+          - {version: hdf5@1.10}
+          - {version: hdf5@1.12}
+          - {version: hdf5-mpi, mpi: true}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with: {submodules: true}
+      - name: Install Rust (${{matrix.rust}})
+        uses: actions-rs/toolchain@v1
+        with: {toolchain: stable, profile: minimal, override: true}
+      - name: Install HDF5 (${{matrix.version}})
+        run: brew install ${{matrix.version}}
+      - name: Build and test all crates
+        run: |
+          [ "${{matrix.mpi}}" != "" ] && FEATURES=mpio
+          cargo test -vv --features="$FEATURES"
+
   conda:
     name: conda
     runs-on: ${{matrix.os}}-latest
@@ -55,6 +80,9 @@ jobs:
           - {os: macos, version: 1.10.5, mpi: openmpi, channel: conda-forge, rust: beta}
           - {os: ubuntu, version: 1.10.6, channel: anaconda, rust: stable}
           - {os: ubuntu, version: 1.10.6, mpi: mpich, channel: conda-forge, rust: nightly}
+          - {os: ubuntu, version: 1.12.0, mpi: openmpi, channel: conda-forge, rust: stable}
+          - {os: macos, version: 1.12.0, channel: conda-forge, rust: stable}
+          - {os: windows, version: 1.12.0, channel: conda-forge, rust: stable}
     defaults:
       run:
         shell: bash -l {0}
@@ -101,26 +129,6 @@ jobs:
         with: {toolchain: '${{matrix.rust}}', profile: minimal, override: true}
       - name: Build and test all crates
         run: cargo test --workspace -v --features hdf5-sys/static,hdf5-sys/zlib --exclude hdf5-derive
-
-  brew:
-    name: brew
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [1.8, '1.10']
-        rust: [stable]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with: {submodules: true}
-      - name: Install Rust (${{matrix.rust}})
-        uses: actions-rs/toolchain@v1
-        with: {toolchain: '${{matrix.rust}}', profile: minimal, override: true}
-      - name: Install HDF5 (${{matrix.version}})
-        run: brew install hdf5@${{matrix.version}}
-      - name: Build and test all crates
-        run: cargo test -v
 
   apt:
     name: apt

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -25,7 +25,7 @@ impl Version {
     }
 
     pub fn parse(s: &str) -> Option<Self> {
-        let re = Regex::new(r"^(1)\.(8|10)\.(\d\d?)(_\d+)?(-patch\d+)?$").ok()?;
+        let re = Regex::new(r"^(1)\.(8|10|12)\.(\d\d?)(_\d+)?(-patch\d+)?$").ok()?;
         let captures = re.captures(s)?;
         Some(Self {
             major: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
@@ -35,7 +35,10 @@ impl Version {
     }
 
     pub fn is_valid(self) -> bool {
-        self.major == 1 && ((self.minor == 8 && self.micro >= 4) || (self.minor == 10))
+        self.major == 1
+            && ((self.minor == 8 && self.micro >= 4)
+                || (self.minor == 10)
+                || (self.minor == 12 && self.micro == 0))
     }
 }
 
@@ -592,6 +595,7 @@ impl Config {
         assert!(version >= Version::new(1, 8, 4), "required HDF5 version: >=1.8.4");
         let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-21]
         vs.extend((0..=5).map(|v| Version::new(1, 10, v))); // 1.10.[0-5]
+        vs.push(Version::new(1, 12, 0)); // 1.12.0
         for v in vs.into_iter().filter(|&v| version >= v) {
             println!("cargo:rustc-cfg=hdf5_{}_{}_{}", v.major, v.minor, v.micro);
             println!("cargo:version_{}_{}_{}=1", v.major, v.minor, v.micro);

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -139,6 +139,8 @@ extern "C" {
     )]
     pub fn H5Fset_latest_format(file_id: hid_t, latest_format: hbool_t) -> herr_t;
     pub fn H5Fis_hdf5(filename: *const c_char) -> htri_t;
+    #[cfg(hdf5_1_12_0)]
+    pub fn H5Fis_accessible(container_name: *const c_char, fapl_id: hid_t) -> htri_t;
     pub fn H5Fcreate(
         filename: *const c_char, flags: c_uint, create_plist: hid_t, access_plist: hid_t,
     ) -> hid_t;
@@ -146,9 +148,13 @@ extern "C" {
     pub fn H5Freopen(file_id: hid_t) -> hid_t;
     pub fn H5Fflush(object_id: hid_t, scope: H5F_scope_t) -> herr_t;
     pub fn H5Fclose(file_id: hid_t) -> herr_t;
+    #[cfg(hdf5_1_12_0)]
+    pub fn H5Fdelete(filename: *const c_char, fapl_id: hid_t) -> herr_t;
     pub fn H5Fget_create_plist(file_id: hid_t) -> hid_t;
     pub fn H5Fget_access_plist(file_id: hid_t) -> hid_t;
     pub fn H5Fget_intent(file_id: hid_t, intent: *mut c_uint) -> herr_t;
+    #[cfg(hdf5_1_12_0)]
+    pub fn H5Fget_fileno(file_id: hid_t, fileno: *mut c_ulong) -> herr_t;
     pub fn H5Fget_obj_count(file_id: hid_t, types: c_uint) -> ssize_t;
     pub fn H5Fget_obj_ids(
         file_id: hid_t, types: c_uint, max_objs: size_t, obj_id_list: *mut hid_t,

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -8,20 +8,27 @@ pub enum H5I_type_t {
     H5I_UNINIT = -2,
     H5I_BADID = -1,
     H5I_FILE = 1,
-    H5I_GROUP = 2,
-    H5I_DATATYPE = 3,
-    H5I_DATASPACE = 4,
-    H5I_DATASET = 5,
-    H5I_ATTR = 6,
+    H5I_GROUP,
+    H5I_DATATYPE,
+    H5I_DATASPACE,
+    H5I_DATASET,
+    #[cfg(hdf5_1_12_0)]
+    H5I_MAP,
+    H5I_ATTR,
+    #[cfg(not(hdf5_1_12_0))]
     #[cfg_attr(hdf5_1_10_2, deprecated(note = "deprecated in HDF5 1.10.2"))]
-    H5I_REFERENCE = 7,
-    H5I_VFL = 8,
-    H5I_GENPROP_CLS = 9,
-    H5I_GENPROP_LST = 10,
-    H5I_ERROR_CLASS = 11,
-    H5I_ERROR_MSG = 12,
-    H5I_ERROR_STACK = 13,
-    H5I_NTYPES = 14,
+    H5I_REFERENCE,
+    H5I_VFL,
+    #[cfg(hdf5_1_12_0)]
+    H5I_VOL,
+    H5I_GENPROP_CLS,
+    H5I_GENPROP_LST,
+    H5I_ERROR_CLASS,
+    H5I_ERROR_MSG,
+    H5I_ERROR_STACK,
+    #[cfg(hdf5_1_12_0)]
+    H5I_SPACE_SEL_ITER,
+    H5I_NTYPES,
 }
 
 #[cfg(hdf5_1_10_0)]
@@ -35,6 +42,8 @@ pub const H5I_INVALID_HID: hid_t = -1;
 pub type H5I_free_t = Option<extern "C" fn(arg1: *mut c_void) -> herr_t>;
 pub type H5I_search_func_t =
     Option<extern "C" fn(obj: *mut c_void, id: hid_t, key: *mut c_void) -> c_int>;
+#[cfg(hdf5_1_12_0)]
+pub type H5I_iterate_func_t = Option<extern "C" fn(id: hid_t, udata: *mut c_void) -> herr_t>;
 
 extern "C" {
     pub fn H5Iregister(type_: H5I_type_t, object: *const c_void) -> hid_t;
@@ -55,6 +64,8 @@ extern "C" {
     pub fn H5Idec_type_ref(type_: H5I_type_t) -> c_int;
     pub fn H5Iget_type_ref(type_: H5I_type_t) -> c_int;
     pub fn H5Isearch(type_: H5I_type_t, func: H5I_search_func_t, key: *mut c_void) -> *mut c_void;
+    #[cfg(hdf5_1_12_0)]
+    pub fn H5Iiterate(type_: H5I_type_t, op: H5I_iterate_func_t, op_data: *mut c_void) -> herr_t;
     pub fn H5Inmembers(type_: H5I_type_t, num_members: *mut hsize_t) -> herr_t;
     pub fn H5Itype_exists(type_: H5I_type_t) -> htri_t;
     pub fn H5Iis_valid(id: hid_t) -> htri_t;

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -123,6 +123,22 @@ mod globals {
     extern_static!(H5P_LST_OBJECT_COPY, H5P_LST_OBJECT_COPY_ID_g);
     extern_static!(H5P_LST_LINK_CREATE, H5P_LST_LINK_CREATE_ID_g);
     extern_static!(H5P_LST_LINK_ACCESS, H5P_LST_LINK_ACCESS_ID_g);
+
+    #[cfg(hdf5_1_12_0)]
+    #[allow(clippy::module_inception)]
+    pub mod globals {
+        use super::*;
+        extern_static!(H5P_MAP_CREATE, H5P_CLS_MAP_CREATE_ID_g);
+        extern_static!(H5P_MAP_ACCESS, H5P_CLS_MAP_ACCESS_ID_g);
+        extern_static!(H5P_VOL_INITIALIZE, H5P_CLS_VOL_INITIALIZE_ID_g);
+        extern_static!(H5P_REFERENCE_ACCESS, H5P_CLS_REFERENCE_ACCESS_ID_g);
+        extern_static!(H5P_MAP_CREATE_DEFAULT, H5P_LST_MAP_CREATE_ID_g);
+        extern_static!(H5P_MAP_ACCESS_DEFAULT, H5P_LST_MAP_ACCESS_ID_g);
+        extern_static!(H5P_VOL_INITIALIZE_DEFAULT, H5P_LST_VOL_INITIALIZE_ID_g);
+        extern_static!(H5P_REFERENCE_ACCESS_DEFAULT, H5P_LST_REFERENCE_ACCESS_ID_g);
+    }
+    #[cfg(hdf5_1_12_0)]
+    pub use globals::*;
 }
 
 #[cfg(all(not(hdf5_1_8_14), all(target_env = "msvc", not(feature = "static"))))]
@@ -205,6 +221,22 @@ mod globals {
     extern_static!(H5P_LST_OBJECT_COPY, __imp_H5P_LST_OBJECT_COPY_ID_g);
     extern_static!(H5P_LST_LINK_CREATE, __imp_H5P_LST_LINK_CREATE_ID_g);
     extern_static!(H5P_LST_LINK_ACCESS, __imp_H5P_LST_LINK_ACCESS_ID_g);
+
+    #[cfg(hdf5_1_12_0)]
+    #[allow(clippy::module_inception)]
+    pub mod globals {
+        use super::*;
+        extern_static!(H5P_MAP_CREATE, __imp_H5P_CLS_MAP_CREATE_ID_g);
+        extern_static!(H5P_MAP_ACCESS, __imp_H5P_CLS_MAP_ACCESS_ID_g);
+        extern_static!(H5P_VOL_INITIALIZE, __imp_H5P_CLS_VOL_INITIALIZE_ID_g);
+        extern_static!(H5P_REFERENCE_ACCESS, __imp_H5P_CLS_REFERENCE_ACCESS_ID_g);
+        extern_static!(H5P_MAP_CREATE_DEFAULT, __imp_H5P_LST_MAP_CREATE_ID_g);
+        extern_static!(H5P_MAP_ACCESS_DEFAULT, __imp_H5P_LST_MAP_ACCESS_ID_g);
+        extern_static!(H5P_VOL_INITIALIZE_DEFAULT, __imp_H5P_LST_VOL_INITIALIZE_ID_g);
+        extern_static!(H5P_REFERENCE_ACCESS_DEFAULT, __imp_H5P_LST_REFERENCE_ACCESS_ID_g);
+    }
+    #[cfg(hdf5_1_12_0)]
+    pub use globals::*;
 }
 
 extern "C" {
@@ -656,7 +688,13 @@ extern "C" {
     pub fn H5Pset_virtual_view(plist_id: hid_t, view: H5D_vds_view_t) -> herr_t;
     pub fn H5Pget_chunk_opts(plist_id: hid_t, opts: *mut c_uint) -> herr_t;
     pub fn H5Pset_chunk_opts(plist_id: hid_t, opts: c_uint) -> herr_t;
-    pub fn H5Pencode(plist_id: hid_t, buf: *mut c_void, nalloc: *mut size_t) -> herr_t;
+    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Pencode2()"))]
+    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Pencode")]
+    pub fn H5Pencode1(plist_id: hid_t, buf: *mut c_void, nalloc: *mut size_t) -> herr_t;
+    #[cfg(hdf5_1_12_0)]
+    pub fn H5Pencode2(
+        plist_id: hid_t, buf: *mut c_void, nalloc: *mut size_t, fapl_id: hid_t,
+    ) -> herr_t;
     pub fn H5Pdecode(buf: *const c_void) -> hid_t;
     #[cfg_attr(
         hdf5_1_10_1,
@@ -673,6 +711,11 @@ extern "C" {
         plist_id: hid_t, strategy: *mut H5F_file_space_type_t, threshold: *mut hsize_t,
     ) -> herr_t;
 }
+
+#[cfg(all(hdf5_1_10_0, not(hdf5_1_12_0)))]
+pub use self::H5Pencode1 as H5Pencode;
+#[cfg(hdf5_1_12_0)]
+pub use self::H5Pencode2 as H5Pencode;
 
 #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
 extern "C" {
@@ -719,4 +762,11 @@ extern "C" {
 extern "C" {
     pub fn H5Pget_dset_no_attrs_hint(dcpl_id: hid_t, minimize: *mut hbool_t) -> herr_t;
     pub fn H5Pset_dset_no_attrs_hint(dcpl_id: hid_t, minimize: hbool_t) -> herr_t;
+}
+
+#[cfg(hdf5_1_12_0)]
+extern "C" {
+    pub fn H5Pget_vol_id(plist_id: hid_t, vol_id: *mut hid_t) -> herr_t;
+    pub fn H5Pget_vol_info(plist_id: hid_t, vol_info: *mut *mut c_void) -> herr_t;
+    pub fn H5Pset_vol(plist_id: hid_t, new_vol_id: hid_t, new_vol_id: *const c_void) -> herr_t;
 }

--- a/hdf5-sys/src/h5pl.rs
+++ b/hdf5-sys/src/h5pl.rs
@@ -9,7 +9,10 @@ mod hdf5_1_8_15 {
     pub enum H5PL_type_t {
         H5PL_TYPE_ERROR = -1,
         H5PL_TYPE_FILTER = 0,
-        H5PL_TYPE_NONE = 1,
+        #[cfg(hdf5_1_12_0)]
+        H5PL_VOL,
+        #[cfg(hdf5_1_12_0)]
+        H5PL_TYPE_NONE,
     }
 
     pub use self::H5PL_type_t::*;

--- a/hdf5-sys/src/h5r.rs
+++ b/hdf5-sys/src/h5r.rs
@@ -6,11 +6,25 @@ use crate::h5o::H5O_type_t;
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[cfg(not(hdf5_1_12_0))]
 pub enum H5R_type_t {
     H5R_BADTYPE = -1,
     H5R_OBJECT = 0,
     H5R_DATASET_REGION = 1,
     H5R_MAXTYPE = 2,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[cfg(hdf5_1_12_0)]
+pub enum H5R_type_t {
+    H5R_BADTYPE = -1,
+    H5R_OBJECT1 = 0,
+    H5R_DATASET_REGION1 = 1,
+    H5R_OBJECT2 = 2,
+    H5R_DATASET_REGION2 = 3,
+    H5R_ATTR = 4,
+    H5R_MAXTYPE = 5,
 }
 
 pub type hobj_ref_t = haddr_t;
@@ -46,3 +60,58 @@ extern "C" {
 
 #[cfg(hdf5_1_10_0)]
 pub use self::H5Rdereference1 as H5Rdereference;
+
+#[cfg(hdf5_1_12_0)]
+pub const H5R_REF_BUF_SIZE: usize = 64;
+
+#[cfg(hdf5_1_12_0)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union H5R_ref_t_u {
+    __data: [u8; H5R_REF_BUF_SIZE],
+    align: i64,
+}
+
+#[cfg(hdf5_1_12_0)]
+impl Default for H5R_ref_t_u {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[cfg(hdf5_1_12_0)]
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct H5R_ref_t {
+    u: H5R_ref_t_u,
+}
+
+#[cfg(hdf5_1_12_0)]
+extern "C" {
+    pub fn H5Rcopy(src_ref_ptr: *const H5R_ref_t, dst_ref_ptr: *mut H5R_ref_t) -> herr_t;
+    pub fn H5Rcreate_attr(
+        loc_id: hid_t, name: *const c_char, attr_name: *const c_char, oapl_id: hid_t,
+        ref_ptr: *mut H5R_ref_t,
+    ) -> herr_t;
+    pub fn H5Rcreate_object(
+        loc_id: hid_t, name: *const c_char, oapl_id: hid_t, ref_ptr: *mut H5R_ref_t,
+    ) -> herr_t;
+    pub fn H5Rcreate_region(
+        loc_id: hid_t, name: *const c_char, space_id: hid_t, oapl_id: hid_t,
+        ref_ptr: *mut H5R_ref_t,
+    ) -> herr_t;
+    pub fn H5Rdestroy(ref_ptr: *mut H5R_ref_t) -> herr_t;
+    pub fn H5Requal(ref1_ptr: *const H5R_ref_t, ref2_ptr: *const H5R_ref_t) -> htri_t;
+    pub fn H5Rget_attr_name(ref_ptr: *const H5R_ref_t, name: *mut c_char, size: size_t) -> ssize_t;
+    pub fn H5Rget_file_name(ref_ptr: *const H5R_ref_t, name: *mut c_char, size: size_t) -> ssize_t;
+    pub fn H5Rget_obj_name(
+        ref_ptr: *const H5R_ref_t, rapl_id: hid_t, name: *mut c_char, size: size_t,
+    ) -> ssize_t;
+    pub fn H5Rget_obj_type3(
+        ref_ptr: *const H5R_ref_t, rapl_id: hid_t, obj_type: *mut H5O_type_t,
+    ) -> herr_t;
+    pub fn H5Rget_type(ref_ptr: *const H5R_ref_t) -> H5R_type_t;
+    pub fn H5Ropen_attr(ref_ptr: *const H5R_ref_t, rapl_id: hid_t, aapl_id: hid_t) -> hid_t;
+    pub fn H5Ropen_object(ref_ptr: *const H5R_ref_t, rapl_id: hid_t, oapl_id: hid_t) -> hid_t;
+    pub fn H5Ropen_region(ref_ptr: *const H5R_ref_t, rapl_id: hid_t, oapl_id: hid_t) -> hid_t;
+}

--- a/hdf5-sys/src/h5s.rs
+++ b/hdf5-sys/src/h5s.rs
@@ -10,6 +10,9 @@ pub const H5S_UNLIMITED: hsize_t = (-1 as hssize_t) as _;
 
 pub const H5S_MAX_RANK: c_uint = 32;
 
+pub const H5S_SEL_ITER_GET_SEQ_LIST_SORTED: c_uint = 0x0001;
+pub const H5S_SEL_ITER_SHARE_WITH_DATASPACE: c_uint = 0x0002;
+
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum H5S_class_t {
@@ -53,7 +56,13 @@ extern "C" {
     ) -> herr_t;
     pub fn H5Scopy(space_id: hid_t) -> hid_t;
     pub fn H5Sclose(space_id: hid_t) -> herr_t;
-    pub fn H5Sencode(obj_id: hid_t, buf: *mut c_void, nalloc: *mut size_t) -> herr_t;
+    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Sencode2()"))]
+    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Sencode")]
+    pub fn H5Sencode1(obj_id: hid_t, buf: *mut c_void, nalloc: *mut size_t) -> herr_t;
+    #[cfg(hdf5_1_12_0)]
+    pub fn H5Sencode2(
+        obj_id: hid_t, buf: *mut c_void, nalloc: *mut size_t, fapl_id: hid_t,
+    ) -> herr_t;
     pub fn H5Sdecode(buf: *const c_void) -> hid_t;
     pub fn H5Sget_simple_extent_npoints(space_id: hid_t) -> hssize_t;
     pub fn H5Sget_simple_extent_ndims(space_id: hid_t) -> c_int;
@@ -89,6 +98,11 @@ extern "C" {
     pub fn H5Sget_select_type(spaceid: hid_t) -> H5S_sel_type;
 }
 
+#[cfg(not(hdf5_1_12_0))]
+pub use self::H5Sencode1 as H5Sencode;
+#[cfg(hdf5_1_12_0)]
+pub use self::H5Sencode2 as H5Sencode;
+
 #[cfg(hdf5_1_10_0)]
 extern "C" {
     pub fn H5Sis_regular_hyperslab(spaceid: hid_t) -> htri_t;
@@ -96,4 +110,29 @@ extern "C" {
         spaceid: hid_t, start: *mut hsize_t, stride: *mut hsize_t, count: *mut hsize_t,
         block: *mut hsize_t,
     ) -> htri_t;
+}
+
+#[cfg(hdf5_1_12_0)]
+extern "C" {
+    pub fn H5Scombine_hyperslab(
+        space_id: hid_t, op: H5S_seloper_t, start: *const hsize_t, stride: *const hsize_t,
+        count: *const hsize_t, block: *const hsize_t,
+    ) -> hid_t;
+    pub fn H5Scombine_select(space1_id: hid_t, op: H5S_seloper_t, space2_id: hid_t) -> hid_t;
+    pub fn H5Smodify_select(space1_id: hid_t, op: H5S_seloper_t, space2_id: hid_t) -> herr_t;
+    pub fn H5Ssel_iter_close(sel_iter_id: hid_t) -> herr_t;
+    pub fn H5Ssel_iter_create(space_id: hid_t, elmt_size: size_t, flags: c_uint) -> hid_t;
+    pub fn H5Ssel_iter_get_seq_list(
+        sel_iter_id: hid_t, maxseq: size_t, maxbytes: size_t, nseq: *mut size_t,
+        nbytes: *mut size_t, off: *mut hsize_t, len: *mut size_t,
+    ) -> herr_t;
+    pub fn H5Sselect_adjust(space_id: hid_t, offset: *const hssize_t) -> herr_t;
+    pub fn H5Sselect_copy(dst_id: hid_t, src_id: hid_t) -> herr_t;
+    pub fn H5Sselect_intersect_block(
+        space_id: hid_t, start: *const hsize_t, end: *const hsize_t,
+    ) -> htri_t;
+    pub fn H5Sselect_project_intersection(
+        src_space_id: hid_t, dst_space_id: hid_t, src_intersect_space_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Sselect_shape_same(space1_id: hid_t, space2_id: hid_t) -> htri_t;
 }

--- a/hdf5-sys/src/h5t.rs
+++ b/hdf5-sys/src/h5t.rs
@@ -426,6 +426,8 @@ mod globals {
     extern_static!(H5T_NATIVE_UINT_LEAST64, H5T_NATIVE_UINT_LEAST64_g);
     extern_static!(H5T_NATIVE_INT_FAST64, H5T_NATIVE_INT_FAST64_g);
     extern_static!(H5T_NATIVE_UINT_FAST64, H5T_NATIVE_UINT_FAST64_g);
+    #[cfg(hdf5_1_12_0)]
+    extern_static!(H5T_STD_REF, H5T_STD_REF_g);
 }
 
 #[cfg(all(target_env = "msvc", not(feature = "static")))]
@@ -519,10 +521,17 @@ mod globals {
     extern_static!(H5T_NATIVE_UINT_LEAST64, __imp_H5T_NATIVE_UINT_LEAST64_g);
     extern_static!(H5T_NATIVE_INT_FAST64, __imp_H5T_NATIVE_INT_FAST64_g);
     extern_static!(H5T_NATIVE_UINT_FAST64, __imp_H5T_NATIVE_UINT_FAST64_g);
+    #[cfg(hdf5_1_12_0)]
+    extern_static!(H5T_STD_REF, __imp_H5T_STD_REF_g);
 }
 
 #[cfg(hdf5_1_10_0)]
 extern "C" {
     pub fn H5Tflush(type_id: hid_t) -> herr_t;
     pub fn H5Trefresh(type_id: hid_t) -> herr_t;
+}
+
+#[cfg(hdf5_1_12_0)]
+extern "C" {
+    pub fn H5Treclaim(type_id: hid_t, space_id: hid_t, dxpl_id: hid_t, buf: *mut c_void) -> herr_t;
 }

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -1,0 +1,23 @@
+#![cfg(hdf5_1_12_0)]
+use crate::internal_prelude::*;
+
+pub type H5VL_class_value_t = c_int;
+
+// Incomplete type
+pub type H5VL_class_t = c_void;
+
+extern "C" {
+    pub fn H5VLclose(connector_id: hid_t) -> herr_t;
+    pub fn H5VLget_connector_id(obj_id: hid_t) -> hid_t;
+    pub fn H5VLget_connector_id_by_name(name: *const c_char) -> hid_t;
+    pub fn H5VLget_connector_id_by_value(connector_value: H5VL_class_value_t) -> hid_t;
+    pub fn H5VLget_connector_name(id: hid_t, name: *mut c_char, size: size_t) -> ssize_t;
+    pub fn H5VLis_connector_registered_by_name(name: *const c_char) -> htri_t;
+    pub fn H5VLis_connector_registered_by_value(connector_value: H5VL_class_value_t) -> htri_t;
+    pub fn H5VLregister_connector(cls: *const H5VL_class_t, vipl_id: hid_t) -> hid_t;
+    pub fn H5VLregister_connector_by_name(name: *const c_char, vipl_id: hid_t) -> hid_t;
+    pub fn H5VLregister_connector_by_value(
+        connector_value: H5VL_class_value_t, vipl_id: hid_t,
+    ) -> hid_t;
+    pub fn H5VLunregister_connector(vol_id: hid_t) -> herr_t;
+}

--- a/hdf5-sys/src/lib.rs
+++ b/hdf5-sys/src/lib.rs
@@ -35,6 +35,7 @@ pub mod h5p;
 pub mod h5r;
 pub mod h5s;
 pub mod h5t;
+pub mod h5vl;
 pub mod h5z;
 
 #[cfg(hdf5_1_8_15)]

--- a/src/hl/group.rs
+++ b/src/hl/group.rs
@@ -288,13 +288,13 @@ pub mod tests {
             file.link_hard("/foo/test", "/foo/hard").unwrap();
             file.group("foo/test/inner").unwrap();
             file.group("/foo/hard/inner").unwrap();
-            assert_err!(
+            assert_err_re!(
                 file.link_hard("foo/test", "/foo/test/inner"),
-                "unable to create link: name already exists"
+                "unable to create (?:hard )?link: name already exists"
             );
             assert_err_re!(
                 file.link_hard("foo/bar", "/foo/baz"),
-                "unable to create link: object.+doesn't exist"
+                "unable to create (?:hard )?link: object.+doesn't exist"
             );
             file.relink("/foo/hard", "/foo/hard2").unwrap();
             file.group("/foo/hard2/inner").unwrap();


### PR DESCRIPTION
Add the newest changes according to https://portal.hdfgroup.org/display/HDF5/Software+Changes+from+Release+to+Release+for+HDF5-1.12. Currently compiles and tests complete sucessfully on all platforms but new functions are not tested nor used anywhere.

Fixes #94 