### PR TITLE
Replace Array trait with const generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Const generics support (MSRV 1.51): `hdf5-types` now uses const generics for array types,
   allowing fixed-size arrays of arbitrary sizes.
 - The `ndarray` dependency has been updated to `0.15`.
+- The `Array` trait has been removed and replaced with const generics.
 
 ## 0.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@
 - Const generics support (MSRV 1.51): `hdf5-types` now uses const generics for array types,
   allowing fixed-size arrays of arbitrary sizes.
 - The `ndarray` dependency has been updated to `0.15`.
-- The `Array` trait has been removed and replaced with const generics.
+- `hdf5_types::Array` trait has been removed and replaced with const generics. String types
+  are now generic over size only: `FixedAscii<N>` and `FixedUnicode<N>`.
 
 ## 0.7.1
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ HDF5 for Rust.
 [![Latest Version](https://img.shields.io/crates/v/hdf5.svg)](https://crates.io/crates/hdf5)
 [![Documentation](https://docs.rs/hdf5/badge.svg)](https://docs.rs/hdf5)
 [![Changelog](https://img.shields.io/github/v/release/aldanor/hdf5-rust)](https://github.com/aldanor/hdf5-rust/blob/master/CHANGELOG.md)
+![hdf5: rustc 1.51+](https://img.shields.io/badge/hdf5-rustc_1.51+-lightblue.svg)
 [![Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
@@ -89,7 +90,7 @@ toolchains; macOS Catalina).
 ### Rust
 
 `hdf5` crate is tested continuously for all three official release channels, and
-requires a reasonably recent Rust compiler (e.g. of version 1.40 or newer).
+requires a reasonably recent Rust compiler (e.g. of version 1.51 or newer).
 
 ### HDF5
 

--- a/hdf5-derive/tests/test.rs
+++ b/hdf5-derive/tests/test.rs
@@ -18,10 +18,10 @@ struct A {
 #[repr(C)]
 struct B {
     a: [A; 4],
-    b: FixedAscii<[u8; 8]>,
+    b: FixedAscii<8>,
     c: VarLenArray<f64>,
     d: bool,
-    e: FixedUnicode<[u8; 7]>,
+    e: FixedUnicode<7>,
     f: VarLenAscii,
     g: VarLenUnicode,
 }

--- a/hdf5-types/src/dyn_value.rs
+++ b/hdf5-types/src/dyn_value.rs
@@ -803,8 +803,8 @@ mod tests {
     #[repr(C)]
     struct Data {
         points: VarLenArray<Point>,
-        fa: FixedAscii<[u8; 5]>,
-        fu: FixedUnicode<[u8; 5]>,
+        fa: FixedAscii<5>,
+        fu: FixedUnicode<5>,
         va: VarLenAscii,
         vu: VarLenUnicode,
     }

--- a/hdf5-types/src/h5type.rs
+++ b/hdf5-types/src/h5type.rs
@@ -3,7 +3,7 @@ use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 
-use crate::array::{Array, VarLenArray};
+use crate::array::VarLenArray;
 use crate::string::{FixedAscii, FixedUnicode, VarLenAscii, VarLenUnicode};
 
 #[allow(non_camel_case_types)]
@@ -331,13 +331,10 @@ macro_rules! impl_tuple {
 
 impl_tuple! { A, B, C, D, E, F, G, H, I, J, K, L }
 
-unsafe impl<T: Array<Item = I>, I: H5Type> H5Type for T {
+unsafe impl<T: H5Type, const N: usize> H5Type for [T; N] {
     #[inline]
     fn type_descriptor() -> TypeDescriptor {
-        TypeDescriptor::FixedArray(
-            Box::new(<I as H5Type>::type_descriptor()),
-            <T as Array>::capacity(),
-        )
+        TypeDescriptor::FixedArray(Box::new(<T as H5Type>::type_descriptor()), N)
     }
 }
 
@@ -348,17 +345,17 @@ unsafe impl<T: Copy + H5Type> H5Type for VarLenArray<T> {
     }
 }
 
-unsafe impl<A: Array<Item = u8>> H5Type for FixedAscii<A> {
+unsafe impl<const N: usize> H5Type for FixedAscii<N> {
     #[inline]
     fn type_descriptor() -> TypeDescriptor {
-        TypeDescriptor::FixedAscii(A::capacity())
+        TypeDescriptor::FixedAscii(N)
     }
 }
 
-unsafe impl<A: Array<Item = u8>> H5Type for FixedUnicode<A> {
+unsafe impl<const N: usize> H5Type for FixedUnicode<N> {
     #[inline]
     fn type_descriptor() -> TypeDescriptor {
-        TypeDescriptor::FixedUnicode(A::capacity())
+        TypeDescriptor::FixedUnicode(N)
     }
 }
 
@@ -439,8 +436,8 @@ pub mod tests {
 
     #[test]
     pub fn test_string_types() {
-        type FA = FixedAscii<[u8; 16]>;
-        type FU = FixedUnicode<[u8; 32]>;
+        type FA = FixedAscii<16>;
+        type FU = FixedUnicode<32>;
         assert_eq!(FA::type_descriptor(), TD::FixedAscii(16));
         assert_eq!(FU::type_descriptor(), TD::FixedUnicode(32));
         assert_eq!(VarLenAscii::type_descriptor(), TD::VarLenAscii);

--- a/hdf5-types/src/lib.rs
+++ b/hdf5-types/src/lib.rs
@@ -19,7 +19,7 @@ pub mod dyn_value;
 mod h5type;
 mod string;
 
-pub use self::array::{Array, VarLenArray};
+pub use self::array::VarLenArray;
 pub use self::dyn_value::{DynValue, OwnedDynValue};
 pub use self::h5type::{
     CompoundField, CompoundType, EnumMember, EnumType, FloatSize, H5Type, IntSize, TypeDescriptor,

--- a/hdf5-types/src/string.rs
+++ b/hdf5-types/src/string.rs
@@ -11,8 +11,6 @@ use std::str::{self, FromStr};
 
 use ascii::{AsAsciiStr, AsAsciiStrError, AsciiStr};
 
-use crate::array::Array;
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[non_exhaustive]
 pub enum StringError {
@@ -46,15 +44,15 @@ impl fmt::Display for StringError {
 // ================================================================================
 
 macro_rules! impl_string_eq {
-    ($lhs:ty, $rhs:ty $(,$t:ident: $b:ident<$a:ident=$v:ty>)*) => {
-        impl<'a $(,$t: $b<$a=$v>)*> PartialEq<$rhs> for $lhs {
+    ($lhs:ty, $rhs:ty $(,const $N:ident:  usize)*) => {
+        impl<'a $(,const $N: usize)*> PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> PartialEq<$lhs> for $rhs {
+        impl<'a $(,const $N: usize)*> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
@@ -64,36 +62,36 @@ macro_rules! impl_string_eq {
 }
 
 macro_rules! impl_string_traits {
-    ($nm:ident, $ty:ty $(,$t:ident: $b:ident<$a:ident=$v:ty>)*) => (
-        impl<'a $(,$t: $b<$a=$v>)*> fmt::Debug for $ty {
+    ($nm:ident, $ty:ty $(, const $N:ident: usize)*) => (
+        impl<'a $(,const $N: usize)*> fmt::Debug for $ty {
             #[inline]
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 self.as_str().fmt(f)
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> fmt::Display for $ty {
+        impl<'a $(,const $N: usize)*> fmt::Display for $ty {
             #[inline]
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 self.as_str().fmt(f)
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> Hash for $ty {
+        impl<'a $(,const $N: usize)*> Hash for $ty {
             #[inline]
             fn hash<H: Hasher>(&self, hasher: &mut H) {
                 Hash::hash(&self.as_bytes(), hasher)
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> Default for $ty {
+        impl<'a $(,const $N: usize)*> Default for $ty {
             #[inline]
             fn default() -> $ty {
                 $nm::new()
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> Deref for $ty {
+        impl<'a $(,const $N: usize)*> Deref for $ty {
             type Target = str;
 
             #[inline]
@@ -102,28 +100,28 @@ macro_rules! impl_string_traits {
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> Borrow<str> for $ty {
+        impl<'a $(,const $N: usize)*> Borrow<str> for $ty {
             #[inline]
             fn borrow(&self) -> &str {
                 self
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> AsRef<str> for $ty {
+        impl<'a $(,const $N: usize)*> AsRef<str> for $ty {
             #[inline]
             fn as_ref(&self) -> &str {
                 self
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> AsRef<[u8]> for $ty {
+        impl<'a $(,const $N: usize)*> AsRef<[u8]> for $ty {
             #[inline]
             fn as_ref(&self) -> &[u8] {
                 self.as_bytes()
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> Index<RangeFull> for $ty {
+        impl<'a $(,const $N: usize)*> Index<RangeFull> for $ty {
             type Output = str;
 
             #[inline]
@@ -132,42 +130,42 @@ macro_rules! impl_string_traits {
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> PartialEq for $ty {
+        impl<'a $(,const $N: usize)*> PartialEq for $ty {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
                 PartialEq::eq(&self[..], &other[..])
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> Eq for $ty { }
+        impl<'a $(,const $N: usize)*> Eq for $ty { }
 
-        impl_string_eq!($ty, str $(,$t: $b<$a=$v>)*);
-        impl_string_eq!($ty, &'a str $(,$t: $b<$a=$v>)*);
-        impl_string_eq!($ty, String $(,$t: $b<$a=$v>)*);
-        impl_string_eq!($ty, Cow<'a, str> $(,$t: $b<$a=$v>)*);
+        impl_string_eq!($ty, str $(,const $N: usize)*);
+        impl_string_eq!($ty, &'a str $(,const $N: usize)*);
+        impl_string_eq!($ty, String $(,const $N: usize)*);
+        impl_string_eq!($ty, Cow<'a, str> $(,const $N: usize)*);
 
-        impl<'a $(,$t: $b<$a=$v>)*> From<$ty> for String {
+        impl<'a $(,const $N: usize)*> From<$ty> for String {
             #[inline]
             fn from(s: $ty) -> String {
                 s.as_str().to_owned()
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> From<&'a $ty> for &'a [u8] {
+        impl<'a $(,const $N: usize)*> From<&'a $ty> for &'a [u8] {
             #[inline]
             fn from(s: &$ty) -> &[u8] {
                 s.as_bytes()
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> From<&'a $ty> for &'a str {
+        impl<'a $(,const $N: usize)*> From<&'a $ty> for &'a str {
             #[inline]
             fn from(s: &$ty) -> &str {
                 s.as_str()
             }
         }
 
-        impl<'a $(,$t: $b<$a=$v>)*> From<$ty> for Vec<u8> {
+        impl<'a $(,const $N: usize)*> From<$ty> for Vec<u8> {
             #[inline]
             fn from(s: $ty) -> Vec<u8> {
                 s.as_bytes().to_vec()
@@ -176,8 +174,8 @@ macro_rules! impl_string_traits {
     )
 }
 
-impl_string_traits!(FixedAscii, FixedAscii<A>, A: Array<Item = u8>);
-impl_string_traits!(FixedUnicode, FixedUnicode<A>, A: Array<Item = u8>);
+impl_string_traits!(FixedAscii, FixedAscii<N>, const N: usize);
+impl_string_traits!(FixedUnicode, FixedUnicode<N>, const N: usize);
 impl_string_traits!(VarLenAscii, VarLenAscii);
 impl_string_traits!(VarLenUnicode, VarLenUnicode);
 
@@ -377,22 +375,22 @@ impl FromStr for VarLenUnicode {
 
 #[repr(C)]
 #[derive(Copy)]
-pub struct FixedAscii<A: Array<Item = u8>> {
-    buf: A,
+pub struct FixedAscii<const N: usize> {
+    buf: [u8; N],
 }
 
-impl<A: Array<Item = u8>> Clone for FixedAscii<A> {
+impl<const N: usize> Clone for FixedAscii<N> {
     #[inline]
     fn clone(&self) -> Self {
         unsafe {
-            let mut buf = mem::MaybeUninit::<A>::uninit();
-            ptr::copy_nonoverlapping(self.buf.as_ptr(), buf.as_mut_ptr() as *mut _, A::capacity());
+            let mut buf: mem::MaybeUninit<[u8; N]> = mem::MaybeUninit::uninit();
+            ptr::copy_nonoverlapping(self.buf.as_ptr(), buf.as_mut_ptr() as *mut _, N);
             FixedAscii { buf: buf.assume_init() }
         }
     }
 }
 
-impl<A: Array<Item = u8>> FixedAscii<A> {
+impl<const N: usize> FixedAscii<N> {
     #[inline]
     pub fn new() -> Self {
         unsafe { FixedAscii { buf: mem::zeroed() } }
@@ -400,20 +398,20 @@ impl<A: Array<Item = u8>> FixedAscii<A> {
 
     #[inline]
     unsafe fn from_bytes(bytes: &[u8]) -> Self {
-        let len = if bytes.len() < A::capacity() { bytes.len() } else { A::capacity() };
-        let mut buf: A = mem::zeroed();
+        let len = if bytes.len() < N { bytes.len() } else { N };
+        let mut buf: [u8; N] = mem::zeroed();
         ptr::copy_nonoverlapping(bytes.as_ptr(), buf.as_mut_ptr() as *mut _, len);
         FixedAscii { buf }
     }
 
     #[inline]
     fn as_raw_slice(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.buf.as_ptr(), A::capacity()) }
+        unsafe { slice::from_raw_parts(self.buf.as_ptr(), N) }
     }
 
     #[inline]
     pub fn capacity() -> usize {
-        A::capacity()
+        N
     }
 
     #[inline]
@@ -448,7 +446,7 @@ impl<A: Array<Item = u8>> FixedAscii<A> {
 
     pub fn from_ascii<B: ?Sized + AsRef<[u8]>>(bytes: &B) -> Result<Self, StringError> {
         let bytes = bytes.as_ref();
-        if bytes.len() > A::capacity() {
+        if bytes.len() > N {
             return Err(StringError::InsufficientCapacity);
         }
         let s = AsciiStr::from_ascii(bytes)?;
@@ -456,7 +454,7 @@ impl<A: Array<Item = u8>> FixedAscii<A> {
     }
 }
 
-impl<A: Array<Item = u8>> AsAsciiStr for FixedAscii<A> {
+impl<const N: usize> AsAsciiStr for FixedAscii<N> {
     type Inner = u8;
 
     #[inline]
@@ -482,22 +480,22 @@ impl<A: Array<Item = u8>> AsAsciiStr for FixedAscii<A> {
 
 #[repr(C)]
 #[derive(Copy)]
-pub struct FixedUnicode<A: Array<Item = u8>> {
-    buf: A,
+pub struct FixedUnicode<const N: usize> {
+    buf: [u8; N],
 }
 
-impl<A: Array<Item = u8>> Clone for FixedUnicode<A> {
+impl<const N: usize> Clone for FixedUnicode<N> {
     #[inline]
     fn clone(&self) -> Self {
         unsafe {
-            let mut buf = mem::MaybeUninit::<A>::uninit();
-            ptr::copy_nonoverlapping(self.buf.as_ptr(), buf.as_mut_ptr() as *mut _, A::capacity());
+            let mut buf: mem::MaybeUninit<[u8; N]> = mem::MaybeUninit::uninit();
+            ptr::copy_nonoverlapping(self.buf.as_ptr(), buf.as_mut_ptr() as *mut _, N);
             FixedUnicode { buf: buf.assume_init() }
         }
     }
 }
 
-impl<A: Array<Item = u8>> FixedUnicode<A> {
+impl<const N: usize> FixedUnicode<N> {
     #[inline]
     pub fn new() -> Self {
         unsafe { FixedUnicode { buf: mem::zeroed() } }
@@ -505,15 +503,15 @@ impl<A: Array<Item = u8>> FixedUnicode<A> {
 
     #[inline]
     unsafe fn from_bytes(bytes: &[u8]) -> Self {
-        let len = if bytes.len() < A::capacity() { bytes.len() } else { A::capacity() };
-        let mut buf: A = mem::zeroed();
+        let len = if bytes.len() < N { bytes.len() } else { N };
+        let mut buf: [u8; N] = mem::zeroed();
         ptr::copy_nonoverlapping(bytes.as_ptr(), buf.as_mut_ptr() as *mut _, len);
         FixedUnicode { buf }
     }
 
     #[inline]
     fn as_raw_slice(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.buf.as_ptr(), A::capacity()) }
+        unsafe { slice::from_raw_parts(self.buf.as_ptr(), N) }
     }
 
     #[inline]
@@ -523,7 +521,7 @@ impl<A: Array<Item = u8>> FixedUnicode<A> {
 
     #[inline]
     pub fn capacity() -> usize {
-        A::capacity()
+        N
     }
 
     #[inline]
@@ -557,14 +555,11 @@ impl<A: Array<Item = u8>> FixedUnicode<A> {
     }
 }
 
-impl<A> FromStr for FixedUnicode<A>
-where
-    A: Array<Item = u8>,
-{
+impl<const N: usize> FromStr for FixedUnicode<N> {
     type Err = StringError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
-        if s.as_bytes().len() <= A::capacity() {
+        if s.as_bytes().len() <= N {
             unsafe { Ok(Self::from_bytes(s.as_bytes())) }
         } else {
             Err(StringError::InsufficientCapacity)
@@ -588,8 +583,8 @@ pub mod tests {
 
     type VA = VarLenAscii;
     type VU = VarLenUnicode;
-    type FA = FixedAscii<[u8; 1024]>;
-    type FU = FixedUnicode<[u8; 1024]>;
+    type FA = FixedAscii<1024>;
+    type FU = FixedUnicode<1024>;
 
     #[derive(Clone, Debug)]
     pub struct AsciiGen(pub Vec<u8>);
@@ -650,8 +645,8 @@ pub mod tests {
 
     #[test]
     pub fn test_capacity() {
-        type A = FixedAscii<[u8; 2]>;
-        type U = FixedUnicode<[u8; 2]>;
+        type A = FixedAscii<2>;
+        type U = FixedUnicode<2>;
         assert_eq!(A::from_ascii("ab").unwrap().as_str(), "ab");
         assert!(A::from_ascii("abc").is_err());
         assert_eq!(U::from_str("ab").unwrap().as_str(), "ab");
@@ -670,8 +665,8 @@ pub mod tests {
 
     #[test]
     pub fn test_null_padding() {
-        type A = FixedAscii<[u8; 3]>;
-        type U = FixedUnicode<[u8; 3]>;
+        type A = FixedAscii<3>;
+        type U = FixedUnicode<3>;
         assert_eq!(A::from_ascii("a\0b").unwrap().as_str(), "a\0b");
         assert_eq!(A::from_ascii("a\0\0").unwrap().as_str(), "a");
         assert!(A::from_ascii("\0\0\0").unwrap().is_empty());

--- a/tests/common/gen.rs
+++ b/tests/common/gen.rs
@@ -4,7 +4,6 @@ use std::iter;
 
 use hdf5::types::{FixedAscii, FixedUnicode, VarLenArray, VarLenAscii, VarLenUnicode};
 use hdf5::H5Type;
-use hdf5_types::Array;
 
 use ndarray::{ArrayD, SliceInfo, SliceInfoElem};
 use rand::distributions::{Alphanumeric, Uniform};
@@ -109,9 +108,9 @@ where
     ArrayD::from_shape_vec(shape, vec).unwrap()
 }
 
-impl<A: Array<Item = u8>> Gen for FixedAscii<A> {
+impl<const N: usize> Gen for FixedAscii<N> {
     fn gen<R: Rng + ?Sized>(rng: &mut R) -> Self {
-        let len = rng.sample(Uniform::new_inclusive(0, A::capacity()));
+        let len = rng.sample(Uniform::new_inclusive(0, N));
         let dist = Uniform::new_inclusive(0, 127);
         let mut v = Vec::with_capacity(len);
         for _ in 0..len {
@@ -121,9 +120,9 @@ impl<A: Array<Item = u8>> Gen for FixedAscii<A> {
     }
 }
 
-impl<A: Array<Item = u8>> Gen for FixedUnicode<A> {
+impl<const N: usize> Gen for FixedUnicode<N> {
     fn gen<R: Rng + ?Sized>(rng: &mut R) -> Self {
-        let len = rng.sample(Uniform::new_inclusive(0, A::capacity()));
+        let len = rng.sample(Uniform::new_inclusive(0, N));
         let mut s = String::new();
         for _ in 0..len {
             let c = rng.gen::<char>();
@@ -201,8 +200,8 @@ impl Gen for TupleStruct {
 #[derive(H5Type, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct FixedStruct {
-    fa: FixedAscii<[u8; 3]>,
-    fu: FixedUnicode<[u8; 11]>,
+    fa: FixedAscii<3>,
+    fu: FixedUnicode<11>,
     tuple: (i8, u64, f32),
     array: [TupleStruct; 2],
 }

--- a/tests/test_datatypes.rs
+++ b/tests/test_datatypes.rs
@@ -31,8 +31,8 @@ pub fn test_datatype_roundtrip() {
     check_roundtrip!(bool, TD::Boolean);
     check_roundtrip!([bool; 5], TD::FixedArray(Box::new(TD::Boolean), 5));
     check_roundtrip!(VarLenArray<bool>, TD::VarLenArray(Box::new(TD::Boolean)));
-    check_roundtrip!(FixedAscii<[_; 5]>, TD::FixedAscii(5));
-    check_roundtrip!(FixedUnicode<[_; 5]>, TD::FixedUnicode(5));
+    check_roundtrip!(FixedAscii<5>, TD::FixedAscii(5));
+    check_roundtrip!(FixedUnicode<5>, TD::FixedUnicode(5));
     check_roundtrip!(VarLenAscii, TD::VarLenAscii);
     check_roundtrip!(VarLenUnicode, TD::VarLenUnicode);
 

--- a/tests/test_plist.rs
+++ b/tests/test_plist.rs
@@ -728,8 +728,8 @@ fn test_dcpl_fill_value() -> hdf5::Result<()> {
     #[derive(H5Type, Clone, Debug, PartialEq, Eq)]
     #[repr(C)]
     struct Data {
-        a: FixedAscii<[u8; 5]>,
-        b: FixedUnicode<[u8; 5]>,
+        a: FixedAscii<5>,
+        b: FixedUnicode<5>,
         c: [i16; 2],
         d: VarLenAscii,
         e: VarLenUnicode,


### PR DESCRIPTION
This removes a layer of indirection and drops the `u8` type from the string types. Introduces breaking changes, and would be nice to include in the next version.

Fixes #143