### PR TITLE
Add deprecated functions and deprecation warnings

### DIFF
--- a/hdf5-sys/src/h5a.rs
+++ b/hdf5-sys/src/h5a.rs
@@ -23,7 +23,7 @@ impl Default for H5A_info_t {
     }
 }
 
-#[deprecated(note = "Deprecated in HDF5 1.8.0, use H5A_operator2_t")]
+#[deprecated(note = "deprecated in HDF5 1.8.0, use H5A_operator2_t")]
 pub type H5A_operator1_t = Option<
     extern "C" fn(
         location_id: hid_t,
@@ -106,17 +106,17 @@ extern "C" {
         obj_id: hid_t, obj_name: *const c_char, attr_name: *const c_char, lapl_id: hid_t,
     ) -> htri_t;
 
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aget_info()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Aget_info")]
     pub fn H5Aget_num_attrs(loc_id: hid_t) -> c_int;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aopen_by_idx()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Aopen_by_idx")]
     pub fn H5Aopen_idx(loc_id: hid_t, idx: c_uint) -> hid_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aopen_by_name()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Aopen_by_name")]
     pub fn H5Aopen_name(loc_id: hid_t, name: *const c_char) -> hid_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Acreate2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Acreate2")]
     pub fn H5Acreate1(
         loc_id: hid_t, name: *const c_char, type_id: hid_t, space_id: hid_t, acpl_id: hid_t,
     ) -> hid_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aiterate2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Aiterate2")]
     pub fn H5Aiterate1(
         loc_id: hid_t, attr_num: *mut c_uint, op: H5A_operator1_t, op_data: *mut c_void,
     ) -> herr_t;

--- a/hdf5-sys/src/h5a.rs
+++ b/hdf5-sys/src/h5a.rs
@@ -3,6 +3,10 @@ use std::mem;
 use crate::internal_prelude::*;
 
 use crate::h5o::H5O_msg_crt_idx_t;
+pub use {
+    H5A_operator2_t as H5A_operator_t, H5A_operator2_t as H5A_operator_r, H5Acreate2 as H5Acreate,
+    H5Aiterate2 as H5Aiterate,
+};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -18,6 +22,15 @@ impl Default for H5A_info_t {
         unsafe { mem::zeroed() }
     }
 }
+
+#[deprecated(note = "Deprecated in HDF5 1.8.0, use H5A_operator2_t")]
+pub type H5A_operator1_t = Option<
+    extern "C" fn(
+        location_id: hid_t,
+        attr_name: *const c_char,
+        operator_data: *mut c_void,
+    ) -> herr_t,
+>;
 
 pub type H5A_operator2_t = Option<
     extern "C" fn(
@@ -92,4 +105,19 @@ extern "C" {
     pub fn H5Aexists_by_name(
         obj_id: hid_t, obj_name: *const c_char, attr_name: *const c_char, lapl_id: hid_t,
     ) -> htri_t;
+
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aget_info()")]
+    pub fn H5Aget_num_attrs(loc_id: hid_t) -> c_int;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aopen_by_idx()")]
+    pub fn H5Aopen_idx(loc_id: hid_t, idx: c_uint) -> hid_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aopen_by_name()")]
+    pub fn H5Aopen_name(loc_id: hid_t, name: *const c_char) -> hid_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Acreate2()")]
+    pub fn H5Acreate1(
+        loc_id: hid_t, name: *const c_char, type_id: hid_t, space_id: hid_t, acpl_id: hid_t,
+    ) -> hid_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Aiterate2()")]
+    pub fn H5Aiterate1(
+        loc_id: hid_t, attr_num: *mut c_uint, op: H5A_operator1_t, op_data: *mut c_void,
+    ) -> herr_t;
 }

--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -6,6 +6,7 @@ pub use self::H5D_mpio_actual_chunk_opt_mode_t::*;
 pub use self::H5D_mpio_actual_io_mode_t::*;
 pub use self::H5D_mpio_no_collective_cause_t::*;
 pub use self::H5D_space_status_t::*;
+pub use {H5Dcreate2 as H5D_create, H5Dopen2 as H5Dopen};
 
 use crate::internal_prelude::*;
 
@@ -178,6 +179,7 @@ extern "C" {
         buf: *mut c_void, type_id: hid_t, space_id: hid_t, op: H5D_operator_t,
         operator_data: *mut c_void,
     ) -> herr_t;
+    #[cfg_attr(hdf5_1_12_0, deprecated(note = "Deprecated in HDF5 1.12.0, use H5Treclaim()"))]
     pub fn H5Dvlen_reclaim(
         type_id: hid_t, space_id: hid_t, plist_id: hid_t, buf: *mut c_void,
     ) -> herr_t;
@@ -189,6 +191,13 @@ extern "C" {
     ) -> herr_t;
     pub fn H5Dset_extent(dset_id: hid_t, size: *const hsize_t) -> herr_t;
     pub fn H5Ddebug(dset_id: hid_t) -> herr_t;
+
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Dcreate2()")]
+    pub fn H5Dcreate1(
+        file_id: hid_t, name: *const c_char, type_id: hid_t, space_id: hid_t, dcpl_id: hid_t,
+    ) -> hid_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Dopen2()")]
+    pub fn H5Dopen1(file_id: hid_t, name: *const c_char) -> hid_t;
 }
 
 #[cfg(hdf5_1_8_11)]

--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -179,7 +179,7 @@ extern "C" {
         buf: *mut c_void, type_id: hid_t, space_id: hid_t, op: H5D_operator_t,
         operator_data: *mut c_void,
     ) -> herr_t;
