### PR TITLE
Use hdf5 allocator

### DIFF
--- a/hdf5-types/src/lib.rs
+++ b/hdf5-types/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "1024"]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::transmute_bytes_to_str))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::missing_safety_doc))]
 
 #[cfg(test)]

--- a/hdf5-types/src/string.rs
+++ b/hdf5-types/src/string.rs
@@ -245,7 +245,7 @@ impl VarLenAscii {
 
     #[inline]
     pub fn as_str(&self) -> &str {
-        unsafe { mem::transmute(self.as_bytes()) }
+        unsafe { str::from_utf8_unchecked(self.as_bytes()) }
     }
 
     #[inline]
@@ -439,7 +439,7 @@ impl<A: Array<Item = u8>> FixedAscii<A> {
 
     #[inline]
     pub fn as_str(&self) -> &str {
-        unsafe { mem::transmute(self.as_bytes()) }
+        unsafe { str::from_utf8_unchecked(self.as_bytes()) }
     }
 
     #[inline]
@@ -549,7 +549,7 @@ impl<A: Array<Item = u8>> FixedUnicode<A> {
 
     #[inline]
     pub fn as_str(&self) -> &str {
-        unsafe { mem::transmute(self.as_bytes()) }
+        unsafe { str::from_utf8_unchecked(self.as_bytes()) }
     }
 
     #[inline]

--- a/src/hl/container.rs
+++ b/src/hl/container.rs
@@ -7,6 +7,7 @@ use ndarray::{SliceInfo, SliceOrIndex};
 
 use hdf5_sys::h5a::{H5Aget_space, H5Aget_storage_size, H5Aget_type, H5Aread, H5Awrite};
 use hdf5_sys::h5d::{H5Dget_space, H5Dget_storage_size, H5Dget_type, H5Dread, H5Dwrite};
+use hdf5_sys::h5p::H5Pcreate;
 
 use crate::internal_prelude::*;
 
@@ -44,13 +45,15 @@ impl<'a> Reader<'a> {
         file_dtype.ensure_convertible(&mem_dtype, self.conv)?;
         let (obj_id, tp_id) = (self.obj.id(), mem_dtype.id());
 
-        let fspace_id = fspace.map_or(H5S_ALL, |f| f.id());
-        let mspace_id = mspace.map_or(H5S_ALL, |m| m.id());
-
         if self.obj.is_attr() {
             h5try!(H5Aread(obj_id, tp_id, buf as *mut _));
         } else {
-            h5try!(H5Dread(obj_id, tp_id, mspace_id, fspace_id, H5P_DEFAULT, buf as *mut _));
+            let fspace_id = fspace.map_or(H5S_ALL, |f| f.id());
+            let mspace_id = mspace.map_or(H5S_ALL, |m| m.id());
+            let xfer =
+                PropertyList::from_id(h5call!(H5Pcreate(*crate::globals::H5P_DATASET_XFER))?)?;
+            crate::hl::plist::set_vlen_manager_libc(xfer.id())?;
+            h5try!(H5Dread(obj_id, tp_id, mspace_id, fspace_id, xfer.id(), buf as *mut _));
         }
         Ok(())
     }
@@ -247,12 +250,11 @@ impl<'a> Writer<'a> {
         mem_dtype.ensure_convertible(&file_dtype, self.conv)?;
         let (obj_id, tp_id) = (self.obj.id(), mem_dtype.id());
 
-        let fspace_id = fspace.map_or(H5S_ALL, |f| f.id());
-        let mspace_id = mspace.map_or(H5S_ALL, |m| m.id());
-
         if self.obj.is_attr() {
             h5try!(H5Awrite(obj_id, tp_id, buf as *const _));
         } else {
+            let fspace_id = fspace.map_or(H5S_ALL, |f| f.id());
+            let mspace_id = mspace.map_or(H5S_ALL, |m| m.id());
             h5try!(H5Dwrite(obj_id, tp_id, mspace_id, fspace_id, H5P_DEFAULT, buf as *const _));
         }
         Ok(())

--- a/src/hl/plist.rs
+++ b/src/hl/plist.rs
@@ -1,10 +1,12 @@
 use std::fmt::{self, Debug, Display};
 use std::ops::Deref;
+use std::panic;
 use std::ptr;
 use std::str::FromStr;
 
 use hdf5_sys::h5p::{
     H5Pcopy, H5Pequal, H5Pexist, H5Pget_class, H5Pget_class_name, H5Pget_nprops, H5Piterate,
+    H5Pset_vlen_mem_manager,
 };
 
 use crate::internal_prelude::*;
@@ -200,6 +202,26 @@ impl PropertyList {
             PropertyListClass::from_str(&name)
         })
     }
+}
+
+/// Set the memory manager for variable length items to
+/// the same allocator as is in use by hdf5-types
+// TODO: move this to dataset_transfer module when DatasetTransfer plist is implemented
+pub fn set_vlen_manager_libc(plist: hid_t) -> Result<()> {
+    extern "C" fn alloc(size: size_t, _info: *mut c_void) -> *mut c_void {
+        panic::catch_unwind(|| unsafe { libc::malloc(size) }).unwrap_or(ptr::null_mut())
+    }
+    extern "C" fn free(ptr: *mut c_void, _info: *mut libc::c_void) {
+        let _ = panic::catch_unwind(|| unsafe { libc::free(ptr) });
+    }
+    h5try!(H5Pset_vlen_mem_manager(
+        plist,
+        Some(alloc),
+        ptr::null_mut(),
+        Some(free),
+        ptr::null_mut()
+    ));
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The allocator functions are not protected by a mutex, as the reentrant mutex is defined in `hdf5` which we can't depend on. Is there a way of moving this mutex to `hdf5-sys`? Should we instead move `hdf5-types` to a module within `hdf5`'?

CI results are available at https://github.com/magnusuMET/hdf5-rust/runs/945773746?check_suite_focus=true

Fixes #104 