### PR TITLE
Support static cross-compilation from Unix to Windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,18 @@ jobs:
           msiexec /i ${{env.MSI_PATH}} /quiet /qn /norestart
       - name: Build and test all crates
         run: cargo test -vv
+
+  wine:
+    name: wine
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with: {submodules: true}
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with: {toolchain: stable, target: x86_64-pc-windows-gnu, profile: minimal, override: true}
+      - name: Install dependencies
+        run: sudo apt-get install wine64 mingw-w64
+      - name: Build and test
+        run: env CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine64 cargo test --features hdf5-sys/static --target x86_64-pc-windows-gnu -- --skip test_compile_fail

--- a/hdf5-src/build.rs
+++ b/hdf5-src/build.rs
@@ -57,7 +57,8 @@ fn main() {
         }
     }
 
-    let debug_postfix = if cfg!(target_os = "windows") { "_D" } else { "_debug" };
+    let targeting_windows = env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows";
+    let debug_postfix = if targeting_windows { "_D" } else { "_debug" };
 
     if feature_enabled("HL") {
         cfg.define("HDF5_BUILD_HL_LIB", "ON");
@@ -69,6 +70,13 @@ fn main() {
             }
         }
         println!("cargo:hl_library={}", hdf5_hl_lib);
+    }
+
+    if cfg!(unix) && targeting_windows {
+        let wine_exec =
+            if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64" { "wine64" } else { "wine" };
+        // when cross-compiling to windows, use Wine to run code generation programs
+        cfg.define("CMAKE_CROSSCOMPILING_EMULATOR", wine_exec);
     }
 
     let dst = cfg.build();


### PR DESCRIPTION
Use wine to run HDF5 configuration programs.

To run Windows unit tests on Linux, use wine as the runner. For example:
```
CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine64 cargo test --features hdf5-sys/static --target x86_64-pc-windows-gnu
```

If your main wine configuration is 32-bit but you're cross-compiling for 64-bit windows, you will need to specify a different wine environment using the `WINEPREFIX` environment variable, eg. `WINEPREFIX=~/wine_win64`.