-    #[cfg_attr(hdf5_1_12_0, deprecated(note = "Deprecated in HDF5 1.12.0, use H5Treclaim()"))]
+    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Treclaim"))]
     pub fn H5Dvlen_reclaim(
         type_id: hid_t, space_id: hid_t, plist_id: hid_t, buf: *mut c_void,
     ) -> herr_t;
@@ -192,11 +192,11 @@ extern "C" {
     pub fn H5Dset_extent(dset_id: hid_t, size: *const hsize_t) -> herr_t;
     pub fn H5Ddebug(dset_id: hid_t) -> herr_t;
 
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Dcreate2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Dcreate2")]
     pub fn H5Dcreate1(
         file_id: hid_t, name: *const c_char, type_id: hid_t, space_id: hid_t, dcpl_id: hid_t,
     ) -> hid_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Dopen2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Dopen2")]
     pub fn H5Dopen1(file_id: hid_t, name: *const c_char) -> hid_t;
 }
 

--- a/hdf5-sys/src/h5e.rs
+++ b/hdf5-sys/src/h5e.rs
@@ -108,24 +108,24 @@ extern "C" {
     ) -> ssize_t;
     pub fn H5Eget_num(error_stack_id: hid_t) -> ssize_t;
 
-    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Epush2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Epush2")]
     pub fn H5Epush1(
         file: *const c_char, func: *const c_char, line: c_uint, maj: H5E_major_t, min: H5E_minor_t,
         str_: *const c_char,
     ) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eprint2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eprint2")]
     pub fn H5Eprint1(stream: *mut FILE) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Ewalk2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Ewalk2")]
     pub fn H5Ewalk1(
         direction: H5E_direction_t, func: H5E_walk1_t, client_data: *mut c_void,
     ) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eget_auto2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eget_auto2")]
     pub fn H5Eget_auto1(func: *mut H5E_auto1_t, client_data: *mut *mut c_void) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eset_auto2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eset_auto2")]
     pub fn H5Eset_auto1(func: H5E_auto1_t, client_data: *mut c_void) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eclear2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eclear2")]
     pub fn H5Eclear1() -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eget_msg()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eget_msg")]
     pub fn H5Eget_major(maj: H5E_major_t) -> *mut c_char;
     #[deprecated(note = "deprecated in HDF5 1.8.0")]
     pub fn H5Eget_minor(min: H5E_minor_t) -> *mut c_char;

--- a/hdf5-sys/src/h5e.rs
+++ b/hdf5-sys/src/h5e.rs
@@ -2,6 +2,11 @@ use std::mem;
 
 pub use self::H5E_direction_t::*;
 pub use self::H5E_type_t::*;
+pub use {
+    H5E_auto2_t as H5E_auto_t, H5E_error2_t as H5E_error_t, H5E_walk2_t as H5E_walk_t,
+    H5Eclear2 as H5Eclear, H5Eget_auto2 as H5Eget_auto, H5Eprint2 as H5Eprint, H5Epush2 as H5Epush,
+    H5Eset_auto2 as H5Eset_auto, H5Ewalk2 as H5Ewalk,
+};
 
 use crate::internal_prelude::*;
 
@@ -12,6 +17,21 @@ pub const H5E_DEFAULT: hid_t = 0;
 pub enum H5E_type_t {
     H5E_MAJOR = 0,
     H5E_MINOR = 1,
+}
+
+pub type H5E_major_t = hid_t;
+pub type H5E_minor_t = hid_t;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[deprecated(note = "deprecated in HDF5 1.8.0, use H5E_error2_t")]
+pub struct H5E_error1_t {
+    maj_num: H5E_major_t,
+    min_num: H5E_minor_t,
+    func_name: *const c_char,
+    file_name: *const c_char,
+    line: c_uint,
+    desc: *const c_char,
 }
 
 #[repr(C)]
@@ -38,6 +58,13 @@ pub enum H5E_direction_t {
     H5E_WALK_UPWARD = 0,
     H5E_WALK_DOWNWARD = 1,
 }
+
+#[deprecated(note = "deprecated in HDF5 1.8.0, use H5E_walk2_t")]
+pub type H5E_walk1_t = Option<
+    unsafe extern "C" fn(n: c_int, err_desc: *mut H5E_error1_t, client_data: *mut c_void) -> herr_t,
+>;
+#[deprecated(note = "deprecated in HDF5 1.8.0, use H5E_auto2_t")]
+pub type H5E_auto1_t = Option<unsafe extern "C" fn(client_data: *mut c_void) -> herr_t>;
 
 pub type H5E_walk2_t = Option<
     unsafe extern "C" fn(
@@ -80,6 +107,28 @@ extern "C" {
         msg_id: hid_t, type_: *mut H5E_type_t, msg: *mut c_char, size: size_t,
     ) -> ssize_t;
     pub fn H5Eget_num(error_stack_id: hid_t) -> ssize_t;
+
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Epush2()")]
+    pub fn H5Epush1(
+        file: *const c_char, func: *const c_char, line: c_uint, maj: H5E_major_t, min: H5E_minor_t,
+        str_: *const c_char,
+    ) -> herr_t;
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eprint2()")]
+    pub fn H5Eprint1(stream: *mut FILE) -> herr_t;
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Ewalk2()")]
+    pub fn H5Ewalk1(
+        direction: H5E_direction_t, func: H5E_walk1_t, client_data: *mut c_void,
+    ) -> herr_t;
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eget_auto2()")]
+    pub fn H5Eget_auto1(func: *mut H5E_auto1_t, client_data: *mut *mut c_void) -> herr_t;
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eset_auto2()")]
+    pub fn H5Eset_auto1(func: H5E_auto1_t, client_data: *mut c_void) -> herr_t;
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eclear2()")]
+    pub fn H5Eclear1() -> herr_t;
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Eget_msg()")]
+    pub fn H5Eget_major(maj: H5E_major_t) -> *mut c_char;
+    #[deprecated(note = "deprecated in HDF5 1.8.0")]
+    pub fn H5Eget_minor(min: H5E_minor_t) -> *mut c_char;
 }
 
 pub use self::globals::*;

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -4,6 +4,16 @@ pub use self::H5F_close_degree_t::*;
 pub use self::H5F_libver_t::*;
 pub use self::H5F_mem_t::*;
 pub use self::H5F_scope_t::*;
