### PR TITLE
Update hdf5-src to use 1.10.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with: {submodules: true}
-      - name: Change to older toolchain
-        if: matrix.os == 'macos'
-        run: sudo xcode-select -s "/Applications/Xcode_11.7.app"
       - name: Install Rust (${{matrix.rust}})
         uses: actions-rs/toolchain@v1
         with: {toolchain: '${{matrix.rust}}', profile: minimal, override: true}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@
 - Added support for attributes. The Attribute API uses the new Dataset API. Attributes
   only supports the same operations as `hdf5` (e.g. one can not perform partial IO,
   but must read the entire attribute at once).
- 
 - Added support in `hdf5-sys` for the new functions in `hdf5` `1.10.6` and `1.10.7`.
   
  ### Changed
@@ -70,6 +69,7 @@
 - `hdf5_types::Array` trait has been removed and replaced with const generics. String types
   are now generic over size only: `FixedAscii<N>` and `FixedUnicode<N>`.
 - The version of `hdf5` built in `hdf5-src` has been updated from `1.10.6` to `1.10.7`.
+- The `zlib` dependency is no longer included with `default-features`.
 
 ## 0.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
   only supports the same operations as `hdf5` (e.g. one can not perform partial IO,
   but must read the entire attribute at once).
  
+- Added support in `hdf5-sys` for the new functions in `hdf5` `1.10.6` and `1.10.7`.
+  
  ### Changed
 
 - Required Rust compiler version is now `1.51`.
@@ -67,6 +69,7 @@
 - The `ndarray` dependency has been updated to `0.15`.
 - `hdf5_types::Array` trait has been removed and replaced with const generics. String types
   are now generic over size only: `FixedAscii<N>` and `FixedUnicode<N>`.
+- The version of `hdf5` built in `hdf5-src` has been updated from `1.10.6` to `1.10.7`.
 
 ## 0.7.1
 

--- a/hdf5-src/Cargo.toml
+++ b/hdf5-src/Cargo.toml
@@ -32,7 +32,7 @@ deprecated = []
 threadsafe = []
 
 [dependencies]
-libz-sys = { version = "1.0.25", features = ["static"], optional = true }
+libz-sys = { version = "1.0.25", features = ["static"], optional = true, default-features=false }
 
 [build-dependencies]
 cmake = "0.1.44"

--- a/hdf5-src/build.rs
+++ b/hdf5-src/build.rs
@@ -18,6 +18,7 @@ fn main() {
         "HDF5_BUILD_JAVA",
         "HDF5_BUILD_FORTRAN",
         "HDF5_BUILD_CPP_LIB",
+        "HDF5_BUILD_UTILS",
         "HDF5_ENABLE_PARALLEL",
     ] {
         cfg.define(option, "OFF");

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 libc = "0.2"
 mpi-sys = { version = "0.1", optional = true }
-libz-sys = { version = "1.0.25", optional = true }
+libz-sys = { version = "1.0.25", optional = true, default-features = false }
 hdf5-src = { path = "../hdf5-src", version = "0.7.1", optional = true }  # !V
 
 # Please see README for further explanation of these feature flags

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -35,10 +35,7 @@ impl Version {
     }
 
     pub fn is_valid(self) -> bool {
-        self.major == 1
-            && ((self.minor == 8 && self.micro >= 4)
-                || (self.minor == 10)
-                || (self.minor == 12 && self.micro == 0))
+        self >= Version { major: 1, minor: 8, micro: 4 }
     }
 }
 
@@ -612,7 +609,7 @@ impl Config {
         let version = self.header.version;
         assert!(version >= Version::new(1, 8, 4), "required HDF5 version: >=1.8.4");
         let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-21]
