### PR TITLE
use const generics in hdf5-types for array impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
         run: |
           [ "${{matrix.mpi}}" != "serial" ] && FEATURES=mpio
           cargo test -vv --features="$FEATURES"
+      - name: Test const generics
+        if: matrix.rust == 'nightly'
+        run: cargo test -p hdf5-types --features hdf5-types/const_generics
 
   msi:
     name: msi

--- a/hdf5-types/Cargo.toml
+++ b/hdf5-types/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/aldanor/hdf5-rust"
 homepage = "https://github.com/aldanor/hdf5-rust"
 edition = "2018"
 
+[features]
+const_generics = []
+
 [dependencies]
 ascii = "1.0"
 libc = "0.2"

--- a/hdf5-types/src/array.rs
+++ b/hdf5-types/src/array.rs
@@ -14,49 +14,78 @@ pub unsafe trait Array: 'static {
     fn capacity() -> usize;
 }
 
-macro_rules! impl_array {
-    () => ();
+#[cfg(not(feature = "const_generics"))]
+mod impl_array {
+    use super::*;
 
-    ($n:expr, $($ns:expr,)*) => (
-        unsafe impl<T: 'static> Array for [T; $n] {
-            type Item = T;
+    macro_rules! impl_array {
+        () => ();
 
-            #[inline(always)]
-            fn as_ptr(&self) -> *const T {
-                self as *const _ as *const _
+        ($n:expr, $($ns:expr,)*) => (
+            unsafe impl<T: 'static> Array for [T; $n] {
+                type Item = T;
+
+                #[inline(always)]
+                fn as_ptr(&self) -> *const T {
+                    self as *const _ as *const _
+                }
+
+                #[inline(always)]
+                fn as_mut_ptr(&mut self) -> *mut T {
+                    self as *mut _ as *mut _
+                }
+
+                #[inline(always)]
+                fn capacity() -> usize {
+                    $n
+                }
             }
 
-            #[inline(always)]
-            fn as_mut_ptr(&mut self) -> *mut T {
-                self as *mut _ as *mut _
-            }
+            impl_array!($($ns,)*);
+        );
+    }
 
-            #[inline(always)]
-            fn capacity() -> usize {
-                $n
-            }
-        }
-
-        impl_array!($($ns,)*);
+    impl_array!(
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31,
+    );
+    impl_array!(
+        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+        55, 56, 57, 58, 59, 60, 61, 62, 63,
+    );
+    impl_array!(
+        64, 70, 72, 80, 90, 96, 100, 110, 120, 128, 130, 140, 150, 160, 170, 180, 190, 192, 200,
+        210, 220, 224, 230, 240, 250,
+    );
+    impl_array!(
+        256, 300, 365, 366, 384, 400, 500, 512, 600, 700, 768, 800, 900, 1000, 1024, 2048, 4096,
+        8192, 16384, 32768,
     );
 }
 
-impl_array!(
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-    26, 27, 28, 29, 30, 31,
-);
-impl_array!(
-    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
-    56, 57, 58, 59, 60, 61, 62, 63,
-);
-impl_array!(
-    64, 70, 72, 80, 90, 96, 100, 110, 120, 128, 130, 140, 150, 160, 170, 180, 190, 192, 200, 210,
-    220, 224, 230, 240, 250,
-);
-impl_array!(
-    256, 300, 384, 400, 500, 512, 600, 700, 768, 800, 900, 1000, 1024, 2048, 4096, 8192, 16384,
-    32768,
-);
+#[cfg(feature = "const_generics")]
+mod impl_array {
+    use super::*;
+
+    unsafe impl<T: 'static, const N: usize> Array for [T; N] {
+        type Item = T;
+
+        #[inline(always)]
+        fn as_ptr(&self) -> *const T {
+            self as *const _
+        }
+
+        #[inline(always)]
+        fn as_mut_ptr(&mut self) -> *mut T {
+            self as *mut _ as *mut _
+        }
+
+        #[inline(always)]
+        fn capacity() -> usize {
+            N
+        }
+    }
+}
 
 #[repr(C)]
 pub struct VarLenArray<T: Copy> {

--- a/hdf5-types/src/lib.rs
+++ b/hdf5-types/src/lib.rs
@@ -1,6 +1,13 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::missing_safety_doc))]
 
+//! Types that can be stored and retrieved from a `HDF5` dataset
+//!
+//! Crate features:
+//! * `const_generics`: Uses const generics to enable arrays [T; N] for all N.
+//!                     Compiling without this limits arrays to certain prespecified
+//!                     sizes
+
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;


### PR DESCRIPTION
Const generics are rapidly approaching which means `impl_array` can be replaced with a generic size, supporting more array cases than one can manually specify. This is feature gated on `const_generics` on `hdf5-types` and should only be a minor bump.

Ref #122 