### PR TITLE
simple optional path to download HDF5 from conda and statically link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [features]
 default = []
 mpio = ["mpi-sys", "hdf5-sys/mpio"]
+conda = ["hdf5-sys/conda"] 
 
 [workspace]
 members = [".", "hdf5-types", "hdf5-derive", "hdf5-sys", "hdf5-src"]

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -27,10 +27,16 @@ threadsafe = ["hdf5-src/threadsafe"]
 zlib = ["libz-sys", "hdf5-src/zlib"]
 static = ["hdf5-src"]
 deprecated = ["hdf5-src/deprecated"]
+conda = ["attohttpc", "md5", "bzip2", "tar"]
 
 [build-dependencies]
 libloading = "0.6"
 regex = { version = "1.3", features = ["std"] }
+md5 = { version = "0.6", optional = true }
+attohttpc = { version = "0.12", default-features = false, features = ["compress", "tls-rustls"], optional = true }
+bzip2 = { version = "0.3.3", optional = true }
+tar = { version = "*", optional = true }
+
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
We've been maintaining this as separate branch for a while: it works really well for us to get reliable builds on diverse machines without requiring an HDF5 installation & to have unit test in downstream crates work seamlessly.  

Is this something you'd be open to? Any suggestions on how you'd like to approach it differently?