-        vs.extend((0..=5).map(|v| Version::new(1, 10, v))); // 1.10.[0-5]
+        vs.extend((0..=6).map(|v| Version::new(1, 10, v))); // 1.10.[0-6]
         vs.push(Version::new(1, 12, 0)); // 1.12.0
         for v in vs.into_iter().filter(|&v| version >= v) {
             println!("cargo:rustc-cfg=hdf5_{}_{}_{}", v.major, v.minor, v.micro);

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -609,7 +609,7 @@ impl Config {
         let version = self.header.version;
         assert!(version >= Version::new(1, 8, 4), "required HDF5 version: >=1.8.4");
         let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-21]
-        vs.extend((0..=6).map(|v| Version::new(1, 10, v))); // 1.10.[0-6]
+        vs.extend((0..=7).map(|v| Version::new(1, 10, v))); // 1.10.[0-7]
         vs.push(Version::new(1, 12, 0)); // 1.12.0
         for v in vs.into_iter().filter(|&v| version >= v) {
             println!("cargo:rustc-cfg=hdf5_{}_{}_{}", v.major, v.minor, v.micro);

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -85,3 +85,23 @@ extern "C" {
 extern "C" {
     pub fn H5is_library_threadsafe(is_ts: *mut hbool_t) -> herr_t;
 }
+
+#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+#[repr(C)]
+pub struct H5_alloc_stats_t {
+    total_alloc_bytes: c_ulonglong,
+    curr_alloc_bytes: size_t,
+    peak_alloc_bytes: size_t,
+    max_block_size: size_t,
+    total_alloc_blocks_count: size_t,
+    curr_alloc_blocks_count: size_t,
+    peak_alloc_blocks_count: size_t,
+}
+
+#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+extern "C" {
+    pub fn H5get_alloc_stats(stats: *mut H5_alloc_stats_t) -> herr_t;
+    pub fn H5get_free_list_sizes(
+        reg_size: *mut size_t, arr_size: *mut size_t, blk_size: *mut size_t, fac_size: *mut size_t,
+    ) -> herr_t;
+}

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -416,6 +416,36 @@ pub mod ros3 {
     }
 }
 
+#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+pub mod splitter {
+    use super::*;
+
+    pub const H5FD_CURR_SPLITTER_VFD_CONFIG_VERSION: c_uint = 1;
+    pub const H5FD_SPLITTER_PATH_MAX: c_uint = 4096;
+    pub const H5FD_SPLITTER_MAGIC: c_uint = 0x2B916880;
+
+    #[repr(C)]
+    pub struct H5FD_splitter_vfg_config_t {
+        magic: i32,
+        version: c_uint,
+        rw_fapl_id: hid_t,
+        wo_fapl_id: hid_t,
+        wo_path: [c_char; H5FD_SPLITTER_PATH_MAX as usize + 1],
+        log_file_path: [c_char; H5FD_SPLITTER_PATH_MAX as usize + 1],
+        ignore_wo_errs: hbool_t,
+    }
+
+    extern "C" {
+        pub fn H5FD_splitter_init() -> hid_t;
+        pub fn H5Pget_fapl_splitter(
+            fapl_id: hid_t, config_ptr: *mut H5FD_splitter_vfg_config_t,
+        ) -> herr_t;
+        pub fn H5Pset_fapl_splitter(
+            fapl_id: hid_t, config_ptr: *mut H5FD_splitter_vfg_config_t,
+        ) -> herr_t;
+    }
+}
+
 #[cfg(hdf5_1_10_2)]
 extern "C" {
     pub fn H5FDdriver_query(driver_id: hid_t, flags: *mut c_ulong) -> herr_t;

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -367,6 +367,55 @@ extern "C" {
     pub fn H5FDunlock(file: *mut H5FD_t) -> herr_t;
 }
 
+#[cfg(hdf5_1_10_6)]
+pub mod hdfs {
+    use super::*;
+    pub const H5FD__CURR_HDFS_FAPL_T_VERSION: c_uint = 1;
+    pub const H5FD__HDFS_NODE_NAME_SPACE: c_uint = 128;
+    pub const H5FD__HDFS_USER_NAME_SPACE: c_uint = 128;
+    pub const H5FD__HDFS_KERB_CACHE_PATH_SPACE: c_uint = 128;
+
+    #[repr(C)]
+    pub struct H5FD_hdfs_fapl_t {
+        version: i32,
+        namenode_name: [c_char; H5FD__HDFS_NODE_NAME_SPACE as usize + 1],
+        namenode_port: i32,
+        user_name: [c_char; H5FD__HDFS_USER_NAME_SPACE as usize + 1],
+        kerberos_ticket_cache: [c_char; H5FD__HDFS_KERB_CACHE_PATH_SPACE as usize + 1],
+        stream_buffer_size: i32,
+    }
+
+    extern "C" {
+        pub fn H5FD_hdfs_init() -> hid_t;
+        pub fn H5Pget_fapl_hdfs(fapl_id: hid_t, fa: *mut H5FD_hdfs_fapl_t) -> herr_t;
+        pub fn H5Pset_fapl_hdfs(fapl_id: hid_t, fa: *mut H5FD_hdfs_fapl_t) -> herr_t;
+    }
+}
+
+#[cfg(hdf5_1_10_6)]
+pub mod ros3 {
+    use super::*;
+    pub const H5FD_CURR_ROS3_FAPL_T_VERSION: c_uint = 1;
+    pub const H5FD_ROS3_MAX_REGION_LEN: c_uint = 128;
+    pub const H5FD_ROS3_MAX_SECRET_ID_LEN: c_uint = 128;
+    pub const H5FD_ROS3_MAX_SECRET_KEY_LEN: c_uint = 128;
+
+    #[repr(C)]
+    pub struct H5FD_ros3_fapl_t {
+        version: i32,
+        authenticate: hbool_t,
+        aws_region: [c_char; H5FD_ROS3_MAX_REGION_LEN as usize + 1],
+        secret_id: [c_char; H5FD_ROS3_MAX_SECRET_ID_LEN as usize + 1],
+        secret_key: [c_char; H5FD_ROS3_MAX_SECRET_KEY_LEN as usize + 1],
+    }
+
+    extern "C" {
+        pub fn H5FD_ros3_init() -> hid_t;
+        pub fn H5Pget_fapl_ros3(fapl_id: hid_t, fa: *mut H5FD_ros3_fapl_t) -> herr_t;
+        pub fn H5Pset_fapl_ros3(fapl_id: hid_t, fa: *mut H5FD_ros3_fapl_t) -> herr_t;
+    }
+}
+
 #[cfg(hdf5_1_10_2)]
 extern "C" {
     pub fn H5FDdriver_query(driver_id: hid_t, flags: *mut c_ulong) -> herr_t;

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -764,6 +764,17 @@ extern "C" {
     pub fn H5Pset_dset_no_attrs_hint(dcpl_id: hid_t, minimize: hbool_t) -> herr_t;
 }
 
+#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+extern "C" {
+    pub fn H5Pget_file_locking(
+        fapl_id: hid_t, use_file_locking: *mut hbool_t, ignore_when_disable: *mut hbool_t,
+    ) -> herr_t;
+    pub fn H5Pset_file_locking(
+        fapl_id: hid_t, use_file_locking: hbool_t, ignore_when_disable: hbool_t,
+    ) -> herr_t;
+
+}
+
 #[cfg(hdf5_1_12_0)]
 extern "C" {
     pub fn H5Pget_vol_id(plist_id: hid_t, vol_id: *mut hid_t) -> herr_t;

--- a/hdf5-sys/src/h5s.rs
+++ b/hdf5-sys/src/h5s.rs
@@ -112,7 +112,7 @@ extern "C" {
     ) -> htri_t;
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(any(hdf5_1_12_0, hdf5_1_10_7))]
 extern "C" {
     pub fn H5Scombine_hyperslab(
         space_id: hid_t, op: H5S_seloper_t, start: *const hsize_t, stride: *const hsize_t,
@@ -120,12 +120,6 @@ extern "C" {
     ) -> hid_t;
     pub fn H5Scombine_select(space1_id: hid_t, op: H5S_seloper_t, space2_id: hid_t) -> hid_t;
     pub fn H5Smodify_select(space1_id: hid_t, op: H5S_seloper_t, space2_id: hid_t) -> herr_t;
-    pub fn H5Ssel_iter_close(sel_iter_id: hid_t) -> herr_t;
-    pub fn H5Ssel_iter_create(space_id: hid_t, elmt_size: size_t, flags: c_uint) -> hid_t;
-    pub fn H5Ssel_iter_get_seq_list(
-        sel_iter_id: hid_t, maxseq: size_t, maxbytes: size_t, nseq: *mut size_t,
-        nbytes: *mut size_t, off: *mut hsize_t, len: *mut size_t,
-    ) -> herr_t;
     pub fn H5Sselect_adjust(space_id: hid_t, offset: *const hssize_t) -> herr_t;
     pub fn H5Sselect_copy(dst_id: hid_t, src_id: hid_t) -> herr_t;
     pub fn H5Sselect_intersect_block(
@@ -135,4 +129,14 @@ extern "C" {
         src_space_id: hid_t, dst_space_id: hid_t, src_intersect_space_id: hid_t,
     ) -> hid_t;
     pub fn H5Sselect_shape_same(space1_id: hid_t, space2_id: hid_t) -> htri_t;
+}
+
+#[cfg(hdf5_1_12_0)]
+extern "C" {
+    pub fn H5Ssel_iter_close(sel_iter_id: hid_t) -> herr_t;
+    pub fn H5Ssel_iter_create(space_id: hid_t, elmt_size: size_t, flags: c_uint) -> hid_t;
+    pub fn H5Ssel_iter_get_seq_list(
+        sel_iter_id: hid_t, maxseq: size_t, maxbytes: size_t, nseq: *mut size_t,
+        nbytes: *mut size_t, off: *mut hsize_t, len: *mut size_t,
+    ) -> herr_t;
 }


### PR DESCRIPTION
This version is mostly a maintaince release, but introduces some new functions for allocation information which might be of use.

Fixes #153 