### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Dependencies are bumped to newest major versions; `ndarray` users may now
+  use both version `0.13` and version `0.14`.
+
 ## 0.7.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pretty_assertions = "0.6"
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1.3"
 scopeguard = "1.0"
-tempdir = "0.3"
+tempfile = "3.2"
 
 [package.metadata.docs.rs]
 features = ["hdf5-sys/static", "hdf5-sys/zlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ default-members = [".", "hdf5-types", "hdf5-derive", "hdf5-sys"]
 bitflags = "1.2"
 lazy_static = "1.4"
 libc = "0.2"
-parking_lot = "0.10"
-ndarray = "0.13"
+parking_lot = "0.11"
+ndarray = ">=0.13,<0.15"
 num-integer = "0.1"
 num-traits = "0.2"
 mpi-sys = { version = "0.1", optional = true }
@@ -35,7 +35,7 @@ hdf5-derive = { path = "hdf5-derive", version = "0.7.0" }  # !V
 [dev-dependencies]
 mashup = "0.1"
 pretty_assertions = "0.6"
-rand = { version = "0.7", features = ["small_rng"] }
+rand = { version = "0.8", features = ["small_rng"] }
 regex = "1.3"
 scopeguard = "1.0"
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ hdf5-types = { path = "hdf5-types", version = "0.7.0" }  # !V
 hdf5-derive = { path = "hdf5-derive", version = "0.7.0" }  # !V
 
 [dev-dependencies]
-mashup = "0.1"
+paste = "1.0"
 pretty_assertions = "0.6"
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1.3"

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -38,7 +38,7 @@ pkg-config = "0.3"
 [target.'cfg(windows)'.build-dependencies]
 serde = "1.0"
 serde_derive = "1.0"
-winreg = { version = "0.7", features = ["serialization-serde"]}
+winreg = { version = "0.8", features = ["serialization-serde"]}
 
 [package.metadata.docs.rs]
 features = ["static", "zlib"]

--- a/hdf5-types/Cargo.toml
+++ b/hdf5-types/Cargo.toml
@@ -14,4 +14,4 @@ ascii = "1.0"
 libc = "0.2"
 
 [dev-dependencies]
-quickcheck = { version = "0.9", default-features = false }
+quickcheck = { version = "1.0", default-features = false }

--- a/hdf5-types/src/string.rs
+++ b/hdf5-types/src/string.rs
@@ -597,7 +597,7 @@ pub mod tests {
     pub struct UnicodeGen(pub String);
 
     impl Arbitrary for AsciiGen {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        fn arbitrary(g: &mut Gen) -> Self {
             let mut bytes: Vec<u8> = Arbitrary::arbitrary(g);
             for c in &mut bytes {
                 *c = *c % 0x7e + 1;
@@ -620,7 +620,7 @@ pub mod tests {
     }
 
     impl Arbitrary for UnicodeGen {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        fn arbitrary(g: &mut Gen) -> Self {
             let s: String = Arbitrary::arbitrary(g);
             let mut s: String = s.chars().filter(|&c| c != '\0').collect();
             while s.as_bytes().len() > 1024 {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 use crate::internal_prelude::*;
 
 pub fn with_tmp_dir<F: Fn(PathBuf)>(func: F) {
-    let dir = TempDir::new_in(".", "tmp").unwrap();
+    let dir = tempdir().unwrap();
     let path = dir.path().to_path_buf();
     let _e = silence_errors();
     func(path);

--- a/tests/common/gen.rs
+++ b/tests/common/gen.rs
@@ -10,11 +10,11 @@ use rand::distributions::{Alphanumeric, Uniform};
 use rand::prelude::{Rng, SliceRandom};
 
 pub fn gen_shape<R: Rng + ?Sized>(rng: &mut R, ndim: usize) -> Vec<usize> {
-    iter::repeat(()).map(|_| rng.gen_range(0, 11)).take(ndim).collect()
+    iter::repeat(()).map(|_| rng.gen_range(0..11)).take(ndim).collect()
 }
 
 pub fn gen_ascii<R: Rng + ?Sized>(rng: &mut R, len: usize) -> String {
-    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
+    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).map(char::from).take(len).collect()
 }
 
 /// Generate a random slice of elements inside the given `shape` dimension.
@@ -33,20 +33,20 @@ fn gen_slice_one_dim<R: Rng + ?Sized>(rng: &mut R, shape: usize) -> ndarray::Sli
     }
 
     if rng.gen_bool(0.1) {
-        ndarray::SliceOrIndex::Index(rng.gen_range(0, shape) as isize)
+        ndarray::SliceOrIndex::Index(rng.gen_range(0..shape) as isize)
     } else {
-        let start = rng.gen_range(0, shape) as isize;
+        let start = rng.gen_range(0..shape) as isize;
 
         let end = if rng.gen_bool(0.5) {
             None
         } else if rng.gen_bool(0.9) {
-            Some(rng.gen_range(start, shape as isize))
+            Some(rng.gen_range(start..shape as isize))
         } else {
             // Occasionally generate a slice with end < start.
-            Some(rng.gen_range(0, shape as isize))
+            Some(rng.gen_range(0..shape as isize))
         };
 
-        let step = if rng.gen_bool(0.9) { 1isize } else { rng.gen_range(1, shape * 2) as isize };
+        let step = if rng.gen_bool(0.9) { 1isize } else { rng.gen_range(1..shape * 2) as isize };
 
         ndarray::SliceOrIndex::Slice { start, end, step }
     }

--- a/tests/test_datatypes.rs
+++ b/tests/test_datatypes.rs
@@ -42,7 +42,7 @@ pub fn test_datatype_roundtrip() {
     enum X {
         A = 1,
         B = -2,
-    };
+    }
     let x_desc = TD::Enum(EnumType {
         size: IntSize::U8,
         signed: true,
@@ -58,7 +58,7 @@ pub fn test_datatype_roundtrip() {
     struct A {
         a: i64,
         b: u64,
-    };
+    }
     let a_desc = TD::Compound(CompoundType {
         fields: vec![
             CompoundField::typed::<i64>("a", 0, 0),
@@ -73,7 +73,7 @@ pub fn test_datatype_roundtrip() {
     struct C {
         a: [X; 2],
         b: [[A; 4]; 32],
-    };
+    }
     let a_arr_desc = TD::FixedArray(Box::new(x_desc), 2);
     let b_arr_desc = TD::FixedArray(Box::new(TD::FixedArray(Box::new(a_desc), 4)), 32);
     let c_desc = TD::Compound(CompoundType {

--- a/tests/test_plist.rs
+++ b/tests/test_plist.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate mashup;
-
 use std::mem;
 
 use hdf5::dataset::*;
@@ -14,11 +11,10 @@ macro_rules! test_pl {
 
     ($ty:ident, $field:ident ($($arg:expr,)+): $($name:ident=$value:expr,)+) => ({
         let mut b = $ty::build();
-        mashup! { m["get" $field] = get_ $field; }
         b.$field($($arg,)+);
         let fapl = b.finish()?;
         $(assert_eq!(fapl.$field().$name, $value);)+
-        m! { $(assert_eq!(fapl."get" $field()?.$name, $value);)+ }
+        paste::paste! { $(assert_eq!(fapl.[<get_ $field>]()?.$name, $value);)+ }
     });
 
     ($ty:ident, $field:ident: $($name:ident=$value:expr),+) => (
@@ -31,11 +27,10 @@ macro_rules! test_pl {
 
     ($ty:ident, $field:ident ($arg:expr): $value:expr) => ({
         let mut b = $ty::build();
-        mashup! { m["get" $field] = get_ $field; }
         b.$field($arg);
         let fapl = b.finish()?;
         assert_eq!(fapl.$field(), $value);
-        m! { assert_eq!(fapl."get" $field()?, $value); }
+        paste::paste! { assert_eq!(fapl.[<get_ $field>]()?, $value); }
     });
 
     ($ty:ident, $field:ident: $value:expr) => ({


### PR DESCRIPTION
This updates `parking_lot` to the newest version, and `ndarray` can now be both `0.13` and `0.14` as we expose this publicly.

Other internal dependencies are updated to deduplicate the dependency graph:
* `tempdir` is replaced with the more up to date `tempfile` to pull in the newest version of `rand`.
* `mashup` is replaced with `paste` to pull `proc-macro2`

This result in `cargo tree -d` returning empty

Closes #125
Closes #123 