### PR TITLE
Export SilenceErrors type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod export {
     pub use crate::{
         class::from_id,
         dim::{Dimension, Ix},
-        error::{silence_errors, Error, Result},
+        error::{silence_errors, Error, Result, SilenceErrors},
         hl::extents::{Extent, Extents, SimpleExtents},
         hl::selection::{Hyperslab, Selection, SliceOrIndex},
         hl::{


### PR DESCRIPTION
This allows storing it in places where we need a type annotation.