+#[cfg(not(hdf5_1_10_0))]
+pub use {
+    H5F_info1_t as H5F_info_t, H5F_info1_t__sohm as H5F_info_t__sohm, H5Fget_info1 as H5Fget_info,
+};
+#[cfg(hdf5_1_10_0)]
+pub use {
+    H5F_info2_t as H5F_info_t, H5F_info2_t__free as H5F_info_t__free,
+    H5F_info2_t__sohm as H5F_info_t__sohm, H5F_info2_t__super as H5F_info_t__super,
+    H5Fget_info2 as H5Fget_info,
+};
 
 use crate::internal_prelude::*;
 
@@ -60,12 +70,12 @@ impl Default for H5F_close_degree_t {
 #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5F_info2_t"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct H5F_info_t {
+pub struct H5F_info1_t {
     pub super_ext_size: hsize_t,
-    pub sohm: H5F_info_t__sohm,
+    pub sohm: H5F_info1_t__sohm,
 }
 
-impl Default for H5F_info_t {
+impl Default for H5F_info1_t {
     fn default() -> Self {
         unsafe { mem::zeroed() }
     }
@@ -74,12 +84,12 @@ impl Default for H5F_info_t {
 #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5F_info2_t"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct H5F_info_t__sohm {
+pub struct H5F_info1_t__sohm {
     pub hdr_size: hsize_t,
     pub msgs_info: H5_ih_info_t,
 }
 
-impl Default for H5F_info_t__sohm {
+impl Default for H5F_info1_t__sohm {
     fn default() -> Self {
         unsafe { mem::zeroed() }
     }
@@ -125,11 +135,6 @@ impl Default for H5F_libver_t {
     fn default() -> Self {
         H5F_LIBVER_LATEST
     }
-}
-
-#[cfg(not(hdf5_1_10_0))]
-extern "C" {
-    pub fn H5Fget_info(obj_id: hid_t, bh_info: *mut H5F_info_t) -> herr_t;
 }
 
 extern "C" {
@@ -308,14 +313,13 @@ mod hdf5_1_10_0 {
         ) -> ssize_t;
         pub fn H5Fformat_convert(fid: hid_t) -> herr_t;
         pub fn H5Fget_info2(obj_id: hid_t, finfo: *mut H5F_info2_t) -> herr_t;
-        #[deprecated(note = "deprecated in HDF5 1.10.0, use H5Fget_info2")]
-        pub fn H5Fget_info1(obj_id: hid_t, finfo: *mut H5F_info1_t) -> herr_t;
     }
+}
 
-    pub use super::{
-        H5F_info_t as H5F_info1_t, H5F_info_t__sohm as H5F_info1_t__sohm,
-        H5Fget_info1 as H5Fget_info,
-    };
+extern "C" {
+    #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5Fget_info2"))]
+    #[cfg_attr(not(hdf5_1_10_0), link_name = "H5Fget_info")]
+    pub fn H5Fget_info1(obj_id: hid_t, finfo: *mut H5F_info1_t) -> herr_t;
 }
 
 #[cfg(hdf5_1_10_0)]

--- a/hdf5-sys/src/h5g.rs
+++ b/hdf5-sys/src/h5g.rs
@@ -1,10 +1,12 @@
 use std::mem;
 
 pub use self::H5G_storage_type_t::*;
+pub use {H5Gcreate2 as H5Gcreate, H5Gopen2 as H5Gopen};
 
 use crate::internal_prelude::*;
 
 use crate::h5l::{H5L_type_t, H5L_SAME_LOC, H5L_TYPE_ERROR, H5L_TYPE_HARD, H5L_TYPE_SOFT};
+use crate::h5o::H5O_stat_t;
 
 pub const H5G_SAME_LOC: hid_t = H5L_SAME_LOC;
 
@@ -62,10 +64,75 @@ extern "C" {
         n: hsize_t, ginfo: *mut H5G_info_t, lapl_id: hid_t,
     ) -> herr_t;
     pub fn H5Gclose(group_id: hid_t) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Gcreate2()")]
+    pub fn H5Gcreate1(loc_id: hid_t, name: *const c_char, size_hint: size_t) -> hid_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Oget_comment()")]
+    pub fn H5Gget_comment(
+        loc_id: hid_t, name: *const c_char, bufsize: size_t, buf: *mut c_char,
+    ) -> c_int;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lget_val()")]
+    pub fn H5Gget_linkval(loc_id: hid_t, name: *const c_char, comment: *const c_char) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Gget_info()")]
+    pub fn H5Gget_num_objs(loc_id: hid_t, num_objs: *mut hsize_t) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Oget_info() or H5Lget_info()")]
+    pub fn H5Gget_objinfo(
+        loc_id: hid_t, name: *const c_char, follow_link: hbool_t, statubuf: *mut H5G_stat_t,
+    ) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lget_name_by_idx()")]
+    pub fn H5Gget_objname_by_idx(
+        loc_id: hid_t, idx: hsize_t, name: *mut c_char, size: size_t,
+    ) -> ssize_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Oget_info()")]
+    pub fn H5Gget_objtype_by_idx(loc_id: hid_t, idx: hsize_t) -> H5G_obj_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lcreate_hard() or H5Lcreate_soft()")]
+    pub fn H5Glink(
+        cur_loc_id: hid_t, type_: H5G_link_t, cur_name: *const c_char, new_name: *const c_char,
+    ) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lcreate_hard() or H5Lcreate_soft()")]
+    pub fn H5Glink2(
+        cur_loc_id: hid_t, cur_name: *const c_char, type_: H5G_link_t, new_loc_id: hid_t,
+        new_name: *const c_char,
+    ) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lmove()")]
+    pub fn H5Gmove(src_loc_id: hid_t, src_name: *const c_char, dst_name: *const c_char) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lmove()")]
+    pub fn H5Gmove2(
+        src_loc_id: hid_t, src_name: *const c_char, dst_loc_id: hid_t, dst_name: *const c_char,
+    ) -> herr_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Gopen2()")]
+    pub fn H5Gopen1(loc_id: hid_t, name: *const c_char) -> hid_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Ldelete()")]
+    pub fn H5Gunlink(loc_id: hid_t, name: *const c_char) -> herr_t;
 }
 
 #[cfg(hdf5_1_10_0)]
 extern "C" {
     pub fn H5Gflush(group_id: hid_t) -> herr_t;
     pub fn H5Grefresh(group_id: hid_t) -> herr_t;
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum H5G_obj_t {
+    H5G_UNKNOwN = -1,
+    H5G_GROUP,
+    H5G_DATASET,
+    H5G_TYPE,
+    H5G_LINK,
+    H5G_UDLINK,
+    H5G_RESERVED_5,
+    H5G_RESERVED_6,
+    H5G_RESERVED_7,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct H5G_stat_t {
+    fileno: [c_ulong; 2],
+    objno: [c_ulong; 2],
+    nlink: c_uint,
+    type_: H5G_obj_t,
+    mtime: time_t,
+    linklen: size_t,
+    ohdr: H5O_stat_t,
 }

--- a/hdf5-sys/src/h5g.rs
+++ b/hdf5-sys/src/h5g.rs
@@ -64,44 +64,44 @@ extern "C" {
         n: hsize_t, ginfo: *mut H5G_info_t, lapl_id: hid_t,
     ) -> herr_t;
     pub fn H5Gclose(group_id: hid_t) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Gcreate2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Gcreate2")]
     pub fn H5Gcreate1(loc_id: hid_t, name: *const c_char, size_hint: size_t) -> hid_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Oget_comment()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Oget_comment")]
     pub fn H5Gget_comment(
         loc_id: hid_t, name: *const c_char, bufsize: size_t, buf: *mut c_char,
     ) -> c_int;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lget_val()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Lget_val")]
     pub fn H5Gget_linkval(loc_id: hid_t, name: *const c_char, comment: *const c_char) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Gget_info()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Gget_info")]
     pub fn H5Gget_num_objs(loc_id: hid_t, num_objs: *mut hsize_t) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Oget_info() or H5Lget_info()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Oget_info or H5Lget_info")]
     pub fn H5Gget_objinfo(
         loc_id: hid_t, name: *const c_char, follow_link: hbool_t, statubuf: *mut H5G_stat_t,
     ) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lget_name_by_idx()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Lget_name_by_idx")]
     pub fn H5Gget_objname_by_idx(
         loc_id: hid_t, idx: hsize_t, name: *mut c_char, size: size_t,
     ) -> ssize_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Oget_info()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Oget_info")]
     pub fn H5Gget_objtype_by_idx(loc_id: hid_t, idx: hsize_t) -> H5G_obj_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lcreate_hard() or H5Lcreate_soft()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Lcreate_hard or H5Lcreate_soft")]
     pub fn H5Glink(
         cur_loc_id: hid_t, type_: H5G_link_t, cur_name: *const c_char, new_name: *const c_char,
     ) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lcreate_hard() or H5Lcreate_soft()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Lcreate_hard or H5Lcreate_soft")]
     pub fn H5Glink2(
         cur_loc_id: hid_t, cur_name: *const c_char, type_: H5G_link_t, new_loc_id: hid_t,
         new_name: *const c_char,
     ) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lmove()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Lmove")]
     pub fn H5Gmove(src_loc_id: hid_t, src_name: *const c_char, dst_name: *const c_char) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Lmove()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Lmove")]
     pub fn H5Gmove2(
         src_loc_id: hid_t, src_name: *const c_char, dst_loc_id: hid_t, dst_name: *const c_char,
     ) -> herr_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Gopen2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Gopen2")]
     pub fn H5Gopen1(loc_id: hid_t, name: *const c_char) -> hid_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Ldelete()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Ldelete")]
     pub fn H5Gunlink(loc_id: hid_t, name: *const c_char) -> herr_t;
 }
 

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -287,23 +287,23 @@ mod hdf5_1_10_3 {
             loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
             op: H5O_iterate1_t, op_data: *mut c_void, fields: c_uint, lapl_id: hid_t,
         ) -> herr_t;
-        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info2()")]
+        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info2")]
         pub fn H5Oget_info1(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
-        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_name2()")]
+        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_name2")]
         pub fn H5Oget_info_by_name1(
             loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
         ) -> herr_t;
-        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_idx2()")]
+        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_idx2")]
         pub fn H5Oget_info_by_idx1(
             loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
             n: hsize_t, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
         ) -> herr_t;
-        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit2()")]
+        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit2")]
         pub fn H5Ovisit1(
             obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate1_t,
             op_data: *mut c_void,
         ) -> herr_t;
-        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit_by_name2()")]
+        #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit_by_name2")]
         pub fn H5Ovisit_by_name1(
             loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
             op: H5O_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,
@@ -326,23 +326,23 @@ extern "C" {
     // They've messed up when introducing compatibility macros which broke ABI compatibility;
     // in 1.10.5 those APIs were copied over to old names in order to be compatible with
     // older library versions - so we can link to them directly again.
-    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info2()")]
+    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info2")]
     pub fn H5Oget_info(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_name2()")]
+    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_name2")]
     pub fn H5Oget_info_by_name(
         loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_idx2()")]
+    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_idx2")]
     pub fn H5Oget_info_by_idx(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         n: hsize_t, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit2()")]
+    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit2")]
     pub fn H5Ovisit(
         obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate1_t,
         op_data: *mut c_void,
     ) -> herr_t;
-    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit_by_name2()")]
+    #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit_by_name2")]
     pub fn H5Ovisit_by_name(
         loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         op: H5O_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -2,6 +2,13 @@ use std::mem;
 
 pub use self::H5O_mcdt_search_ret_t::*;
 pub use self::H5O_type_t::*;
+#[cfg(not(hdf5_1_12_0))]
+pub use {
+    H5O_info1_t as H5O_info_t, H5O_info1_t__meta_size as H5O_info_t_meta_size,
+    H5O_iterate1_t as H5O_iterate_t,
+};
+#[cfg(hdf5_1_12_0)]
+pub use {H5O_info2_t as H5O_info_t, H5O_iterate2_t as H5O_iterate_t};
 
 use crate::internal_prelude::*;
 
@@ -126,7 +133,7 @@ impl Default for H5O_hdr_info_t__mesg {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct H5O_info_t {
+pub struct H5O_info1_t {
     pub fileno: c_ulong,
     pub addr: haddr_t,
     pub type_: H5O_type_t,
@@ -137,10 +144,10 @@ pub struct H5O_info_t {
     pub btime: time_t,
     pub num_attrs: hsize_t,
     pub hdr: H5O_hdr_info_t,
-    pub meta_size: H5O_info_t__meta_size,
+    pub meta_size: H5O_info1_t__meta_size,
 }
 
-impl Default for H5O_info_t {
+impl Default for H5O_info1_t {
     fn default() -> Self {
         unsafe { mem::zeroed() }
     }
@@ -148,13 +155,12 @@ impl Default for H5O_info_t {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct H5O_info_t__meta_size {
+pub struct H5O_info1_t__meta_size {
     pub obj: H5_ih_info_t,
     pub attr: H5_ih_info_t,
 }
 
-#[cfg(not(hdf5_1_12_0))]
-impl Default for H5O_info_t__meta_size {
+impl Default for H5O_info1_t__meta_size {
     fn default() -> Self {
         unsafe { mem::zeroed() }
     }
@@ -162,11 +168,11 @@ impl Default for H5O_info_t__meta_size {
 
 pub type H5O_msg_crt_idx_t = uint32_t;
 
-pub type H5O_iterate_t = Option<
+pub type H5O_iterate1_t = Option<
     extern "C" fn(
         obj: hid_t,
         name: *const c_char,
-        info: *const H5O_info_t,
+        info: *const H5O_info1_t,
         op_data: *mut c_void,
     ) -> herr_t,
 >;
@@ -195,21 +201,21 @@ pub type H5O_mcdt_search_cb_t =
 
 #[cfg(not(hdf5_1_10_3))]
 extern "C" {
-    pub fn H5Oget_info(loc_id: hid_t, oinfo: *mut H5O_info_t) -> herr_t;
+    pub fn H5Oget_info(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
     pub fn H5Oget_info_by_name(
-        loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info_t, lapl_id: hid_t,
+        loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
     pub fn H5Oget_info_by_idx(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-        n: hsize_t, oinfo: *mut H5O_info_t, lapl_id: hid_t,
+        n: hsize_t, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
     pub fn H5Ovisit(
-        obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate_t,
+        obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate1_t,
         op_data: *mut c_void,
     ) -> herr_t;
     pub fn H5Ovisit_by_name(
         loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-        op: H5O_iterate_t, op_data: *mut c_void, lapl_id: hid_t,
+        op: H5O_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,
     ) -> herr_t;
 }
 
@@ -229,7 +235,9 @@ extern "C" {
         src_loc_id: hid_t, src_name: *const c_char, dst_loc_id: hid_t, dst_name: *const c_char,
         ocpypl_id: hid_t, lcpl_id: hid_t,
     ) -> herr_t;
+    #[deprecated(note = "Function is deprecated in favor of object attributes")]
     pub fn H5Oset_comment(obj_id: hid_t, comment: *const c_char) -> herr_t;
+    #[deprecated(note = "Function is deprecated in favor of object attributes")]
     pub fn H5Oset_comment_by_name(
         loc_id: hid_t, name: *const c_char, comment: *const c_char, lapl_id: hid_t,
     ) -> herr_t;
@@ -262,43 +270,43 @@ mod hdf5_1_10_3 {
     use super::*;
 
     extern "C" {
-        pub fn H5Oget_info2(loc_id: hid_t, oinfo: *mut H5O_info_t, fields: c_uint) -> herr_t;
+        pub fn H5Oget_info2(loc_id: hid_t, oinfo: *mut H5O_info1_t, fields: c_uint) -> herr_t;
         pub fn H5Oget_info_by_name2(
-            loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info_t, fields: c_uint,
+            loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info1_t, fields: c_uint,
             lapl_id: hid_t,
         ) -> herr_t;
         pub fn H5Oget_info_by_idx2(
             loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-            n: hsize_t, oinfo: *mut H5O_info_t, fields: c_uint, lapl_id: hid_t,
+            n: hsize_t, oinfo: *mut H5O_info1_t, fields: c_uint, lapl_id: hid_t,
         ) -> herr_t;
         pub fn H5Ovisit2(
-            obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate_t,
+            obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate1_t,
             op_data: *mut c_void, fields: c_uint,
         ) -> herr_t;
         pub fn H5Ovisit_by_name2(
             loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-            op: H5O_iterate_t, op_data: *mut c_void, fields: c_uint, lapl_id: hid_t,
+            op: H5O_iterate1_t, op_data: *mut c_void, fields: c_uint, lapl_id: hid_t,
         ) -> herr_t;
         #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info2()")]
-        pub fn H5Oget_info1(loc_id: hid_t, oinfo: *mut H5O_info_t) -> herr_t;
+        pub fn H5Oget_info1(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
         #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_name2()")]
         pub fn H5Oget_info_by_name1(
-            loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info_t, lapl_id: hid_t,
+            loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
         ) -> herr_t;
         #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_idx2()")]
         pub fn H5Oget_info_by_idx1(
             loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-            n: hsize_t, oinfo: *mut H5O_info_t, lapl_id: hid_t,
+            n: hsize_t, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
         ) -> herr_t;
         #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit2()")]
         pub fn H5Ovisit1(
-            obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate_t,
+            obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate1_t,
             op_data: *mut c_void,
         ) -> herr_t;
         #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit_by_name2()")]
         pub fn H5Ovisit_by_name1(
             loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-            op: H5O_iterate_t, op_data: *mut c_void, lapl_id: hid_t,
+            op: H5O_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,
         ) -> herr_t;
     }
 
@@ -319,25 +327,25 @@ extern "C" {
     // in 1.10.5 those APIs were copied over to old names in order to be compatible with
     // older library versions - so we can link to them directly again.
     #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info2()")]
-    pub fn H5Oget_info(loc_id: hid_t, oinfo: *mut H5O_info_t) -> herr_t;
+    pub fn H5Oget_info(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
     #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_name2()")]
     pub fn H5Oget_info_by_name(
-        loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info_t, lapl_id: hid_t,
+        loc_id: hid_t, name: *const c_char, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
     #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Oget_info_by_idx2()")]
     pub fn H5Oget_info_by_idx(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-        n: hsize_t, oinfo: *mut H5O_info_t, lapl_id: hid_t,
+        n: hsize_t, oinfo: *mut H5O_info1_t, lapl_id: hid_t,
     ) -> herr_t;
     #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit2()")]
     pub fn H5Ovisit(
-        obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate_t,
+        obj_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5O_iterate1_t,
         op_data: *mut c_void,
     ) -> herr_t;
     #[deprecated(note = "deprecated in HDF5 1.10.3, use H5Ovisit_by_name2()")]
     pub fn H5Ovisit_by_name(
         loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
-        op: H5O_iterate_t, op_data: *mut c_void, lapl_id: hid_t,
+        op: H5O_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,
     ) -> herr_t;
 }
 
@@ -387,6 +395,15 @@ pub struct H5O_native_info_meta_size_t {
 pub struct H5O_native_info_t {
     hdf: H5O_hdr_info_t,
     meta_size: H5O_native_info_meta_size_t,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct H5O_stat_t {
+    size: hsize_t,
+    free: hsize_t,
+    nmesgs: c_uint,
+    nchunks: c_uint,
 }
 
 #[cfg(hdf5_1_12_0)]

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -235,9 +235,9 @@ extern "C" {
         src_loc_id: hid_t, src_name: *const c_char, dst_loc_id: hid_t, dst_name: *const c_char,
         ocpypl_id: hid_t, lcpl_id: hid_t,
     ) -> herr_t;
-    #[deprecated(note = "Function is deprecated in favor of object attributes")]
+    #[deprecated(note = "function is deprecated in favor of object attributes")]
     pub fn H5Oset_comment(obj_id: hid_t, comment: *const c_char) -> herr_t;
-    #[deprecated(note = "Function is deprecated in favor of object attributes")]
+    #[deprecated(note = "function is deprecated in favor of object attributes")]
     pub fn H5Oset_comment_by_name(
         loc_id: hid_t, name: *const c_char, comment: *const c_char, lapl_id: hid_t,
     ) -> herr_t;

--- a/hdf5-sys/src/h5r.rs
+++ b/hdf5-sys/src/h5r.rs
@@ -41,7 +41,7 @@ extern "C" {
         space_id: hid_t,
     ) -> herr_t;
     pub fn H5Rget_region(dataset: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> hid_t;
-    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Rget_obj_type2()")]
+    #[deprecated(note = "deprecated in HDF5 1.8.0, use H5Rget_obj_type2")]
     pub fn H5Rget_obj_type1(id: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> H5G_obj_t;
     pub fn H5Rget_obj_type2(
         id: hid_t, ref_type: H5R_type_t, ref_: *const c_void, obj_type: *mut H5O_type_t,
@@ -52,7 +52,7 @@ extern "C" {
 }
 
 extern "C" {
-    #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5Rdereference2()"))]
+    #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5Rdereference2"))]
     #[cfg_attr(not(hdf5_1_10_0), link_name = "H5Rdereference")]
     pub fn H5Rdereference1(obj_id: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> hid_t;
     #[cfg(hdf5_1_10_0)]

--- a/hdf5-sys/src/h5r.rs
+++ b/hdf5-sys/src/h5r.rs
@@ -1,7 +1,12 @@
 pub use self::H5R_type_t::*;
+#[cfg(not(hdf5_1_10_0))]
+pub use H5Rdereference1 as H5Rdereference;
+#[cfg(hdf5_1_10_0)]
+pub use H5Rdereference2 as H5Rdereference;
 
 use crate::internal_prelude::*;
 
+use crate::h5g::H5G_obj_t;
 use crate::h5o::H5O_type_t;
 
 #[repr(C)]
@@ -30,17 +35,14 @@ pub enum H5R_type_t {
 pub type hobj_ref_t = haddr_t;
 pub type hdset_reg_ref_t = [c_uchar; 12usize];
 
-#[cfg(not(hdf5_1_10_0))]
-extern "C" {
-    pub fn H5Rdereference(dataset: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> hid_t;
-}
-
 extern "C" {
     pub fn H5Rcreate(
         ref_: *mut c_void, loc_id: hid_t, name: *const c_char, ref_type: H5R_type_t,
         space_id: hid_t,
     ) -> herr_t;
     pub fn H5Rget_region(dataset: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> hid_t;
+    #[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Rget_obj_type2()")]
+    pub fn H5Rget_obj_type1(id: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> H5G_obj_t;
     pub fn H5Rget_obj_type2(
         id: hid_t, ref_type: H5R_type_t, ref_: *const c_void, obj_type: *mut H5O_type_t,
     ) -> herr_t;
@@ -49,17 +51,15 @@ extern "C" {
     ) -> ssize_t;
 }
 
-#[cfg(hdf5_1_10_0)]
 extern "C" {
-    #[deprecated(note = "deprecated in HDF5 1.10.0, use H5Rdereference2()")]
+    #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5Rdereference2()"))]
+    #[cfg_attr(not(hdf5_1_10_0), link_name = "H5Rdereference")]
     pub fn H5Rdereference1(obj_id: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> hid_t;
+    #[cfg(hdf5_1_10_0)]
     pub fn H5Rdereference2(
         obj_id: hid_t, oapl_id: hid_t, ref_type: H5R_type_t, ref_: *const c_void,
     ) -> hid_t;
 }
-
-#[cfg(hdf5_1_10_0)]
-pub use self::H5Rdereference1 as H5Rdereference;
 
 #[cfg(hdf5_1_12_0)]
 pub const H5R_REF_BUF_SIZE: usize = 64;

--- a/hdf5-sys/src/h5s.rs
+++ b/hdf5-sys/src/h5s.rs
@@ -1,6 +1,10 @@
 pub use self::H5S_class_t::*;
 pub use self::H5S_sel_type::*;
 pub use self::H5S_seloper_t::*;
+#[cfg(not(hdf5_1_12_0))]
+pub use self::H5Sencode1 as H5Sencode;
+#[cfg(hdf5_1_12_0)]
+pub use self::H5Sencode2 as H5Sencode;
 
 use crate::internal_prelude::*;
 
@@ -97,11 +101,6 @@ extern "C" {
     pub fn H5Sget_select_bounds(spaceid: hid_t, start: *mut hsize_t, end: *mut hsize_t) -> herr_t;
     pub fn H5Sget_select_type(spaceid: hid_t) -> H5S_sel_type;
 }
-
-#[cfg(not(hdf5_1_12_0))]
-pub use self::H5Sencode1 as H5Sencode;
-#[cfg(hdf5_1_12_0)]
-pub use self::H5Sencode2 as H5Sencode;
 
 #[cfg(hdf5_1_10_0)]
 extern "C" {

--- a/hdf5-sys/src/h5t.rs
+++ b/hdf5-sys/src/h5t.rs
@@ -336,15 +336,15 @@ extern "C" {
         src_id: hid_t, dst_id: hid_t, nelmts: size_t, buf: *mut c_void, background: *mut c_void,
         plist_id: hid_t,
     ) -> herr_t;
-    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tcommit2()")]
+    #[deprecated(note = "deprecated since HDF5 1.8.0, use H5Tcommit2")]
     pub fn H5Tcommit1(loc_id: hid_t, name: *const c_char, type_id: hid_t) -> herr_t;
-    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tcommit2()")]
+    #[deprecated(note = "deprecated since HDF5 1.8.0, use H5Tcommit2")]
     pub fn H5Topen1(loc_id: hid_t, name: *const c_char) -> hid_t;
-    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tarray_create2()")]
+    #[deprecated(note = "deprecated since HDF5 1.8.0, use H5Tarray_create2")]
     pub fn H5Tarray_create1(
         base_id: hid_t, ndims: c_int, dim: *const hsize_t, perm: *const c_int,
     ) -> hid_t;
-    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tget_array_dims2()")]
+    #[deprecated(note = "deprecated since HDF5 1.8.0, use H5Tget_array_dims2")]
     pub fn H5Tget_array_dims1(type_id: hid_t, dims: *mut hsize_t, perm: *mut c_int) -> c_int;
 }
 

--- a/hdf5-sys/src/h5t.rs
+++ b/hdf5-sys/src/h5t.rs
@@ -13,6 +13,10 @@ pub use self::H5T_pad_t::*;
 pub use self::H5T_pers_t::*;
 pub use self::H5T_sign_t::*;
 pub use self::H5T_str_t::*;
+pub use {
+    H5Tarray_create2 as H5Tarray_create, H5Tcommit2 as H5Tcommit,
+    H5Tget_array_dims2 as H5Tget_array_dims, H5Topen2 as H5Topen,
+};
 
 use crate::internal_prelude::*;
 
@@ -332,6 +336,16 @@ extern "C" {
         src_id: hid_t, dst_id: hid_t, nelmts: size_t, buf: *mut c_void, background: *mut c_void,
         plist_id: hid_t,
     ) -> herr_t;
+    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tcommit2()")]
+    pub fn H5Tcommit1(loc_id: hid_t, name: *const c_char, type_id: hid_t) -> herr_t;
+    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tcommit2()")]
+    pub fn H5Topen1(loc_id: hid_t, name: *const c_char) -> hid_t;
+    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tarray_create2()")]
+    pub fn H5Tarray_create1(
+        base_id: hid_t, ndims: c_int, dim: *const hsize_t, perm: *const c_int,
+    ) -> hid_t;
+    #[deprecated(note = "Deprecated since HDF5 1.8.0, use H5Tget_array_dims2()")]
+    pub fn H5Tget_array_dims1(type_id: hid_t, dims: *mut hsize_t, perm: *mut c_int) -> c_int;
 }
 
 pub use self::globals::*;

--- a/hdf5-sys/src/h5z.rs
+++ b/hdf5-sys/src/h5z.rs
@@ -151,7 +151,7 @@ extern "C" {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Z_class2_t")]
+#[deprecated(note = "deprecated in HDF5 1.8.0, use H5Z_class2_t")]
 pub struct H5Z_class1_t {
     id: H5Z_filter_t,
     name: *const c_char,

--- a/hdf5-sys/src/h5z.rs
+++ b/hdf5-sys/src/h5z.rs
@@ -3,6 +3,7 @@ use std::mem;
 pub use self::H5Z_EDC_t::*;
 pub use self::H5Z_SO_scale_type_t::*;
 pub use self::H5Z_cb_return_t::*;
+pub use self::H5Z_class2_t as H5Z_class_t;
 
 use crate::internal_prelude::*;
 
@@ -146,4 +147,15 @@ extern "C" {
     pub fn H5Zunregister(id: H5Z_filter_t) -> herr_t;
     pub fn H5Zfilter_avail(id: H5Z_filter_t) -> htri_t;
     pub fn H5Zget_filter_info(filter: H5Z_filter_t, filter_config_flags: *mut c_uint) -> herr_t;
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[deprecated(note = "Deprecated in HDF5 1.8.0, use H5Z_class2_t")]
+pub struct H5Z_class1_t {
+    id: H5Z_filter_t,
+    name: *const c_char,
+    can_apply: H5Z_can_apply_func_t,
+    set_local: H5Z_set_local_func_t,
+    filter: H5Z_func_t,
 }

--- a/src/hl/location.rs
+++ b/src/hl/location.rs
@@ -2,11 +2,13 @@ use std::fmt::{self, Debug};
 use std::ops::Deref;
 use std::ptr;
 
+#[allow(deprecated)]
+use hdf5_sys::h5o::H5Oset_comment;
 use hdf5_sys::{
     h5a::H5Aopen,
     h5f::H5Fget_name,
     h5i::{H5Iget_file_id, H5Iget_name},
-    h5o::{H5Oget_comment, H5Oset_comment},
+    h5o::H5Oget_comment,
 };
 
 use crate::internal_prelude::*;
@@ -77,15 +79,19 @@ impl Location {
     }
 
     /// Set or the commment attached to the named object.
+    #[deprecated(note = "Attributes are preferred to comments")]
     pub fn set_comment(&self, comment: &str) -> Result<()> {
         // TODO: &mut self?
         let comment = to_cstring(comment)?;
+        #[allow(deprecated)]
         h5call!(H5Oset_comment(self.id(), comment.as_ptr())).and(Ok(()))
     }
 
     /// Clear the commment attached to the named object.
+    #[deprecated(note = "Attributes are preferred to comments")]
     pub fn clear_comment(&self) -> Result<()> {
         // TODO: &mut self?
+        #[allow(deprecated)]
         h5call!(H5Oset_comment(self.id(), ptr::null_mut())).and(Ok(()))
     }
 
@@ -134,6 +140,7 @@ pub mod tests {
 
     #[test]
     pub fn test_comment() {
+        #[allow(deprecated)]
         with_tmp_file(|file| {
             assert!(file.comment().is_none());
             assert!(file.set_comment("foo").is_ok());

--- a/src/hl/location.rs
+++ b/src/hl/location.rs
@@ -79,7 +79,7 @@ impl Location {
     }
 
     /// Set or the commment attached to the named object.
-    #[deprecated(note = "Attributes are preferred to comments")]
+    #[deprecated(note = "attributes are preferred to comments")]
     pub fn set_comment(&self, comment: &str) -> Result<()> {
         // TODO: &mut self?
         let comment = to_cstring(comment)?;
@@ -88,7 +88,7 @@ impl Location {
     }
 
     /// Clear the commment attached to the named object.
-    #[deprecated(note = "Attributes are preferred to comments")]
+    #[deprecated(note = "attributes are preferred to comments")]
     pub fn clear_comment(&self) -> Result<()> {
         // TODO: &mut self?
         #[allow(deprecated)]


### PR DESCRIPTION
I went through the [documentation](https://portal.hdfgroup.org/display/HDF5/HDF5) and added all functions which were marked as deprecated, mostly for completeness of the bindings. Most of these functions were deprecated in 1.8.0, which is a version we don't support.

 I've also fixed up the name of some structs to be consistent with the naming in 1.12.0, and made sure we have aliases for these to remain compatible with other supported versions.

Comments on objects are officially deprecated in favor of attributes. I've added the `deprecated` attribute on the set/clear_comment in the top crate.

FIxes #114