### PR TITLE
Get ready for HDF 1.13.*

### DIFF
--- a/hdf5-src/build.rs
+++ b/hdf5-src/build.rs
@@ -18,6 +18,7 @@ fn main() {
         "HDF5_BUILD_JAVA",
         "HDF5_BUILD_FORTRAN",
         "HDF5_BUILD_CPP_LIB",
+        "HDF5_BUILD_UTILS",
         "HDF5_ENABLE_PARALLEL",
     ] {
         cfg.define(option, "OFF");

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -25,7 +25,7 @@ impl Version {
     }
 
     pub fn parse(s: &str) -> Option<Self> {
-        let re = Regex::new(r"^(1)\.(8|10|12)\.(\d\d?)(_\d+)?(-patch\d+)?$").ok()?;
+        let re = Regex::new(r"^(1)\.(8|10|12|13)\.(\d\d?)(_\d+)?(-patch\d+)?$").ok()?;
         let captures = re.captures(s)?;
         Some(Self {
             major: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
@@ -38,7 +38,8 @@ impl Version {
         self.major == 1
             && ((self.minor == 8 && self.micro >= 4)
                 || (self.minor == 10)
-                || (self.minor == 12 && self.micro == 0))
+                || (self.minor == 12 && self.micro == 0)
+                || (self.minor == 13))
     }
 }
 


### PR DESCRIPTION
Preparing for HDF5 1.13.*

- hdf5-src: tag to current develop
- hdf5-src: disable build HDF5 utils
- hdf5-sys: allow hdf 1.13.*

