### PR TITLE
Ubuntu 16.04 is no longer available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {ubuntu: 16.04, mpi: serial, rust: nightly}
           - {ubuntu: 18.04, mpi: mpich, rust: beta}
           - {ubuntu: 20.04, mpi: openmpi, rust: stable}
     steps:


### PR DESCRIPTION
See https://github.com/actions/virtual-environments/issues/3287 for the official notice