### PR TITLE
Re-export the used version of ndarray.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,9 @@ mod export {
 
 pub use crate::export::*;
 
+// Re-exports.
+pub use ndarray;
+
 #[macro_use]
 mod macros;
 #[macro_use]


### PR DESCRIPTION
Hi, simple request. I'm in a painful spot where multiple versions of `ndarray` are being used (0.13.* and 0.14.0), and even though the base `Array2` type that I'm using has not changed between `ndarray` versions, rustc complains that I'm trying to mix different `ndarray` types. I can't transmute (in the hope of a compiled no-op) the `ndarray` types used by `hdf5-rust` to whatever I need because the `ndarray` used by `hdf5-rust` is not re-exported. This PR re-exports `ndarray`, such that downstream users could do this kind of thing if they wanted.

Thanks for your time, and please let me know if there's anything I can do to help.