### PR TITLE
Leave the error stack unexpanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
 - The version of `hdf5` built in `hdf5-src` has been updated from `1.10.6` to `1.10.7`.
 - The `zlib` dependency is no longer included with `default-features`.
 - `hdf5` no longer calls `H5close` automatically on program exit.
+- Errors are now silenced, and will not be written to `stdout`
+- Errors are not expanded when encountered, but only when being used for printing or by
+  the library user.
 
 ## 0.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@
 - The version of `hdf5` built in `hdf5-src` has been updated from `1.10.6` to `1.10.7`.
 - The `zlib` dependency is no longer included with `default-features`.
 - `hdf5` no longer calls `H5close` automatically on program exit.
-- Errors are now silenced, and will not be written to `stdout`
+- Errors are now silenced, and will not be written to `stderr` by default.
+- `silence_errors` now work globally and will not be reset on dropping `SilenceErrors`.
 - Errors are not expanded when encountered, but only when being used for printing or by
   the library user.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ fn main() -> hdf5::Result<()> {
     use self::Color::*;
     use ndarray::{arr1, arr2};
 
-    // so that libhdf5 doesn't print errors to stdout
-    let _e = hdf5::silence_errors();
-
     {
         // write
         let file = hdf5::File::create("pixels.h5")?;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,9 +17,6 @@ fn main() -> hdf5::Result<()> {
     use self::Color::*;
     use ndarray::{arr1, arr2};
 
-    // so that libhdf5 doesn't print errors to stdout
-    let _e = hdf5::silence_errors();
-
     {
         // write
         let file = hdf5::File::create("pixels.h5")?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ impl ErrorStack {
         Handle::try_new(stack_id).map(Self)
     }
 
-    pub(crate) fn expand(self) -> Result<ExpandedErrorStack> {
+    pub fn expand(self) -> Result<ExpandedErrorStack> {
         struct CallbackData {
             stack: ExpandedErrorStack,
             err: Option<Error>,
@@ -95,7 +95,7 @@ pub struct ErrorFrame {
 }
 
 impl ErrorFrame {
-    pub fn new(desc: &str, func: &str, major: &str, minor: &str) -> Self {
+    pub(crate) fn new(desc: &str, func: &str, major: &str, minor: &str) -> Self {
         Self {
             desc: desc.into(),
             func: func.into(),
@@ -139,7 +139,7 @@ impl Default for ExpandedErrorStack {
 }
 
 impl ExpandedErrorStack {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self { frames: Vec::new(), description: None }
     }
 
@@ -147,7 +147,7 @@ impl ExpandedErrorStack {
         self.frames.len()
     }
 
-    pub fn push(&mut self, frame: ErrorFrame) {
+    pub(crate) fn push(&mut self, frame: ErrorFrame) {
         self.frames.push(frame);
         if !self.is_empty() {
             let top_desc = self.frames[0].description().to_owned();

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ impl ErrorStack {
         Handle::try_new(stack_id).map(Self)
     }
 
+    /// Expands the error stack to a format which is easier to handle
+    // known HDF5 bug: H5Eget_msg() used in this function may corrupt
+    // the current stack, so we use self over &self
     pub fn expand(self) -> Result<ExpandedErrorStack> {
         struct CallbackData {
             stack: ExpandedErrorStack,

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,11 +80,7 @@ impl ErrorStack {
             H5Ewalk2(stack_id, H5E_WALK_DOWNWARD, Some(callback), data_ptr);
         });
 
-        if let Some(err) = data.err {
-            Err(err)
-        } else {
-            Ok(data.stack)
-        }
+        data.err.map_or(Ok(data.stack), Err)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::error::Error as StdError;
 use std::fmt;
-use std::ops::Index;
+use std::ops::Deref;
 use std::panic;
 use std::ptr;
 
@@ -123,11 +123,11 @@ pub struct ExpandedErrorStack {
     description: Option<String>,
 }
 
-impl Index<usize> for ExpandedErrorStack {
-    type Output = ErrorFrame;
+impl Deref for ExpandedErrorStack {
+    type Target = [ErrorFrame];
 
-    fn index(&self, index: usize) -> &ErrorFrame {
-        &self.frames[index]
+    fn deref(&self) -> &Self::Target {
+        &self.frames
     }
 }
 
@@ -140,10 +140,6 @@ impl Default for ExpandedErrorStack {
 impl ExpandedErrorStack {
     pub(crate) fn new() -> Self {
         Self { frames: Vec::new(), description: None }
-    }
-
-    pub fn len(&self) -> usize {
-        self.frames.len()
     }
 
     pub(crate) fn push(&mut self, frame: ErrorFrame) {
@@ -159,16 +155,8 @@ impl ExpandedErrorStack {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.frames.is_empty()
-    }
-
     pub fn top(&self) -> Option<&ErrorFrame> {
-        if self.is_empty() {
-            None
-        } else {
-            Some(&self.frames[0])
-        }
+        self.get(0)
     }
 
     pub fn description(&self) -> &str {

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -23,7 +23,7 @@ lazy_static! {
             // still be live on other threads on program exit
             ::hdf5_sys::h5::H5dont_atexit();
             ::hdf5_sys::h5::H5open();
-            ::hdf5_sys::h5e::H5Eset_auto2(::hdf5_sys::h5e::H5E_DEFAULT, None, core::ptr::null_mut());
+            crate::error::silence_errors(true);
         });
         let _e = crate::hl::filters::register_filters();
     };

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -23,6 +23,7 @@ lazy_static! {
             // still be live on other threads on program exit
             ::hdf5_sys::h5::H5dont_atexit();
             ::hdf5_sys::h5::H5open();
+            ::hdf5_sys::h5e::H5Eset_auto2(::hdf5_sys::h5e::H5E_DEFAULT, None, core::ptr::null_mut());
         });
         let _e = crate::hl::filters::register_filters();
     };

--- a/src/hl/dataspace.rs
+++ b/src/hl/dataspace.rs
@@ -208,7 +208,6 @@ mod tests {
 
     #[test]
     fn test_dataspace_err() {
-        let _e = silence_errors();
         assert_err!(Dataspace::from_id(H5I_INVALID_HID), "Invalid dataspace id");
     }
 

--- a/src/hl/datatype.rs
+++ b/src/hl/datatype.rs
@@ -171,7 +171,6 @@ impl Datatype {
         let dst = dst.borrow();
         let mut cdata = H5T_cdata_t::default();
         h5lock!({
-            let _e = silence_errors();
             let noop = H5Tfind(*H5T_NATIVE_INT, *H5T_NATIVE_INT, &mut (&mut cdata as *mut _));
             if H5Tfind(self.id(), dst.id(), &mut (&mut cdata as *mut _)) == noop {
                 Some(Conversion::NoOp)

--- a/src/hl/plist.rs
+++ b/src/hl/plist.rs
@@ -201,7 +201,7 @@ impl PropertyList {
             let class_id = h5check(H5Pget_class(self.id()))?;
             let buf = H5Pget_class_name(class_id);
             if buf.is_null() {
-                return Err(Error::query().unwrap_or_else(|| "invalid property class".into()));
+                return Err(Error::query().unwrap_or_else(|_| "invalid property class".into()));
             }
             let name = string_from_cstr(buf);
             h5_free_memory(buf.cast());

--- a/src/hl/plist/dataset_access.rs
+++ b/src/hl/plist/dataset_access.rs
@@ -53,7 +53,6 @@ impl ObjectClass for DatasetAccess {
 
 impl Debug for DatasetAccess {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _e = silence_errors();
         let mut formatter = f.debug_struct("DatasetAccess");
         formatter.field("chunk_cache", &self.chunk_cache());
         #[cfg(hdf5_1_8_17)]

--- a/src/hl/plist/dataset_create.rs
+++ b/src/hl/plist/dataset_create.rs
@@ -66,7 +66,6 @@ impl ObjectClass for DatasetCreate {
 
 impl Debug for DatasetCreate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _e = silence_errors();
         let mut formatter = f.debug_struct("DatasetCreate");
         formatter.field("filters", &self.filters());
         formatter.field("alloc_time", &self.alloc_time());

--- a/src/hl/plist/file_access.rs
+++ b/src/hl/plist/file_access.rs
@@ -109,7 +109,6 @@ impl ObjectClass for FileAccess {
 
 impl Debug for FileAccess {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _e = silence_errors();
         let mut formatter = f.debug_struct("FileAccess");
         formatter.field("alignment", &self.alignment());
         formatter.field("chunk_cache", &self.chunk_cache());

--- a/src/hl/plist/file_create.rs
+++ b/src/hl/plist/file_create.rs
@@ -57,7 +57,6 @@ impl ObjectClass for FileCreate {
 
 impl Debug for FileCreate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _e = silence_errors();
         let mut formatter = f.debug_struct("FileCreate");
         formatter.field("userblock", &self.userblock());
         formatter.field("sizes", &self.sizes());

--- a/src/hl/plist/link_create.rs
+++ b/src/hl/plist/link_create.rs
@@ -39,7 +39,6 @@ impl ObjectClass for LinkCreate {
 
 impl Debug for LinkCreate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _e = silence_errors();
         let mut formatter = f.debug_struct("LinkCreate");
         formatter.field("create_intermediate_group", &self.create_intermediate_group());
         formatter.field("char_encoding", &self.char_encoding());

--- a/src/hl/selection.rs
+++ b/src/hl/selection.rs
@@ -1423,8 +1423,6 @@ mod test {
             })
         }
 
-        let _e = silence_errors();
-
         check(&[1, 2], RawSelection::None, None)?;
         check(&[1, 2], RawSelection::All, None)?;
         check(&[1, 2], RawSelection::Points(arr2(&[[0, 1], [0, 0]])), None)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod export {
     pub use crate::{
         class::from_id,
         dim::{Dimension, Ix},
-        error::{Error, Result},
+        error::{Error, ErrorFrame, ErrorStack, ExpandedErrorStack, Result},
         hl::extents::{Extent, Extents, SimpleExtents},
         hl::selection::{Hyperslab, Selection, SliceOrIndex},
         hl::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod export {
     pub use crate::{
         class::from_id,
         dim::{Dimension, Ix},
-        error::{Error, ErrorFrame, ErrorStack, ExpandedErrorStack, Result},
+        error::{silence_errors, Error, ErrorFrame, ErrorStack, ExpandedErrorStack, Result},
         hl::extents::{Extent, Extents, SimpleExtents},
         hl::selection::{Hyperslab, Selection, SliceOrIndex},
         hl::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod export {
     pub use crate::{
         class::from_id,
         dim::{Dimension, Ix},
-        error::{silence_errors, Error, Result},
+        error::{Error, Result},
         hl::extents::{Extent, Extents, SimpleExtents},
         hl::selection::{Hyperslab, Selection, SliceOrIndex},
         hl::{
@@ -131,7 +131,7 @@ mod internal_prelude {
     pub use crate::{
         class::ObjectClass,
         dim::Dimension,
-        error::{h5check, silence_errors},
+        error::h5check,
         export::*,
         handle::{get_id_type, is_valid_user_id, Handle},
         hl::plist::PropertyListClass,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -44,7 +44,7 @@ macro_rules! assert_err {
                 panic!("assertion failed: not an error in `{}`", stringify!($expr));
             }
             Err(ref value) => {
-                let desc = value.description().to_string();
+                let desc = value.to_string();
                 if !desc.contains($err) {
                     panic!(
                         "assertion failed: error message `{}` doesn't contain `{}` in `{}`",
@@ -70,7 +70,7 @@ macro_rules! assert_err_re {
             Err(ref value) => {
                 use regex::Regex;
                 let re = Regex::new($err).unwrap();
-                let desc = value.description().to_string();
+                let desc = value.to_string();
                 if !re.is_match(desc.as_ref()) {
                     panic!(
                         "assertion failed: error message `{}` doesn't match `{}` in `{}`",

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,7 +7,6 @@ use crate::internal_prelude::*;
 pub fn with_tmp_dir<F: Fn(PathBuf)>(func: F) {
     let dir = tempdir().unwrap();
     let path = dir.path().to_path_buf();
-    let _e = silence_errors();
     func(path);
 }
 

--- a/tests/common/macros.rs
+++ b/tests/common/macros.rs
@@ -6,7 +6,7 @@ macro_rules! assert_err {
                 panic!("assertion failed: not an error in `{}`", stringify!($expr));
             }
             Err(ref value) => {
-                let desc = value.description().to_string();
+                let desc = value.to_string();
                 if !desc.contains($err) {
                     panic!(
                         "assertion failed: error message `{}` doesn't contain `{}` in `{}`",

--- a/tests/test_plist.rs
+++ b/tests/test_plist.rs
@@ -145,7 +145,6 @@ fn test_fcpl_attr_phase_change() -> hdf5::Result<()> {
     assert_eq!(pl.get_attr_phase_change()?, expected);
     assert_eq!(pl.attr_phase_change(), expected);
     assert_eq!(FCB::from_plist(&pl)?.finish()?.get_attr_phase_change()?, expected);
-    let _e = hdf5::silence_errors();
     assert!(FCB::new().attr_phase_change(12, 34).finish().is_err());
     Ok(())
 }
@@ -156,7 +155,6 @@ fn test_fcpl_attr_creation_order() -> hdf5::Result<()> {
     assert_eq!(FC::try_new()?.attr_creation_order().bits(), 0);
     test_pl!(FC, attr_creation_order: AttrCreationOrder::TRACKED);
     test_pl!(FC, attr_creation_order: AttrCreationOrder::TRACKED | AttrCreationOrder::INDEXED);
-    let _e = hdf5::silence_errors();
     assert!(FCB::new().attr_creation_order(AttrCreationOrder::INDEXED).finish().is_err());
     Ok(())
 }
@@ -715,8 +713,6 @@ fn test_dcpl_fill_value() -> hdf5::Result<()> {
     assert_eq!(DC::try_new()?.get_fill_value_as::<f64>()?, Some(0.0));
     assert_eq!(DC::try_new()?.fill_value_as::<bool>(), Some(false));
 
-    let _e = hdf5::silence_errors();
-
     let mut b = DCB::new();
     b.fill_value(1.23);
     let pl = b.finish()?;
@@ -768,7 +764,6 @@ fn test_dcpl_external() -> hdf5::Result<()> {
     assert_eq!(pl.get_external()?, expected);
     assert_eq!(pl.external(), expected);
     assert_eq!(DCB::from_plist(&pl)?.finish()?.get_external()?, expected);
-    let _e = hdf5::silence_errors();
     assert!(DCB::new().external("a", 1, 0).external("b", 1, 2).finish().is_err());
     Ok(())
 }
@@ -778,8 +773,6 @@ fn test_dcpl_external() -> hdf5::Result<()> {
 fn test_dcpl_virtual_map() -> hdf5::Result<()> {
     use hdf5::Hyperslab;
     use ndarray::s;
-
-    let _e = hdf5::silence_errors();
 
     let pl = DC::try_new()?;
     assert!(pl.get_virtual_map().is_err());
@@ -851,7 +844,6 @@ fn test_dcpl_attr_phase_change() -> hdf5::Result<()> {
     assert_eq!(pl.get_attr_phase_change()?, expected);
     assert_eq!(pl.attr_phase_change(), expected);
     assert_eq!(DCB::from_plist(&pl)?.finish()?.get_attr_phase_change()?, expected);
-    let _e = hdf5::silence_errors();
     assert!(DCB::new().attr_phase_change(12, 34).finish().is_err());
     Ok(())
 }
@@ -862,7 +854,6 @@ fn test_dcpl_attr_creation_order() -> hdf5::Result<()> {
     assert_eq!(DC::try_new()?.attr_creation_order().bits(), 0);
     test_pl!(DC, attr_creation_order: AttrCreationOrder::TRACKED);
     test_pl!(DC, attr_creation_order: AttrCreationOrder::TRACKED | AttrCreationOrder::INDEXED);
-    let _e = hdf5::silence_errors();
     assert!(DCB::new().attr_creation_order(AttrCreationOrder::INDEXED).finish().is_err());
     Ok(())
 }


### PR DESCRIPTION
This introduces a wrapper around the errorstack, which should make the error stack a bit easier to reason about. Errors are now silenced by default

Fixes #155
Closes #158