### PR TITLE
Prevent hdf5 calling atexit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
   are now generic over size only: `FixedAscii<N>` and `FixedUnicode<N>`.
 - The version of `hdf5` built in `hdf5-src` has been updated from `1.10.6` to `1.10.7`.
 - The `zlib` dependency is no longer included with `default-features`.
+- `hdf5` no longer calls `H5close` automatically on program exit.
 
 ## 0.7.1
 

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -19,6 +19,8 @@ use crate::internal_prelude::*;
 lazy_static! {
     static ref LIBRARY_INIT: () = {
         h5lock!({
+            // Ensure hdf5 does not invalidate handles which might
+            // still be live on other threads on program exit
             ::hdf5_sys::h5::H5dont_atexit();
             ::hdf5_sys::h5::H5open();
         });

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -18,7 +18,10 @@ use crate::internal_prelude::*;
 
 lazy_static! {
     static ref LIBRARY_INIT: () = {
-        h5lock!(::hdf5_sys::h5::H5open());
+        h5lock!({
+            ::hdf5_sys::h5::H5dont_atexit();
+            ::hdf5_sys::h5::H5open();
+        });
         let _e = crate::hl::filters::register_filters();
     };
 }

--- a/src/hl/plist/dataset_create.rs
+++ b/src/hl/plist/dataset_create.rs
@@ -729,7 +729,7 @@ impl DatasetCreate {
                 h5try!(H5Pget_fill_value(self.id(), dtype.id(), buf.as_mut_ptr().cast()));
                 Ok(Some(unsafe { OwnedDynValue::from_raw(tp.clone(), buf) }))
             }
-            _ => Ok(None),
+            FillValue::Undefined => Ok(None),
         }
     }
 

--- a/src/hl/plist/file_create.rs
+++ b/src/hl/plist/file_create.rs
@@ -413,7 +413,9 @@ impl FileCreateBuilder {
                     FileSpaceStrategy::PageAggregation => {
                         (H5F_fspace_strategy_t::H5F_FSPACE_STRATEGY_AGGR, 0, 0)
                     }
-                    _ => (H5F_fspace_strategy_t::H5F_FSPACE_STRATEGY_NONE, 0, 0),
+                    FileSpaceStrategy::None => {
+                        (H5F_fspace_strategy_t::H5F_FSPACE_STRATEGY_NONE, 0, 0)
+                    }
                 };
                 h5try!(H5Pset_file_space_strategy(id, strategy, persist, threshold));
             }

--- a/src/hl/selection.rs
+++ b/src/hl/selection.rs
@@ -448,7 +448,7 @@ where
     Dout: ndarray::Dimension,
 {
     fn from(slice: ndarray::SliceInfo<T, Din, Dout>) -> Self {
-        slice.deref().as_ref().iter().cloned().map(Into::into).collect::<Vec<_>>().into()
+        slice.deref().as_ref().iter().copied().map(Into::into).collect::<Vec<_>>().into()
     }
 }
 


### PR DESCRIPTION
`hdf5` calling `atexit` could create double free situations, where an orphaned thread would try to access a handle after it's been freed by the main thread.

The functioncality disabled by this involves [flushing data, closing objects, and cleaning up memory used](https://portal.hdfgroup.org/display/HDF5/H5_CLOSE). This is provided by `Drop` by rust, and pure rust programs will not be affected by this change.

In multi-language applications, care must be taken that all handles are closed by the programmer before program exit.

Fixes #159 