### PR TITLE
Missing build files for static build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with: {toolchain: '${{matrix.rust}}', profile: minimal, override: true}
       - name: Build and test all crates
-        run: cargo test --workspace -v --features hdf5-sys/static,hdf5-sys/zlib --exclude hdf5-derive
+        run: cargo test --workspace -v --features hdf5-sys/static,hdf5-sys/zlib,hdf5-src/hl --exclude hdf5-derive
 
   apt:
     name: apt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
         with: {toolchain: '${{matrix.rust}}', profile: minimal, override: true}
       - name: Build and test all crates
         run: cargo test --workspace -v --features hdf5-sys/static,hdf5-sys/zlib,hdf5-src/hl --exclude hdf5-derive
+      - name: Package hdf5-src (dry-run)
+        run: cd hdf5-src && cargo publish --all-features --dry-run
 
   apt:
     name: apt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@
 - Errors are not expanded when encountered, but only when being used for printing or by
   the library user.
 
+## Fixed
+- Some build files were missing from the packaged crate, which made building fail on `macos`-based platforms in certain cases.
+
 ## 0.7.1
 
 ### Added

--- a/hdf5-src/Cargo.toml
+++ b/hdf5-src/Cargo.toml
@@ -11,7 +11,6 @@ description = "Build script for compiling HDF5 C library from source."
 edition = "2018"
 links = "hdf5src"
 exclude = [
-    "ext/hdf5/bin/**",
     "ext/hdf5/c++/**",
     "ext/hdf5/examples/**",
     "ext/hdf5/fortran/**",


### PR DESCRIPTION
Seems some build files were necessary, but not included in the packaged build. This should hopefully fix this.

Fixes #164 