### PR TITLE
Configure the docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.3"
 scopeguard = "1.0"
 tempdir = "0.3"
+
+[package.metadata.docs.rs]
+features = ["hdf5-sys/static", "hdf5-sys/zlib"]

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -39,3 +39,6 @@ pkg-config = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 winreg = { version = "0.7", features = ["serialization-serde"]}
+
+[package.metadata.docs.rs]
+features = ["static", "zlib"]


### PR DESCRIPTION
By setting metadata in `Cargo.toml` (https://docs.rs/about#metadata), where we build hdf5 statically, we get documentation for "free" on `docs.rs`. We no longer have to build and deploy the documentation ourselfs.

@aldanor This would be a great PR to merge before the next release!