### PR TITLE
Experimental docs.rs changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,18 @@ jobs:
           command: ${{matrix.command}}
           args: "${{matrix.command == 'fmt' && '--all -- --check' || '-- -D warnings'}}"
 
+  doc: # This task should mirror the procedure on docs.rs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with: {submodules: true}
+      - name: Install Rust (${{matrix.rust}})
+        uses: actions-rs/toolchain@v1
+        with: {toolchain: nightly, profile: minimal, override: true}
+      - name: Document workspace
+        run: env RUSTDOCFLAGS="--cfg docsrs" cargo doc --features hdf5-sys/static,hdf5-sys/zlib,blosc,lzf
+
   brew:
     name: brew
     runs-on: macos-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ default = []
 mpio = ["mpi-sys", "hdf5-sys/mpio"]
 lzf = ["lzf-sys", "errno"]
 blosc = ["blosc-sys"]
+# The features with version numbers such as 1.10.3, 1.12.0 are metafeatures
+# and is only available when the HDF5 library is at least this version.
+# Features have_direct and have_parallel are also metafeatures and dependent
+# on the HDF5 library which is linked against.
 
 [workspace]
 members = [".", "hdf5-types", "hdf5-derive", "hdf5-sys", "hdf5-src"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ tempfile = "3.2"
 
 [package.metadata.docs.rs]
 features = ["hdf5-sys/static", "hdf5-sys/zlib", "blosc", "lzf"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,21 @@
 use std::env;
 
 fn main() {
+    let print_feature = |key: &str| println!("cargo:rustc-cfg=feature=\"{}\"", key);
+    let print_cfg = |key: &str| println!("cargo:rustc-cfg={}", key);
     for (key, _) in env::vars() {
-        let key = match key.as_str() {
-            "DEP_HDF5_HAVE_DIRECT" => "have_direct".into(),
-            "DEP_HDF5_HAVE_STDBOOL" => "have_stdbool".into(),
-            "DEP_HDF5_HAVE_PARALLEL" => "have_parallel".into(),
-            "DEP_HDF5_HAVE_THREADSAFE" => "have_threadsafe".into(),
-            "DEP_HDF5_MSVC_DLL_INDIRECTION" => "dll_indirection".into(),
+        match key.as_str() {
+            // public features
+            "DEP_HDF5_HAVE_DIRECT" => print_feature("have-direct"),
+            "DEP_HDF5_HAVE_PARALLEL" => print_feature("have-parallel"),
+            "DEP_HDF5_HAVE_THREADSAFE" => print_feature("have-threadsafe"),
+            // internal config flags
+            "DEP_HDF5_MSVC_DLL_INDIRECTION" => print_cfg("msvc_dll_indirection"),
+            // public version features
             key if key.starts_with("DEP_HDF5_VERSION_") => {
-                let version = key.trim_start_matches("DEP_HDF5_VERSION_");
-                format!("feature=\"{}\"", version.replace("_", "."))
+                print_feature(&key.trim_start_matches("DEP_HDF5_VERSION_").replace("_", "."));
             }
             _ => continue,
-        };
-        println!("cargo:rustc-cfg={}", key);
+        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn main() {
             "DEP_HDF5_MSVC_DLL_INDIRECTION" => "h5_dll_indirection".into(),
             key if key.starts_with("DEP_HDF5_VERSION_") => {
                 let version = key.trim_start_matches("DEP_HDF5_VERSION_");
-                format!("hdf5_{}", version)
+                format!("feature=\"{}\"", version.replace("_", "."))
             }
             _ => continue,
         };

--- a/build.rs
+++ b/build.rs
@@ -3,11 +3,11 @@ use std::env;
 fn main() {
     for (key, _) in env::vars() {
         let key = match key.as_str() {
-            "DEP_HDF5_HAVE_DIRECT" => "h5_have_direct".into(),
-            "DEP_HDF5_HAVE_STDBOOL" => "h5_have_stdbool".into(),
-            "DEP_HDF5_HAVE_PARALLEL" => "h5_have_parallel".into(),
-            "DEP_HDF5_HAVE_THREADSAFE" => "h5_have_threadsafe".into(),
-            "DEP_HDF5_MSVC_DLL_INDIRECTION" => "h5_dll_indirection".into(),
+            "DEP_HDF5_HAVE_DIRECT" => "have_direct".into(),
+            "DEP_HDF5_HAVE_STDBOOL" => "have_stdbool".into(),
+            "DEP_HDF5_HAVE_PARALLEL" => "have_parallel".into(),
+            "DEP_HDF5_HAVE_THREADSAFE" => "have_threadsafe".into(),
+            "DEP_HDF5_MSVC_DLL_INDIRECTION" => "dll_indirection".into(),
             key if key.starts_with("DEP_HDF5_VERSION_") => {
                 let version = key.trim_start_matches("DEP_HDF5_VERSION_");
                 format!("feature=\"{}\"", version.replace("_", "."))

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -620,8 +620,8 @@ impl Config {
             println!("cargo:version_{}_{}_{}=1", v.major, v.minor, v.micro);
         }
         if self.header.have_stdbool_h {
-            println!("cargo:have_stdbool=1");
             println!("cargo:rustc-cfg=have_stdbool_h");
+            // there should be no need to export have_stdbool_h downstream
         }
         if self.header.have_direct {
             println!("cargo:rustc-cfg=feature=\"have-direct\"");

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -620,19 +620,19 @@ impl Config {
             println!("cargo:version_{}_{}_{}=1", v.major, v.minor, v.micro);
         }
         if self.header.have_stdbool_h {
-            println!("cargo:rustc-cfg=h5_have_stdbool_h");
             println!("cargo:have_stdbool=1");
+            println!("cargo:rustc-cfg=have_stdbool_h");
         }
         if self.header.have_direct {
-            println!("cargo:rustc-cfg=h5_have_direct");
+            println!("cargo:rustc-cfg=feature=\"have-direct\"");
             println!("cargo:have_direct=1");
         }
         if self.header.have_parallel {
-            println!("cargo:rustc-cfg=h5_have_parallel");
+            println!("cargo:rustc-cfg=feature=\"have-parallel\"");
             println!("cargo:have_parallel=1");
         }
         if self.header.have_threadsafe {
-            println!("cargo:rustc-cfg=h5_have_threadsafe");
+            println!("cargo:rustc-cfg=feature=\"have-threadsafe\"");
             println!("cargo:have_threadsafe=1");
         }
     }

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -616,7 +616,7 @@ impl Config {
         vs.extend((0..=7).map(|v| Version::new(1, 10, v))); // 1.10.[0-7]
         vs.push(Version::new(1, 12, 0)); // 1.12.0
         for v in vs.into_iter().filter(|&v| version >= v) {
-            println!("cargo:rustc-cfg=hdf5_{}_{}_{}", v.major, v.minor, v.micro);
+            println!("cargo:rustc-cfg=feature=\"{}.{}.{}\"", v.major, v.minor, v.micro);
             println!("cargo:version_{}_{}_{}=1", v.major, v.minor, v.micro);
         }
         if self.header.have_stdbool_h {

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -12,9 +12,9 @@ pub type hsize_t = c_ulonglong;
 pub type hssize_t = c_longlong;
 pub type haddr_t = uint64_t;
 
-#[cfg(all(hdf5_1_10_0, h5_have_stdbool_h))]
+#[cfg(all(feature = "1.10.0", h5_have_stdbool_h))]
 pub type hbool_t = u8;
-#[cfg(any(not(hdf5_1_10_0), not(h5_have_stdbool_h)))]
+#[cfg(any(not(feature = "1.10.0"), not(h5_have_stdbool_h)))]
 pub type hbool_t = c_uint;
 
 #[repr(C)]
@@ -71,23 +71,23 @@ extern "C" {
     pub fn H5check_version(majnum: c_uint, minnum: c_uint, relnum: c_uint) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_13)]
+#[cfg(feature = "1.8.13")]
 extern "C" {
     pub fn H5free_memory(mem: *mut c_void) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_15)]
+#[cfg(feature = "1.8.15")]
 extern "C" {
     pub fn H5allocate_memory(size: size_t, clear: hbool_t) -> *mut c_void;
     pub fn H5resize_memory(mem: *mut c_void, size: size_t) -> *mut c_void;
 }
 
-#[cfg(hdf5_1_8_16)]
+#[cfg(feature = "1.8.16")]
 extern "C" {
     pub fn H5is_library_threadsafe(is_ts: *mut hbool_t) -> herr_t;
 }
 
-#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.7", not(feature = "1.12.0")))]
 #[repr(C)]
 pub struct H5_alloc_stats_t {
     total_alloc_bytes: c_ulonglong,
@@ -99,7 +99,7 @@ pub struct H5_alloc_stats_t {
     peak_alloc_blocks_count: size_t,
 }
 
-#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.7", not(feature = "1.12.0")))]
 extern "C" {
     pub fn H5get_alloc_stats(stats: *mut H5_alloc_stats_t) -> herr_t;
     pub fn H5get_free_list_sizes(

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -12,9 +12,9 @@ pub type hsize_t = c_ulonglong;
 pub type hssize_t = c_longlong;
 pub type haddr_t = uint64_t;
 
-#[cfg(all(feature = "1.10.0", h5_have_stdbool_h))]
+#[cfg(all(feature = "1.10.0", have_stdbool_h))]
 pub type hbool_t = u8;
-#[cfg(any(not(feature = "1.10.0"), not(h5_have_stdbool_h)))]
+#[cfg(any(not(feature = "1.10.0"), not(have_stdbool_h)))]
 pub type hbool_t = c_uint;
 
 #[repr(C)]

--- a/hdf5-sys/src/h5ac.rs
+++ b/hdf5-sys/src/h5ac.rs
@@ -45,9 +45,9 @@ pub struct H5AC_cache_config_t {
     pub epochs_before_eviction: c_int,
     pub apply_empty_reserve: hbool_t,
     pub empty_reserve: c_double,
-    #[cfg(not(hdf5_1_10_0))]
+    #[cfg(not(feature = "1.10.0"))]
     pub dirty_bytes_threshold: c_int,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub dirty_bytes_threshold: size_t,
     pub metadata_write_strategy: c_int,
 }
@@ -58,7 +58,7 @@ impl Default for H5AC_cache_config_t {
     }
 }
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 mod hdf5_1_10_1 {
     use super::*;
 
@@ -78,5 +78,5 @@ mod hdf5_1_10_1 {
     }
 }
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 pub use self::hdf5_1_10_1::*;

--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -16,7 +16,7 @@ pub const H5D_CHUNK_CACHE_NBYTES_DEFAULT: size_t = !0;
 
 pub const H5D_CHUNK_CACHE_W0_DEFAULT: c_float = -1.0;
 
-#[cfg(not(hdf5_1_10_0))]
+#[cfg(not(feature = "1.10.0"))]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum H5D_layout_t {
@@ -134,7 +134,7 @@ pub type H5D_operator_t = Option<
     ) -> herr_t,
 >;
 
-#[cfg(hdf5_1_8_11)]
+#[cfg(feature = "1.8.11")]
 pub type H5D_scatter_func_t = Option<
     extern "C" fn(
         src_buf: *mut *const c_void,
@@ -142,7 +142,7 @@ pub type H5D_scatter_func_t = Option<
         op_data: *mut c_void,
     ) -> herr_t,
 >;
-#[cfg(hdf5_1_8_11)]
+#[cfg(feature = "1.8.11")]
 pub type H5D_gather_func_t = Option<
     extern "C" fn(
         dst_buf: *const c_void,
@@ -180,7 +180,7 @@ extern "C" {
         buf: *mut c_void, type_id: hid_t, space_id: hid_t, op: H5D_operator_t,
         operator_data: *mut c_void,
     ) -> herr_t;
-    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Treclaim"))]
+    #[cfg_attr(feature = "1.12.0", deprecated(note = "deprecated in HDF5 1.12.0, use H5Treclaim"))]
     pub fn H5Dvlen_reclaim(
         type_id: hid_t, space_id: hid_t, plist_id: hid_t, buf: *mut c_void,
     ) -> herr_t;
@@ -201,7 +201,7 @@ extern "C" {
     pub fn H5Dopen1(file_id: hid_t, name: *const c_char) -> hid_t;
 }
 
-#[cfg(hdf5_1_8_11)]
+#[cfg(feature = "1.8.11")]
 extern "C" {
     pub fn H5Dscatter(
         op: H5D_scatter_func_t, op_data: *mut c_void, type_id: hid_t, dst_space_id: hid_t,
@@ -213,7 +213,7 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 mod hdf5_1_10_0 {
     use super::*;
 
@@ -260,10 +260,10 @@ mod hdf5_1_10_0 {
     }
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 pub use self::hdf5_1_10_0::*;
 
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 extern "C" {
     pub fn H5Dread_chunk(
         dset_id: hid_t, dxpl_id: hid_t, offset: *const hsize_t, filters: *mut u32, buf: *mut c_void,
@@ -274,7 +274,7 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_5)]
+#[cfg(feature = "1.10.5")]
 extern "C" {
     pub fn H5Dget_chunk_info(
         dset_id: hid_t, fspace_id: hid_t, index: hsize_t, offset: *mut hsize_t,

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -5,11 +5,11 @@ pub use self::H5F_close_degree_t::*;
 pub use self::H5F_libver_t::*;
 pub use self::H5F_mem_t::*;
 pub use self::H5F_scope_t::*;
-#[cfg(not(hdf5_1_10_0))]
+#[cfg(not(feature = "1.10.0"))]
 pub use {
     H5F_info1_t as H5F_info_t, H5F_info1_t__sohm as H5F_info_t__sohm, H5Fget_info1 as H5Fget_info,
 };
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 pub use {
     H5F_info2_t as H5F_info_t, H5F_info2_t__free as H5F_info_t__free,
     H5F_info2_t__sohm as H5F_info_t__sohm, H5F_info2_t__super as H5F_info_t__super,
@@ -20,7 +20,7 @@ use crate::internal_prelude::*;
 
 use crate::h5ac::H5AC_cache_config_t;
 
-#[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0"))]
+#[cfg_attr(feature = "1.10.0", deprecated(note = "deprecated in HDF5 1.10.0"))]
 pub const H5F_ACC_DEBUG: c_uint = 0x0000;
 
 /* these flags call H5check() in the C library */
@@ -68,7 +68,7 @@ impl Default for H5F_close_degree_t {
     }
 }
 
-#[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5F_info2_t"))]
+#[cfg_attr(feature = "1.10.0", deprecated(note = "deprecated in HDF5 1.10.0, use H5F_info2_t"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5F_info1_t {
@@ -82,7 +82,7 @@ impl Default for H5F_info1_t {
     }
 }
 
-#[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5F_info2_t"))]
+#[cfg_attr(feature = "1.10.0", deprecated(note = "deprecated in HDF5 1.10.0, use H5F_info2_t"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5F_info1_t__sohm {
@@ -110,7 +110,7 @@ pub enum H5F_mem_t {
     H5FD_MEM_NTYPES = 7,
 }
 
-#[cfg(not(hdf5_1_10_2))]
+#[cfg(not(feature = "1.10.2"))]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum H5F_libver_t {
@@ -118,7 +118,7 @@ pub enum H5F_libver_t {
     H5F_LIBVER_LATEST = 1,
 }
 
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum H5F_libver_t {
@@ -129,7 +129,7 @@ pub enum H5F_libver_t {
     H5F_LIBVER_NBOUNDS = 3,
 }
 
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 pub const H5F_LIBVER_LATEST: H5F_libver_t = H5F_LIBVER_V110;
 
 impl Default for H5F_libver_t {
@@ -145,7 +145,7 @@ extern "C" {
     )]
     pub fn H5Fset_latest_format(file_id: hid_t, latest_format: hbool_t) -> herr_t;
     pub fn H5Fis_hdf5(filename: *const c_char) -> htri_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Fis_accessible(container_name: *const c_char, fapl_id: hid_t) -> htri_t;
     pub fn H5Fcreate(
         filename: *const c_char, flags: c_uint, create_plist: hid_t, access_plist: hid_t,
@@ -154,12 +154,12 @@ extern "C" {
     pub fn H5Freopen(file_id: hid_t) -> hid_t;
     pub fn H5Fflush(object_id: hid_t, scope: H5F_scope_t) -> herr_t;
     pub fn H5Fclose(file_id: hid_t) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Fdelete(filename: *const c_char, fapl_id: hid_t) -> herr_t;
     pub fn H5Fget_create_plist(file_id: hid_t) -> hid_t;
     pub fn H5Fget_access_plist(file_id: hid_t) -> hid_t;
     pub fn H5Fget_intent(file_id: hid_t, intent: *mut c_uint) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Fget_fileno(file_id: hid_t, fileno: *mut c_ulong) -> herr_t;
     pub fn H5Fget_obj_count(file_id: hid_t, types: c_uint) -> ssize_t;
     pub fn H5Fget_obj_ids(
@@ -181,23 +181,23 @@ extern "C" {
     pub fn H5Fget_name(obj_id: hid_t, name: *mut c_char, size: size_t) -> ssize_t;
 }
 
-#[cfg(hdf5_1_8_7)]
+#[cfg(feature = "1.8.7")]
 extern "C" {
     pub fn H5Fclear_elink_file_cache(file_id: hid_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 extern "C" {
     pub fn H5Fget_file_image(file_id: hid_t, buf_ptr: *mut c_void, buf_len: size_t) -> ssize_t;
 }
 
-#[cfg(all(hdf5_1_8_9, h5_have_parallel))]
+#[cfg(all(feature = "1.8.9", h5_have_parallel))]
 extern "C" {
     pub fn H5Fset_mpi_atomicity(file_id: hid_t, flag: hbool_t) -> herr_t;
     pub fn H5Fget_mpi_atomicity(file_id: hid_t, flag: *mut hbool_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 mod hdf5_1_10_0 {
     use super::*;
 
@@ -318,15 +318,18 @@ mod hdf5_1_10_0 {
 }
 
 extern "C" {
-    #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5Fget_info2"))]
-    #[cfg_attr(not(hdf5_1_10_0), link_name = "H5Fget_info")]
+    #[cfg_attr(
+        feature = "1.10.0",
+        deprecated(note = "deprecated in HDF5 1.10.0, use H5Fget_info2")
+    )]
+    #[cfg_attr(not(feature = "1.10.0"), link_name = "H5Fget_info")]
     pub fn H5Fget_info1(obj_id: hid_t, finfo: *mut H5F_info1_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 pub use self::hdf5_1_10_0::*;
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 mod hdf5_1_10_1 {
     use super::*;
 
@@ -360,10 +363,10 @@ mod hdf5_1_10_1 {
     }
 }
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 pub use self::hdf5_1_10_1::*;
 
-#[cfg(hdf5_1_10_5)]
+#[cfg(feature = "1.10.5")]
 extern "C" {
     pub fn H5Fget_dset_no_attrs_hint(file_id: hid_t, minimize: *mut hbool_t) -> herr_t;
     pub fn H5Fset_dset_no_attrs_hint(file_id: hid_t, minimize: hbool_t) -> herr_t;

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -191,7 +191,7 @@ extern "C" {
     pub fn H5Fget_file_image(file_id: hid_t, buf_ptr: *mut c_void, buf_len: size_t) -> ssize_t;
 }
 
-#[cfg(all(feature = "1.8.9", h5_have_parallel))]
+#[cfg(all(feature = "1.8.9", feature = "have-parallel"))]
 extern "C" {
     pub fn H5Fset_mpi_atomicity(file_id: hid_t, flag: hbool_t) -> herr_t;
     pub fn H5Fget_mpi_atomicity(file_id: hid_t, flag: *mut hbool_t) -> herr_t;

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -67,7 +67,7 @@ pub const H5FD_FEAT_DIRTY_SBLK_LOAD: c_uint = 0x00000040;
 pub const H5FD_FEAT_POSIX_COMPAT_HANDLE: c_uint = 0x00000080;
 pub const H5FD_FEAT_ALLOW_FILE_IMAGE: c_uint = 0x00000400;
 pub const H5FD_FEAT_CAN_USE_FILE_IMAGE_CALLBACKS: c_uint = 0x00000800;
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 pub const H5FD_FEAT_DEFAULT_VFD_COMPATIBLE: c_uint = 0x00008000;
 
 /* Flags for H5Pset_fapl_log() */
@@ -262,7 +262,7 @@ pub enum H5FD_file_image_op_t {
     H5FD_FILE_IMAGE_OP_FILE_CLOSE = 7,
 }
 
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5FD_file_image_callbacks_t {
@@ -302,7 +302,7 @@ pub struct H5FD_file_image_callbacks_t {
     pub udata: *mut c_void,
 }
 
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 impl Default for H5FD_file_image_callbacks_t {
     fn default() -> Self {
         unsafe { mem::zeroed() }
@@ -362,13 +362,13 @@ extern "C" {
     pub fn H5FD_direct_init() -> hid_t;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 extern "C" {
     pub fn H5FDlock(file: *mut H5FD_t, rw: hbool_t) -> herr_t;
     pub fn H5FDunlock(file: *mut H5FD_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_6)]
+#[cfg(feature = "1.10.6")]
 pub mod hdfs {
     use super::*;
     pub const H5FD__CURR_HDFS_FAPL_T_VERSION: c_uint = 1;
@@ -393,7 +393,7 @@ pub mod hdfs {
     }
 }
 
-#[cfg(hdf5_1_10_6)]
+#[cfg(feature = "1.10.6")]
 pub mod ros3 {
     use super::*;
     pub const H5FD_CURR_ROS3_FAPL_T_VERSION: c_uint = 1;
@@ -417,7 +417,7 @@ pub mod ros3 {
     }
 }
 
-#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.7", not(feature = "1.12.0")))]
 pub mod splitter {
     use super::*;
 
@@ -447,7 +447,7 @@ pub mod splitter {
     }
 }
 
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 extern "C" {
     pub fn H5FDdriver_query(driver_id: hid_t, flags: *mut c_ulong) -> herr_t;
 }

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -352,12 +352,12 @@ extern "C" {
     pub fn H5FD_multi_init() -> hid_t;
 }
 
-#[cfg(h5_have_parallel)]
+#[cfg(feature = "have-parallel")]
 extern "C" {
     pub fn H5FD_mpio_init() -> hid_t;
 }
 
-#[cfg(h5_have_direct)]
+#[cfg(feature = "have-direct")]
 extern "C" {
     pub fn H5FD_direct_init() -> hid_t;
 }

--- a/hdf5-sys/src/h5g.rs
+++ b/hdf5-sys/src/h5g.rs
@@ -106,7 +106,7 @@ extern "C" {
     pub fn H5Gunlink(loc_id: hid_t, name: *const c_char) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 extern "C" {
     pub fn H5Gflush(group_id: hid_t) -> herr_t;
     pub fn H5Grefresh(group_id: hid_t) -> herr_t;

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -13,29 +13,29 @@ pub enum H5I_type_t {
     H5I_DATATYPE,
     H5I_DATASPACE,
     H5I_DATASET,
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     H5I_MAP,
     H5I_ATTR,
-    #[cfg(not(hdf5_1_12_0))]
-    #[cfg_attr(hdf5_1_10_2, deprecated(note = "deprecated in HDF5 1.10.2"))]
+    #[cfg(not(feature = "1.12.0"))]
+    #[cfg_attr(feature = "1.10.2", deprecated(note = "deprecated in HDF5 1.10.2"))]
     H5I_REFERENCE,
     H5I_VFL,
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     H5I_VOL,
     H5I_GENPROP_CLS,
     H5I_GENPROP_LST,
     H5I_ERROR_CLASS,
     H5I_ERROR_MSG,
     H5I_ERROR_STACK,
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     H5I_SPACE_SEL_ITER,
     H5I_NTYPES,
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 pub type hid_t = i64;
 
-#[cfg(not(hdf5_1_10_0))]
+#[cfg(not(feature = "1.10.0"))]
 pub type hid_t = c_int;
 
 pub const H5I_INVALID_HID: hid_t = -1;
@@ -43,7 +43,7 @@ pub const H5I_INVALID_HID: hid_t = -1;
 pub type H5I_free_t = Option<extern "C" fn(arg1: *mut c_void) -> herr_t>;
 pub type H5I_search_func_t =
     Option<extern "C" fn(obj: *mut c_void, id: hid_t, key: *mut c_void) -> c_int>;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub type H5I_iterate_func_t = Option<extern "C" fn(id: hid_t, udata: *mut c_void) -> herr_t>;
 
 extern "C" {
@@ -65,7 +65,7 @@ extern "C" {
     pub fn H5Idec_type_ref(type_: H5I_type_t) -> c_int;
     pub fn H5Iget_type_ref(type_: H5I_type_t) -> c_int;
     pub fn H5Isearch(type_: H5I_type_t, func: H5I_search_func_t, key: *mut c_void) -> *mut c_void;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Iiterate(type_: H5I_type_t, op: H5I_iterate_func_t, op_data: *mut c_void) -> herr_t;
     pub fn H5Inmembers(type_: H5I_type_t, num_members: *mut hsize_t) -> herr_t;
     pub fn H5Itype_exists(type_: H5I_type_t) -> htri_t;

--- a/hdf5-sys/src/h5l.rs
+++ b/hdf5-sys/src/h5l.rs
@@ -3,7 +3,7 @@ use std::mem;
 
 pub use self::H5L_type_t::*;
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 use crate::h5o::H5O_token_t;
 use crate::internal_prelude::*;
 
@@ -65,7 +65,7 @@ impl H5L_info1_t__u {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub struct H5L_info2_t {
     pub type_: H5L_type_t,
     pub corder_valid: hbool_t,
@@ -74,7 +74,7 @@ pub struct H5L_info2_t {
     pub u: H5L_info1_t__u,
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 impl Default for H5L_info2_t {
     fn default() -> Self {
         unsafe { mem::zeroed() }
@@ -83,13 +83,13 @@ impl Default for H5L_info2_t {
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub union H5L_info2_t__u {
     token: H5O_token_t,
     val_size: size_t,
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 impl Default for H5L_info2_t__u {
     fn default() -> Self {
         unsafe { mem::zeroed() }
@@ -176,7 +176,7 @@ pub type H5L_iterate1_t = Option<
         op_data: *mut c_void,
     ) -> herr_t,
 >;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub type H5L_iterate2_t = Option<
     extern "C" fn(
         group: hid_t,
@@ -227,12 +227,15 @@ extern "C" {
         n: hsize_t, buf: *mut c_void, size: size_t, lapl_id: hid_t,
     ) -> herr_t;
     pub fn H5Lexists(loc_id: hid_t, name: *const c_char, lapl_id: hid_t) -> htri_t;
-    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Lget_info2()"))]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Lget_info")]
+    #[cfg_attr(
+        feature = "1.12.0",
+        deprecated(note = "deprecated in HDF5 1.12.0, use H5Lget_info2()")
+    )]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Lget_info")]
     pub fn H5Lget_info1(
         loc_id: hid_t, name: *const c_char, linfo: *mut H5L_info1_t, lapl_id: hid_t,
     ) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Lget_info2(
         loc_id: hid_t, name: *const c_char, linfo: *mut H5L_info2_t, lapl_id: hid_t,
     ) -> herr_t;
@@ -240,12 +243,12 @@ extern "C" {
         hdf5_1_12_0,
         deprecated(note = "deprecated in HDF5 1.12.0, use H5Lget_info_by_idx2()")
     )]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Lget_info_by_idx")]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Lget_info_by_idx")]
     pub fn H5Lget_info_by_idx(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         n: hsize_t, linfo: *mut H5L_info1_t, lapl_id: hid_t,
     ) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Lget_info_by_idx2(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         n: hsize_t, linfo: *mut H5L_info2_t, lapl_id: hid_t,
@@ -254,13 +257,16 @@ extern "C" {
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         n: hsize_t, name: *mut c_char, size: size_t, lapl_id: hid_t,
     ) -> ssize_t;
-    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Literate2()"))]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Literate")]
+    #[cfg_attr(
+        feature = "1.12.0",
+        deprecated(note = "deprecated in HDF5 1.12.0, use H5Literate2()")
+    )]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Literate")]
     pub fn H5Literate1(
         grp_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, idx: *mut hsize_t,
         op: H5L_iterate1_t, op_data: *mut c_void,
     ) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Literate2(
         grp_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, idx: *mut hsize_t,
         op: H5L_iterate2_t, op_data: *mut c_void,
@@ -269,23 +275,23 @@ extern "C" {
         hdf5_1_12_0,
         deprecated(note = "deprecated in HDF5 1.12.0, use H5Literate_by_name2()")
     )]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Literate_by_name")]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Literate_by_name")]
     pub fn H5Literate_by_name1(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         idx: *mut hsize_t, op: H5L_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,
     ) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Literate_by_name2(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         idx: *mut hsize_t, op: H5L_iterate2_t, op_data: *mut c_void, lapl_id: hid_t,
     ) -> herr_t;
-    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Lvisit2()"))]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Lvisit")]
+    #[cfg_attr(feature = "1.12.0", deprecated(note = "deprecated in HDF5 1.12.0, use H5Lvisit2()"))]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Lvisit")]
     pub fn H5Lvisit1(
         grp_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5L_iterate1_t,
         op_data: *mut c_void,
     ) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Lvisit2(
         grp_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t, op: H5L_iterate2_t,
         op_data: *mut c_void,
@@ -294,12 +300,12 @@ extern "C" {
         hdf5_1_12_0,
         deprecated(note = "deprecated in HDF5 1.12.0, use H5Lvisit_by_name2()")
     )]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Lvisit_by_name")]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Lvisit_by_name")]
     pub fn H5Lvisit_by_name1(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         op: H5L_iterate1_t, op_data: *mut c_void, lapl_id: hid_t,
     ) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Lvisit_by_name2(
         loc_id: hid_t, group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t,
         op: H5L_iterate2_t, op_data: *mut c_void, lapl_id: hid_t,
@@ -321,11 +327,11 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(not(hdf5_1_12_0))]
+#[cfg(not(feature = "1.12.0"))]
 pub use self::{
     H5L_info1_t as H5L_info_t, H5L_iterate1_t as H5L_iterate_t, H5Literate1 as H5Literate,
 };
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub use self::{
     H5L_info2_t as H5L_info_t, H5L_iterate2_t as H5L_iterate_t, H5Literate2 as H5Literate,
 };

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -3,14 +3,14 @@ use std::mem;
 
 pub use self::H5O_mcdt_search_ret_t::*;
 pub use self::H5O_type_t::*;
-#[cfg(not(hdf5_1_12_0))]
+#[cfg(not(feature = "1.12.0"))]
 pub use {
     H5O_info1_t as H5O_info_t, H5O_info1_t__meta_size as H5O_info_t_meta_size,
     H5O_iterate1_t as H5O_iterate_t,
 };
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub use {H5O_info2_t as H5O_info_t, H5O_iterate2_t as H5O_iterate_t};
-#[cfg(not(hdf5_1_10_3))]
+#[cfg(not(feature = "1.10.3"))]
 pub use {
     H5Oget_info1 as H5Oget_info, H5Oget_info_by_idx1 as H5Oget_info_by_idx,
     H5Oget_info_by_name1 as H5Oget_info_by_name, H5Ovisit1 as H5Ovisit,
@@ -25,11 +25,11 @@ pub const H5O_COPY_EXPAND_EXT_LINK_FLAG: c_uint = 0x0004;
 pub const H5O_COPY_EXPAND_REFERENCE_FLAG: c_uint = 0x0008;
 pub const H5O_COPY_WITHOUT_ATTR_FLAG: c_uint = 0x0010;
 pub const H5O_COPY_PRESERVE_NULL_FLAG: c_uint = 0x0020;
-#[cfg(not(hdf5_1_8_9))]
+#[cfg(not(feature = "1.8.9"))]
 pub const H5O_COPY_ALL: c_uint = 0x003F;
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 pub const H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG: c_uint = 0x0040;
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 pub const H5O_COPY_ALL: c_uint = 0x007F;
 
 pub const H5O_SHMESG_NONE_FLAG: c_uint = 0x0000;
@@ -58,27 +58,27 @@ pub const H5O_HDR_ALL_FLAGS: c_uint = H5O_HDR_CHUNK0_SIZE
 pub const H5O_SHMESG_MAX_NINDEXES: c_uint = 8;
 pub const H5O_SHMESG_MAX_LIST_SIZE: c_uint = 5000;
 
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 pub const H5O_INFO_BASIC: c_uint = 0x0001;
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 pub const H5O_INFO_TIME: c_uint = 0x0002;
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 pub const H5O_INFO_NUM_ATTRS: c_uint = 0x0004;
-#[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.3", not(feature = "1.12.0")))]
 pub const H5O_INFO_HDR: c_uint = 0x0008;
-#[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.3", not(feature = "1.12.0")))]
 pub const H5O_INFO_META_SIZE: c_uint = 0x0010;
-#[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.3", not(feature = "1.12.0")))]
 pub const H5O_INFO_ALL: c_uint =
     H5O_INFO_BASIC | H5O_INFO_TIME | H5O_INFO_NUM_ATTRS | H5O_INFO_HDR | H5O_INFO_META_SIZE;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub const H5O_INFO_ALL: c_uint = H5O_INFO_BASIC | H5O_INFO_TIME | H5O_INFO_NUM_ATTRS;
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub const H5O_NATIVE_INFO_HDR: c_uint = 0x0008;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub const H5O_NATIVE_INFO_META_SIZE: c_uint = 0x0010;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub const H5O_NATIVE_INFO_ALL: c_uint = H5O_NATIVE_INFO_HDR | H5O_NATIVE_INFO_META_SIZE;
 
 #[repr(C)]
@@ -88,7 +88,7 @@ pub enum H5O_type_t {
     H5O_TYPE_GROUP,
     H5O_TYPE_DATASET,
     H5O_TYPE_NAMED_DATATYPE,
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     H5O_TYPE_MAP,
     H5O_TYPE_NTYPES,
 }
@@ -184,7 +184,7 @@ pub type H5O_iterate1_t = Option<
     ) -> herr_t,
 >;
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub type H5O_iterate2_t = Option<
     extern "C" fn(
         obj: hid_t,
@@ -202,11 +202,11 @@ pub enum H5O_mcdt_search_ret_t {
     H5O_MCDT_SEARCH_STOP = 1,
 }
 
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 pub type H5O_mcdt_search_cb_t =
     Option<extern "C" fn(op_data: *mut c_void) -> H5O_mcdt_search_ret_t>;
 
-#[cfg(not(hdf5_1_10_3))]
+#[cfg(not(feature = "1.10.3"))]
 extern "C" {
     #[link_name = "H5Oget_info"]
     pub fn H5Oget_info1(loc_id: hid_t, oinfo: *mut H5O_info1_t) -> herr_t;
@@ -260,15 +260,15 @@ extern "C" {
     pub fn H5Oclose(object_id: hid_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_5)]
+#[cfg(feature = "1.8.5")]
 use crate::h5::htri_t;
 
-#[cfg(hdf5_1_8_5)]
+#[cfg(feature = "1.8.5")]
 extern "C" {
     pub fn H5Oexists_by_name(loc_id: hid_t, name: *const c_char, lapl_id: hid_t) -> htri_t;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 extern "C" {
     pub fn H5Odisable_mdc_flushes(object_id: hid_t) -> herr_t;
     pub fn H5Oenable_mdc_flushes(object_id: hid_t) -> herr_t;
@@ -277,7 +277,7 @@ extern "C" {
     pub fn H5Orefresh(oid: hid_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 mod hdf5_1_10_3 {
     use super::*;
 
@@ -322,7 +322,7 @@ mod hdf5_1_10_3 {
         ) -> herr_t;
     }
 
-    #[cfg(not(hdf5_1_10_5))]
+    #[cfg(not(feature = "1.10.5"))]
     pub use self::{
         H5Oget_info1 as H5Oget_info, H5Oget_info_by_idx1 as H5Oget_info_by_idx,
         H5Oget_info_by_name1 as H5Oget_info_by_name, H5Ovisit1 as H5Ovisit,
@@ -330,10 +330,10 @@ mod hdf5_1_10_3 {
     };
 }
 
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 pub use self::hdf5_1_10_3::*;
 
-#[cfg(hdf5_1_10_5)]
+#[cfg(feature = "1.10.5")]
 extern "C" {
     // They've messed up when introducing compatibility macros which broke ABI compatibility;
     // in 1.10.5 those APIs were copied over to old names in order to be compatible with
@@ -361,24 +361,24 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub const H5O_MAX_TOKEN_SIZE: usize = 16;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub struct H5O_token_t {
     __data: [u8; H5O_MAX_TOKEN_SIZE],
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 impl Default for H5O_token_t {
     fn default() -> Self {
         *H5O_TOKEN_UNDEF
     }
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5O_info2_t {
@@ -393,7 +393,7 @@ pub struct H5O_info2_t {
     pub num_attrs: hsize_t,
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5O_native_info_meta_size_t {
@@ -401,7 +401,7 @@ pub struct H5O_native_info_meta_size_t {
     attr: H5_ih_info_t,
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5O_native_info_t {
@@ -418,7 +418,7 @@ pub struct H5O_stat_t {
     nchunks: c_uint,
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 extern "C" {
     pub fn H5Oget_info3(loc_id: hid_t, oinfo: *mut H5O_info2_t, fields: c_uint) -> herr_t;
     pub fn H5Oget_info_by_idx3(
@@ -460,16 +460,16 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub use self::globals::*;
 
-#[cfg(all(not(all(target_env = "msvc", not(feature = "static"))), hdf5_1_12_0))]
+#[cfg(all(not(all(target_env = "msvc", not(feature = "static"))), feature = "1.12.0"))]
 mod globals {
     use super::H5O_token_t as id_t;
     extern_static!(H5O_TOKEN_UNDEF, H5O_TOKEN_UNDEF_g);
 }
 
-#[cfg(all(target_env = "msvc", not(feature = "static"), hdf5_1_12_0))]
+#[cfg(all(target_env = "msvc", not(feature = "static"), feature = "1.12.0"))]
 mod globals {
     // TODO: special DLL handling?
     use super::H5O_token_t as id_t;

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -10,11 +10,11 @@ use crate::h5mm::{H5MM_allocate_t, H5MM_free_t};
 use crate::h5t::{H5T_conv_except_func_t, H5T_cset_t};
 use crate::h5z::{H5Z_EDC_t, H5Z_SO_scale_type_t, H5Z_filter_func_t, H5Z_filter_t};
 
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 use crate::h5fd::H5FD_file_image_callbacks_t;
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 use crate::h5o::H5O_mcdt_search_cb_t;
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 use crate::{h5ac::H5AC_cache_image_config_t, h5f::H5F_fspace_strategy_t};
 
 pub const H5P_CRT_ORDER_TRACKED: c_uint = 0x0001;
@@ -46,7 +46,7 @@ pub type H5P_iterate_t =
 
 pub use self::globals::*;
 
-#[cfg(all(not(hdf5_1_8_14), not(all(target_env = "msvc", not(feature = "static")))))]
+#[cfg(all(not(feature = "1.8.14"), not(all(target_env = "msvc", not(feature = "static")))))]
 mod globals {
     pub use crate::h5i::hid_t as id_t;
 
@@ -86,7 +86,7 @@ mod globals {
     extern_static!(H5P_LST_LINK_ACCESS, H5P_LST_LINK_ACCESS_g);
 }
 
-#[cfg(all(hdf5_1_8_14, not(all(target_env = "msvc", not(feature = "static")))))]
+#[cfg(all(feature = "1.8.14", not(all(target_env = "msvc", not(feature = "static")))))]
 mod globals {
     pub use crate::h5i::hid_t as id_t;
 
@@ -125,7 +125,7 @@ mod globals {
     extern_static!(H5P_LST_LINK_CREATE, H5P_LST_LINK_CREATE_ID_g);
     extern_static!(H5P_LST_LINK_ACCESS, H5P_LST_LINK_ACCESS_ID_g);
 
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     #[allow(clippy::module_inception)]
     pub mod globals {
         use super::*;
@@ -138,11 +138,11 @@ mod globals {
         extern_static!(H5P_VOL_INITIALIZE_DEFAULT, H5P_LST_VOL_INITIALIZE_ID_g);
         extern_static!(H5P_REFERENCE_ACCESS_DEFAULT, H5P_LST_REFERENCE_ACCESS_ID_g);
     }
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub use globals::*;
 }
 
-#[cfg(all(not(hdf5_1_8_14), all(target_env = "msvc", not(feature = "static"))))]
+#[cfg(all(not(feature = "1.8.14"), all(target_env = "msvc", not(feature = "static"))))]
 mod globals {
     // dllimport hack
     pub type id_t = usize;
@@ -183,7 +183,7 @@ mod globals {
     extern_static!(H5P_LST_LINK_ACCESS, __imp_H5P_LST_LINK_ACCESS_g);
 }
 
-#[cfg(all(hdf5_1_8_14, all(target_env = "msvc", not(feature = "static"))))]
+#[cfg(all(feature = "1.8.14", all(target_env = "msvc", not(feature = "static"))))]
 mod globals {
     // dllimport hack
     pub type id_t = usize;
@@ -223,7 +223,7 @@ mod globals {
     extern_static!(H5P_LST_LINK_CREATE, __imp_H5P_LST_LINK_CREATE_ID_g);
     extern_static!(H5P_LST_LINK_ACCESS, __imp_H5P_LST_LINK_ACCESS_ID_g);
 
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     #[allow(clippy::module_inception)]
     pub mod globals {
         use super::*;
@@ -236,7 +236,7 @@ mod globals {
         extern_static!(H5P_VOL_INITIALIZE_DEFAULT, __imp_H5P_LST_VOL_INITIALIZE_ID_g);
         extern_static!(H5P_REFERENCE_ACCESS_DEFAULT, __imp_H5P_LST_REFERENCE_ACCESS_ID_g);
     }
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub use globals::*;
 }
 
@@ -467,7 +467,10 @@ extern "C" {
     ) -> herr_t;
     pub fn H5Pset_copy_object(plist_id: hid_t, crt_intmd: c_uint) -> herr_t;
     pub fn H5Pget_copy_object(plist_id: hid_t, crt_intmd: *mut c_uint) -> herr_t;
-    #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5Fget_info2()"))]
+    #[cfg_attr(
+        feature = "1.10.0",
+        deprecated(note = "deprecated in HDF5 1.10.0, use H5Fget_info2()")
+    )]
     pub fn H5Pget_version(
         plist_id: hid_t, boot: *mut c_uint, freelist: *mut c_uint, stab: *mut c_uint,
         shhdr: *mut c_uint,
@@ -592,13 +595,13 @@ extern "C" {
     pub fn H5Pset_fapl_windows(fapl_id: hid_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_7)]
+#[cfg(feature = "1.8.7")]
 extern "C" {
     pub fn H5Pset_elink_file_cache_size(plist_id: hid_t, efc_size: c_uint) -> herr_t;
     pub fn H5Pget_elink_file_cache_size(plist_id: hid_t, efc_size: *mut c_uint) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_9)]
+#[cfg(feature = "1.8.9")]
 extern "C" {
     pub fn H5Pset_file_image(fapl_id: hid_t, buf_ptr: *mut c_void, buf_len: size_t) -> herr_t;
     pub fn H5Pget_file_image(
@@ -620,7 +623,7 @@ extern "C" {
     pub fn H5Pfree_merge_committed_dtype_paths(plist_id: hid_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_13)]
+#[cfg(feature = "1.8.13")]
 extern "C" {
     pub fn H5Pset_core_write_tracking(
         fapl_id: hid_t, is_enabled: hbool_t, page_size: size_t,
@@ -630,19 +633,19 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(hdf5_1_8_17)]
+#[cfg(feature = "1.8.17")]
 extern "C" {
     pub fn H5Pset_efile_prefix(dapl_id: hid_t, prefix: *const c_char) -> herr_t;
     pub fn H5Pget_efile_prefix(dapl_id: hid_t, prefix: *const c_char, size: size_t) -> ssize_t;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use crate::{
     h5d::{H5D_append_cb_t, H5D_vds_view_t},
     h5f::{H5F_file_space_type_t, H5F_flush_cb_t},
 };
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 extern "C" {
     pub fn H5Pset_append_flush(
         plist_id: hid_t, ndims: c_uint, boundary: *const hsize_t, func: H5D_append_cb_t,
@@ -689,10 +692,13 @@ extern "C" {
     pub fn H5Pset_virtual_view(plist_id: hid_t, view: H5D_vds_view_t) -> herr_t;
     pub fn H5Pget_chunk_opts(plist_id: hid_t, opts: *mut c_uint) -> herr_t;
     pub fn H5Pset_chunk_opts(plist_id: hid_t, opts: c_uint) -> herr_t;
-    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Pencode2()"))]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Pencode")]
+    #[cfg_attr(
+        feature = "1.12.0",
+        deprecated(note = "deprecated in HDF5 1.12.0, use H5Pencode2()")
+    )]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Pencode")]
     pub fn H5Pencode1(plist_id: hid_t, buf: *mut c_void, nalloc: *mut size_t) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Pencode2(
         plist_id: hid_t, buf: *mut c_void, nalloc: *mut size_t, fapl_id: hid_t,
     ) -> herr_t;
@@ -713,12 +719,12 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(all(hdf5_1_10_0, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.0", not(feature = "1.12.0")))]
 pub use self::H5Pencode1 as H5Pencode;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub use self::H5Pencode2 as H5Pencode;
 
-#[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+#[cfg(all(feature = "1.10.0", h5_have_parallel))]
 extern "C" {
     pub fn H5Pset_coll_metadata_write(fapl_id: hid_t, is_collective: hbool_t) -> herr_t;
     pub fn H5Pget_coll_metadata_write(fapl_id: hid_t, is_collective: *mut hbool_t) -> herr_t;
@@ -726,7 +732,7 @@ extern "C" {
     pub fn H5Pget_all_coll_metadata_ops(accpl_id: hid_t, is_collective: *mut hbool_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 extern "C" {
     pub fn H5Pset_evict_on_close(fapl_id: hid_t, evict_on_close: hbool_t) -> herr_t;
     pub fn H5Pget_evict_on_close(fapl_id: hid_t, evict_on_close: *mut hbool_t) -> herr_t;
@@ -753,19 +759,19 @@ extern "C" {
     pub fn H5Pget_file_space_page_size(plist_id: hid_t, fsp_size: *mut hsize_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 extern "C" {
     pub fn H5Pset_virtual_prefix(dapl_id: hid_t, prefix: *const c_char) -> herr_t;
     pub fn H5Pget_virtual_prefix(dapl_id: hid_t, prefix: *mut c_char, size: size_t) -> ssize_t;
 }
 
-#[cfg(hdf5_1_10_5)]
+#[cfg(feature = "1.10.5")]
 extern "C" {
     pub fn H5Pget_dset_no_attrs_hint(dcpl_id: hid_t, minimize: *mut hbool_t) -> herr_t;
     pub fn H5Pset_dset_no_attrs_hint(dcpl_id: hid_t, minimize: hbool_t) -> herr_t;
 }
 
-#[cfg(all(hdf5_1_10_7, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.7", not(feature = "1.12.0")))]
 extern "C" {
     pub fn H5Pget_file_locking(
         fapl_id: hid_t, use_file_locking: *mut hbool_t, ignore_when_disable: *mut hbool_t,
@@ -776,7 +782,7 @@ extern "C" {
 
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 extern "C" {
     pub fn H5Pget_vol_id(plist_id: hid_t, vol_id: *mut hid_t) -> herr_t;
     pub fn H5Pget_vol_info(plist_id: hid_t, vol_info: *mut *mut c_void) -> herr_t;

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -531,17 +531,17 @@ extern "C" {
     ) -> herr_t;
 
     // direct
-    #[cfg(h5_have_direct)]
+    #[cfg(feature = "have-direct")]
     pub fn H5Pset_fapl_direct(
         fapl_id: hid_t, alignment: size_t, block_size: size_t, cbuf_size: size_t,
     ) -> herr_t;
-    #[cfg(h5_have_direct)]
+    #[cfg(feature = "have-parallel")]
     pub fn H5Pget_fapl_direct(
         fapl_id: hid_t, alignment: *mut size_t, block_size: *mut size_t, cbuf_size: *mut size_t,
     ) -> herr_t;
 }
 
-#[cfg(h5_have_parallel)]
+#[cfg(feature = "have-parallel")]
 mod mpio {
     use crate::internal_prelude::*;
 
@@ -587,7 +587,7 @@ mod mpio {
     }
 }
 
-#[cfg(h5_have_parallel)]
+#[cfg(feature = "have-parallel")]
 pub use self::mpio::*;
 
 #[cfg(target_os = "windows")]
@@ -724,7 +724,7 @@ pub use self::H5Pencode1 as H5Pencode;
 #[cfg(feature = "1.12.0")]
 pub use self::H5Pencode2 as H5Pencode;
 
-#[cfg(all(feature = "1.10.0", h5_have_parallel))]
+#[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
 extern "C" {
     pub fn H5Pset_coll_metadata_write(fapl_id: hid_t, is_collective: hbool_t) -> herr_t;
     pub fn H5Pget_coll_metadata_write(fapl_id: hid_t, is_collective: *mut hbool_t) -> herr_t;

--- a/hdf5-sys/src/h5pl.rs
+++ b/hdf5-sys/src/h5pl.rs
@@ -1,7 +1,7 @@
 //! Programmatically controlling dynamically loaded plugins
 use crate::internal_prelude::*;
 
-#[cfg(hdf5_1_8_15)]
+#[cfg(feature = "1.8.15")]
 mod hdf5_1_8_15 {
     use super::*;
 
@@ -10,9 +10,9 @@ mod hdf5_1_8_15 {
     pub enum H5PL_type_t {
         H5PL_TYPE_ERROR = -1,
         H5PL_TYPE_FILTER = 0,
-        #[cfg(hdf5_1_12_0)]
+        #[cfg(feature = "1.12.0")]
         H5PL_VOL,
-        #[cfg(hdf5_1_12_0)]
+        #[cfg(feature = "1.12.0")]
         H5PL_TYPE_NONE,
     }
 
@@ -27,10 +27,10 @@ mod hdf5_1_8_15 {
     }
 }
 
-#[cfg(hdf5_1_8_15)]
+#[cfg(feature = "1.8.15")]
 pub use self::hdf5_1_8_15::*;
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 extern "C" {
     pub fn H5PLappend(search_path: *const c_char) -> herr_t;
     pub fn H5PLprepend(search_path: *const c_char) -> herr_t;

--- a/hdf5-sys/src/h5r.rs
+++ b/hdf5-sys/src/h5r.rs
@@ -1,8 +1,8 @@
 //! Creating and manipulating references to specific objects and data regions in an HDF5 file
 pub use self::H5R_type_t::*;
-#[cfg(not(hdf5_1_10_0))]
+#[cfg(not(feature = "1.10.0"))]
 pub use H5Rdereference1 as H5Rdereference;
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 pub use H5Rdereference2 as H5Rdereference;
 
 use crate::internal_prelude::*;
@@ -12,7 +12,7 @@ use crate::h5o::H5O_type_t;
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-#[cfg(not(hdf5_1_12_0))]
+#[cfg(not(feature = "1.12.0"))]
 pub enum H5R_type_t {
     H5R_BADTYPE = -1,
     H5R_OBJECT = 0,
@@ -22,7 +22,7 @@ pub enum H5R_type_t {
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub enum H5R_type_t {
     H5R_BADTYPE = -1,
     H5R_OBJECT1 = 0,
@@ -53,19 +53,22 @@ extern "C" {
 }
 
 extern "C" {
-    #[cfg_attr(hdf5_1_10_0, deprecated(note = "deprecated in HDF5 1.10.0, use H5Rdereference2"))]
-    #[cfg_attr(not(hdf5_1_10_0), link_name = "H5Rdereference")]
+    #[cfg_attr(
+        feature = "1.10.0",
+        deprecated(note = "deprecated in HDF5 1.10.0, use H5Rdereference2")
+    )]
+    #[cfg_attr(not(feature = "1.10.0"), link_name = "H5Rdereference")]
     pub fn H5Rdereference1(obj_id: hid_t, ref_type: H5R_type_t, ref_: *const c_void) -> hid_t;
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn H5Rdereference2(
         obj_id: hid_t, oapl_id: hid_t, ref_type: H5R_type_t, ref_: *const c_void,
     ) -> hid_t;
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub const H5R_REF_BUF_SIZE: usize = 64;
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union H5R_ref_t_u {
@@ -73,21 +76,21 @@ pub union H5R_ref_t_u {
     align: i64,
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 impl Default for H5R_ref_t_u {
     fn default() -> Self {
         unsafe { std::mem::zeroed() }
     }
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct H5R_ref_t {
     u: H5R_ref_t_u,
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 extern "C" {
     pub fn H5Rcopy(src_ref_ptr: *const H5R_ref_t, dst_ref_ptr: *mut H5R_ref_t) -> herr_t;
     pub fn H5Rcreate_attr(

--- a/hdf5-sys/src/h5s.rs
+++ b/hdf5-sys/src/h5s.rs
@@ -2,9 +2,9 @@
 pub use self::H5S_class_t::*;
 pub use self::H5S_sel_type::*;
 pub use self::H5S_seloper_t::*;
-#[cfg(not(hdf5_1_12_0))]
+#[cfg(not(feature = "1.12.0"))]
 pub use self::H5Sencode1 as H5Sencode;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 pub use self::H5Sencode2 as H5Sencode;
 
 use crate::internal_prelude::*;
@@ -61,10 +61,13 @@ extern "C" {
     ) -> herr_t;
     pub fn H5Scopy(space_id: hid_t) -> hid_t;
     pub fn H5Sclose(space_id: hid_t) -> herr_t;
-    #[cfg_attr(hdf5_1_12_0, deprecated(note = "deprecated in HDF5 1.12.0, use H5Sencode2()"))]
-    #[cfg_attr(not(hdf5_1_12_0), link_name = "H5Sencode")]
+    #[cfg_attr(
+        feature = "1.12.0",
+        deprecated(note = "deprecated in HDF5 1.12.0, use H5Sencode2()")
+    )]
+    #[cfg_attr(not(feature = "1.12.0"), link_name = "H5Sencode")]
     pub fn H5Sencode1(obj_id: hid_t, buf: *mut c_void, nalloc: *mut size_t) -> herr_t;
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     pub fn H5Sencode2(
         obj_id: hid_t, buf: *mut c_void, nalloc: *mut size_t, fapl_id: hid_t,
     ) -> herr_t;
@@ -103,7 +106,7 @@ extern "C" {
     pub fn H5Sget_select_type(spaceid: hid_t) -> H5S_sel_type;
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 extern "C" {
     pub fn H5Sis_regular_hyperslab(spaceid: hid_t) -> htri_t;
     pub fn H5Sget_regular_hyperslab(
@@ -112,7 +115,7 @@ extern "C" {
     ) -> htri_t;
 }
 
-#[cfg(any(hdf5_1_12_0, hdf5_1_10_7))]
+#[cfg(any(feature = "1.12.0", feature = "1.10.7"))]
 extern "C" {
     pub fn H5Scombine_hyperslab(
         space_id: hid_t, op: H5S_seloper_t, start: *const hsize_t, stride: *const hsize_t,
@@ -131,7 +134,7 @@ extern "C" {
     pub fn H5Sselect_shape_same(space1_id: hid_t, space2_id: hid_t) -> htri_t;
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 extern "C" {
     pub fn H5Ssel_iter_close(sel_iter_id: hid_t) -> herr_t;
     pub fn H5Ssel_iter_create(space_id: hid_t, elmt_size: size_t, flags: c_uint) -> hid_t;

--- a/hdf5-sys/src/h5t.rs
+++ b/hdf5-sys/src/h5t.rs
@@ -39,7 +39,7 @@ pub enum H5T_class_t {
     H5T_NCLASSES = 11,
 }
 
-#[cfg(hdf5_1_8_6)]
+#[cfg(feature = "1.8.6")]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum H5T_order_t {
@@ -51,7 +51,7 @@ pub enum H5T_order_t {
     H5T_ORDER_NONE = 4,
 }
 
-#[cfg(not(hdf5_1_8_6))]
+#[cfg(not(feature = "1.8.6"))]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum H5T_order_t {
@@ -441,7 +441,7 @@ mod globals {
     extern_static!(H5T_NATIVE_UINT_LEAST64, H5T_NATIVE_UINT_LEAST64_g);
     extern_static!(H5T_NATIVE_INT_FAST64, H5T_NATIVE_INT_FAST64_g);
     extern_static!(H5T_NATIVE_UINT_FAST64, H5T_NATIVE_UINT_FAST64_g);
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     extern_static!(H5T_STD_REF, H5T_STD_REF_g);
 }
 
@@ -536,17 +536,17 @@ mod globals {
     extern_static!(H5T_NATIVE_UINT_LEAST64, __imp_H5T_NATIVE_UINT_LEAST64_g);
     extern_static!(H5T_NATIVE_INT_FAST64, __imp_H5T_NATIVE_INT_FAST64_g);
     extern_static!(H5T_NATIVE_UINT_FAST64, __imp_H5T_NATIVE_UINT_FAST64_g);
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     extern_static!(H5T_STD_REF, __imp_H5T_STD_REF_g);
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 extern "C" {
     pub fn H5Tflush(type_id: hid_t) -> herr_t;
     pub fn H5Trefresh(type_id: hid_t) -> herr_t;
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 extern "C" {
     pub fn H5Treclaim(type_id: hid_t, space_id: hid_t, dxpl_id: hid_t, buf: *mut c_void) -> herr_t;
 }

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -1,5 +1,5 @@
 //! Using the Virtual Object Layer
-#![cfg(hdf5_1_12_0)]
+#![cfg(feature = "1.12.0")]
 use crate::internal_prelude::*;
 
 pub type H5VL_class_value_t = c_int;

--- a/hdf5-sys/src/lib.rs
+++ b/hdf5-sys/src/lib.rs
@@ -14,7 +14,7 @@ macro_rules! extern_static {
     };
 }
 
-#[cfg(all(feature = "mpio", not(h5_have_parallel)))]
+#[cfg(all(feature = "mpio", not(feature = "have-parallel")))]
 compile_error!("Enabling \"mpio\" feature requires HDF5 library built with MPI support");
 
 #[cfg(all(feature = "mpio", feature = "static"))]

--- a/hdf5-sys/src/lib.rs
+++ b/hdf5-sys/src/lib.rs
@@ -40,7 +40,7 @@ pub mod h5t;
 pub mod h5vl;
 pub mod h5z;
 
-#[cfg(hdf5_1_8_15)]
+#[cfg(feature = "1.8.15")]
 pub mod h5pl;
 
 #[allow(non_camel_case_types)]

--- a/hdf5-sys/src/lib.rs
+++ b/hdf5-sys/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::missing_safety_doc))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::cognitive_complexity))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::upper_case_acronyms))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 macro_rules! extern_static {
     ($dest:ident, $src:ident) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use std::ptr;
 
 use ndarray::ShapeError;
 
-#[cfg(not(hdf5_1_10_0))]
+#[cfg(not(feature = "1.10.0"))]
 use hdf5_sys::h5::hssize_t;
 use hdf5_sys::h5e::{
     H5E_auto2_t, H5E_error2_t, H5Eget_current_stack, H5Eget_msg, H5Eprint2, H5Eset_auto2, H5Ewalk2,
@@ -301,14 +301,14 @@ impl H5ErrorCode for herr_t {
     }
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 impl H5ErrorCode for hid_t {
     fn is_err_code(value: Self) -> bool {
         value < 0
     }
 }
 
-#[cfg(not(hdf5_1_10_0))]
+#[cfg(not(feature = "1.10.0"))]
 impl H5ErrorCode for hssize_t {
     fn is_err_code(value: Self) -> bool {
         value < 0

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -16,10 +16,10 @@ use hdf5_sys::{h5e, h5p, h5t};
 
 use crate::internal_prelude::*;
 
-#[cfg(dll_indirection)]
-pub struct H5GlobalConstant(&'static usize);
-#[cfg(not(dll_indirection))]
-pub struct H5GlobalConstant(&'static hdf5_sys::h5i::hid_t);
+pub struct H5GlobalConstant(
+    #[cfg(dll_indirection)] &'static usize,
+    #[cfg(not(dll_indirection))] &'static hdf5_sys::h5i::hid_t,
+);
 
 impl std::ops::Deref for H5GlobalConstant {
     type Target = hdf5_sys::h5i::hid_t;

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -4,9 +4,9 @@ use std::mem;
 
 use lazy_static::lazy_static;
 
-#[cfg(h5_have_direct)]
+#[cfg(have_direct)]
 use hdf5_sys::h5fd::H5FD_direct_init;
-#[cfg(h5_have_parallel)]
+#[cfg(have_parallel)]
 use hdf5_sys::h5fd::H5FD_mpio_init;
 use hdf5_sys::h5fd::{
     H5FD_core_init, H5FD_family_init, H5FD_log_init, H5FD_multi_init, H5FD_sec2_init,
@@ -16,9 +16,9 @@ use hdf5_sys::{h5e, h5p, h5t};
 
 use crate::internal_prelude::*;
 
-#[cfg(h5_dll_indirection)]
+#[cfg(dll_indirection)]
 pub struct H5GlobalConstant(&'static usize);
-#[cfg(not(h5_dll_indirection))]
+#[cfg(not(dll_indirection))]
 pub struct H5GlobalConstant(&'static hdf5_sys::h5i::hid_t);
 
 impl std::ops::Deref for H5GlobalConstant {
@@ -26,7 +26,7 @@ impl std::ops::Deref for H5GlobalConstant {
     fn deref(&self) -> &Self::Target {
         lazy_static::initialize(&crate::sync::LIBRARY_INIT);
         cfg_if::cfg_if! {
-            if #[cfg(h5_dll_indirection)] {
+            if #[cfg(dll_indirection)] {
                 let dll_ptr = self.0 as *const usize;
                 let ptr: *const *const hdf5_sys::h5i::hid_t = dll_ptr.cast();
                 unsafe {
@@ -336,21 +336,21 @@ lazy_static! {
 }
 
 // MPI-IO file driver
-#[cfg(h5_have_parallel)]
+#[cfg(have_parallel)]
 lazy_static! {
     pub static ref H5FD_MPIO: hid_t = unsafe { h5lock!(H5FD_mpio_init()) };
 }
-#[cfg(not(h5_have_parallel))]
+#[cfg(not(have_parallel))]
 lazy_static! {
     pub static ref H5FD_MPIO: hid_t = H5I_INVALID_HID;
 }
 
 // Direct VFD
-#[cfg(h5_have_direct)]
+#[cfg(have_direct)]
 lazy_static! {
     pub static ref H5FD_DIRECT: hid_t = unsafe { h5lock!(H5FD_direct_init()) };
 }
-#[cfg(not(h5_have_direct))]
+#[cfg(not(have_direct))]
 lazy_static! {
     pub static ref H5FD_DIRECT: hid_t = H5I_INVALID_HID;
 }

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -8,7 +8,7 @@ use hdf5_sys::h5d::{
     H5Dcreate2, H5Dcreate_anon, H5Dget_access_plist, H5Dget_create_plist, H5Dget_offset,
     H5Dset_extent,
 };
-#[cfg(hdf5_1_10_5)]
+#[cfg(feature = "1.10.5")]
 use hdf5_sys::h5d::{H5Dget_chunk_info, H5Dget_num_chunks};
 use hdf5_sys::h5l::H5Ldelete;
 use hdf5_sys::h5p::H5P_DEFAULT;
@@ -18,10 +18,10 @@ use hdf5_types::{OwnedDynValue, TypeDescriptor};
 #[cfg(feature = "blosc")]
 use crate::hl::filters::{Blosc, BloscShuffle};
 use crate::hl::filters::{Filter, SZip, ScaleOffset};
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use crate::hl::plist::dataset_access::VirtualView;
 use crate::hl::plist::dataset_access::{DatasetAccess, DatasetAccessBuilder};
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use crate::hl::plist::dataset_create::ChunkOpts;
 use crate::hl::plist::dataset_create::{
     AllocTime, AttrCreationOrder, DatasetCreate, DatasetCreateBuilder, FillTime, Layout,
@@ -66,7 +66,7 @@ impl Deref for Dataset {
     }
 }
 
-#[cfg(hdf5_1_10_5)]
+#[cfg(feature = "1.10.5")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChunkInfo {
     /// Array with a size equal to the dataset’s rank whose elements contain 0-based
@@ -83,7 +83,7 @@ pub struct ChunkInfo {
     pub size: u64,
 }
 
-#[cfg(hdf5_1_10_5)]
+#[cfg(feature = "1.10.5")]
 impl ChunkInfo {
     pub(crate) fn new(ndim: usize) -> Self {
         let mut offset = Vec::with_capacity(ndim);
@@ -133,7 +133,7 @@ impl Dataset {
         self.dcpl().map_or(Layout::default(), |pl| pl.layout())
     }
 
-    #[cfg(hdf5_1_10_5)]
+    #[cfg(feature = "1.10.5")]
     /// Returns the number of chunks if the dataset is chunked.
     pub fn num_chunks(&self) -> Option<usize> {
         if !self.is_chunked() {
@@ -145,7 +145,7 @@ impl Dataset {
         }))
     }
 
-    #[cfg(hdf5_1_10_5)]
+    #[cfg(feature = "1.10.5")]
     /// Retrieves the chunk information for the chunk specified by its index.
     pub fn chunk_info(&self, index: usize) -> Option<ChunkInfo> {
         if !self.is_chunked() {
@@ -596,22 +596,22 @@ impl DatasetBuilderInner {
         self.with_dapl(|pl| pl.chunk_cache(nslots, nbytes, w0));
     }
 
-    #[cfg(hdf5_1_8_17)]
+    #[cfg(feature = "1.8.17")]
     pub fn efile_prefix(&mut self, prefix: &str) {
         self.with_dapl(|pl| pl.efile_prefix(prefix));
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_view(&mut self, view: VirtualView) {
         self.with_dapl(|pl| pl.virtual_view(view));
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_printf_gap(&mut self, gap_size: usize) {
         self.with_dapl(|pl| pl.virtual_printf_gap(gap_size));
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) {
         self.with_dapl(|pl| pl.all_coll_metadata_ops(is_collective));
     }
@@ -773,7 +773,7 @@ impl DatasetBuilderInner {
         self.with_dcpl(|pl| pl.layout(layout));
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn chunk_opts(&mut self, opts: ChunkOpts) {
         self.with_dcpl(|pl| pl.chunk_opts(opts));
     }
@@ -782,7 +782,7 @@ impl DatasetBuilderInner {
         self.with_dcpl(|pl| pl.external(name, offset, size));
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_map<F, D, E1, S1, E2, S2>(
         &mut self, src_filename: F, src_dataset: D, src_extents: E1, src_selection: S1,
         vds_extents: E2, vds_selection: S2,
@@ -938,13 +938,13 @@ macro_rules! impl_builder_methods {
         impl_builder!(DatasetAccess: access/dapl);
 
         impl_builder!(DatasetAccess: chunk_cache(nslots: usize, nbytes: usize, w0: f64));
-        #[cfg(hdf5_1_8_17)]
+        #[cfg(feature = "1.8.17")]
         impl_builder!(DatasetAccess: efile_prefix(prefix: &str));
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         impl_builder!(DatasetAccess: virtual_view(view: VirtualView));
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         impl_builder!(DatasetAccess: virtual_printf_gap(gap_size: usize));
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         impl_builder!(DatasetAccess: all_coll_metadata_ops(is_collective: bool));
 
         impl_builder!(DatasetCreate: create/dcpl);
@@ -984,10 +984,10 @@ macro_rules! impl_builder_methods {
         impl_builder!(*: chunk_min_kb(size: usize));
         impl_builder!(DatasetCreate: no_chunk());
         impl_builder!(DatasetCreate: layout(layout: Layout));
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         impl_builder!(DatasetCreate: chunk_opts(opts: ChunkOpts));
         impl_builder!(DatasetCreate: external(name: &str, offset: usize, size: usize));
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         impl_builder!(
             DatasetCreate: virtual_map<
                 F: AsRef<str>, D: AsRef<str>,

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -907,12 +907,12 @@ macro_rules! impl_builder {
             self.builder.$name($($var),*); self
         }
     };
-    ($(#[cfg(feature = $feature:literal)])*
-     $(#[cfg(all(feature = $feature2:literal, feature = $feature3:literal))])*
-     $plist:ident: $name:ident($($var:ident: $ty:ty),*)) => {
+    (
+        $(#[cfg(feature = $feature:literal)])* $(#[cfg(all($(feature = $features:literal),*))])*
+        $plist:ident: $name:ident($($var:ident: $ty:ty),*)
+    ) => {
         paste::paste! {
-            $(#[cfg(feature = $feature )])*
-            $(#[cfg(all(feature = $feature2, feature = $feature3))])*
+            $(#[cfg(feature = $feature)])* $(#[cfg(all($(feature = $features),*))])*
             #[inline] #[must_use] #[doc =
                 "\u{21b3} [`" $plist "Builder::" $name "`]"
                 "(crate::plist::" $plist "Builder::" $name ")"
@@ -922,9 +922,12 @@ macro_rules! impl_builder {
             }
         }
     };
-    ($(#[cfg(feature = $feature:literal)])* $plist:ident: $name:ident<$($gid:ident: $gty:path),+>($($var:ident: $ty:ty),*)) => {
+    (
+        $(#[cfg(feature = $feature:literal)])* $(#[cfg(all($(feature = $features:literal),*))])*
+        $plist:ident: $name:ident<$($gid:ident: $gty:path),+>($($var:ident: $ty:ty),*)
+    ) => {
         paste::paste! {
-            $(#[cfg(feature = $feature )])*
+            $(#[cfg(feature = $feature)])* $(#[cfg(all($(feature = $features),*))])*
             #[inline] #[must_use] #[doc =
                 "\u{21b3} [`" $plist "Builder::" $name "`]"
                 "(crate::plist::" $plist "Builder::" $name ")"

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -611,7 +611,7 @@ impl DatasetBuilderInner {
         self.with_dapl(|pl| pl.virtual_printf_gap(gap_size));
     }
 
-    #[cfg(all(feature = "1.10.0", have_parallel))]
+    #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) {
         self.with_dapl(|pl| pl.all_coll_metadata_ops(is_collective));
     }
@@ -908,11 +908,11 @@ macro_rules! impl_builder {
         }
     };
     ($(#[cfg(feature = $feature:literal)])*
-     $(#[cfg(all(feature = $feature2:literal, $feature3:ident))])*
+     $(#[cfg(all(feature = $feature2:literal, feature = $feature3:literal))])*
      $plist:ident: $name:ident($($var:ident: $ty:ty),*)) => {
         paste::paste! {
             $(#[cfg(feature = $feature )])*
-            $(#[cfg(all(feature = $feature2, $feature3))])*
+            $(#[cfg(all(feature = $feature2, feature = $feature3))])*
             #[inline] #[must_use] #[doc =
                 "\u{21b3} [`" $plist "Builder::" $name "`]"
                 "(crate::plist::" $plist "Builder::" $name ")"
@@ -947,7 +947,7 @@ macro_rules! impl_builder_methods {
         impl_builder!(#[cfg(feature = "1.10.0")] DatasetAccess: virtual_view(view: VirtualView));
         impl_builder!(#[cfg(feature = "1.10.0")] DatasetAccess: virtual_printf_gap(gap_size: usize));
         impl_builder!(
-            #[cfg(all(feature = "1.10.0", have_parallel))]
+            #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
             DatasetAccess: all_coll_metadata_ops(is_collective: bool)
         );
 

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -907,8 +907,12 @@ macro_rules! impl_builder {
             self.builder.$name($($var),*); self
         }
     };
-    ($plist:ident: $name:ident($($var:ident: $ty:ty),*)) => {
+    ($(#[cfg(feature = $feature:literal)])*
+     $(#[cfg(all(feature = $feature2:literal, $feature3:ident))])*
+     $plist:ident: $name:ident($($var:ident: $ty:ty),*)) => {
         paste::paste! {
+            $(#[cfg(feature = $feature )])*
+            $(#[cfg(all(feature = $feature2, $feature3))])*
             #[inline] #[must_use] #[doc =
                 "\u{21b3} [`" $plist "Builder::" $name "`]"
                 "(crate::plist::" $plist "Builder::" $name ")"
@@ -918,8 +922,9 @@ macro_rules! impl_builder {
             }
         }
     };
-    ($plist:ident: $name:ident<$($gid:ident: $gty:path),+>($($var:ident: $ty:ty),*)) => {
+    ($(#[cfg(feature = $feature:literal)])* $plist:ident: $name:ident<$($gid:ident: $gty:path),+>($($var:ident: $ty:ty),*)) => {
         paste::paste! {
+            $(#[cfg(feature = $feature )])*
             #[inline] #[must_use] #[doc =
                 "\u{21b3} [`" $plist "Builder::" $name "`]"
                 "(crate::plist::" $plist "Builder::" $name ")"
@@ -938,14 +943,13 @@ macro_rules! impl_builder_methods {
         impl_builder!(DatasetAccess: access/dapl);
 
         impl_builder!(DatasetAccess: chunk_cache(nslots: usize, nbytes: usize, w0: f64));
-        #[cfg(feature = "1.8.17")]
-        impl_builder!(DatasetAccess: efile_prefix(prefix: &str));
-        #[cfg(feature = "1.10.0")]
-        impl_builder!(DatasetAccess: virtual_view(view: VirtualView));
-        #[cfg(feature = "1.10.0")]
-        impl_builder!(DatasetAccess: virtual_printf_gap(gap_size: usize));
-        #[cfg(all(feature = "1.10.0", have_parallel))]
-        impl_builder!(DatasetAccess: all_coll_metadata_ops(is_collective: bool));
+        impl_builder!(#[cfg(feature = "1.8.17")] DatasetAccess: efile_prefix(prefix: &str));
+        impl_builder!(#[cfg(feature = "1.10.0")] DatasetAccess: virtual_view(view: VirtualView));
+        impl_builder!(#[cfg(feature = "1.10.0")] DatasetAccess: virtual_printf_gap(gap_size: usize));
+        impl_builder!(
+            #[cfg(all(feature = "1.10.0", have_parallel))]
+            DatasetAccess: all_coll_metadata_ops(is_collective: bool)
+        );
 
         impl_builder!(DatasetCreate: create/dcpl);
 
@@ -956,24 +960,35 @@ macro_rules! impl_builder_methods {
         impl_builder!(DatasetCreate: szip(coding: SZip, px_per_block: u8));
         impl_builder!(DatasetCreate: nbit());
         impl_builder!(DatasetCreate: scale_offset(mode: ScaleOffset));
-        #[cfg(feature = "lzf")]
-        impl_builder!(DatasetCreate: lzf());
-        #[cfg(feature = "blosc")]
+        impl_builder!(#[cfg(feature = "lzf")] DatasetCreate: lzf());
         impl_builder!(
+            #[cfg(feature = "blosc")]
             DatasetCreate: blosc(complib: Blosc, clevel: u8, shuffle: impl Into<BloscShuffle>)
         );
-        #[cfg(feature = "blosc")]
-        impl_builder!(DatasetCreate: blosc_blosclz(clevel: u8, shuffle: impl Into<BloscShuffle>));
-        #[cfg(feature = "blosc")]
-        impl_builder!(DatasetCreate: blosc_lz4(clevel: u8, shuffle: impl Into<BloscShuffle>));
-        #[cfg(feature = "blosc")]
-        impl_builder!(DatasetCreate: blosc_lz4hc(clevel: u8, shuffle: impl Into<BloscShuffle>));
-        #[cfg(feature = "blosc")]
-        impl_builder!(DatasetCreate: blosc_snappy(clevel: u8, shuffle: impl Into<BloscShuffle>));
-        #[cfg(feature = "blosc")]
-        impl_builder!(DatasetCreate: blosc_zlib(clevel: u8, shuffle: impl Into<BloscShuffle>));
-        #[cfg(feature = "blosc")]
-        impl_builder!(DatasetCreate: blosc_zstd(clevel: u8, shuffle: impl Into<BloscShuffle>));
+        impl_builder!(
+            #[cfg(feature = "blosc")]
+            DatasetCreate: blosc_blosclz(clevel: u8, shuffle: impl Into<BloscShuffle>)
+        );
+        impl_builder!(
+            #[cfg(feature = "blosc")]
+            DatasetCreate: blosc_lz4(clevel: u8, shuffle: impl Into<BloscShuffle>)
+        );
+        impl_builder!(
+            #[cfg(feature = "blosc")]
+            DatasetCreate: blosc_lz4hc(clevel: u8, shuffle: impl Into<BloscShuffle>)
+        );
+        impl_builder!(
+            #[cfg(feature = "blosc")]
+            DatasetCreate: blosc_snappy(clevel: u8, shuffle: impl Into<BloscShuffle>)
+        );
+        impl_builder!(
+            #[cfg(feature = "blosc")]
+            DatasetCreate: blosc_zlib(clevel: u8, shuffle: impl Into<BloscShuffle>)
+        );
+        impl_builder!(
+            #[cfg(feature = "blosc")]
+            DatasetCreate: blosc_zstd(clevel: u8, shuffle: impl Into<BloscShuffle>)
+        );
         impl_builder!(DatasetCreate: add_filter(id: H5Z_filter_t, cdata: &[c_uint]));
         impl_builder!(DatasetCreate: clear_filters());
         impl_builder!(DatasetCreate: alloc_time(alloc_time: Option<AllocTime>));
@@ -984,11 +999,10 @@ macro_rules! impl_builder_methods {
         impl_builder!(*: chunk_min_kb(size: usize));
         impl_builder!(DatasetCreate: no_chunk());
         impl_builder!(DatasetCreate: layout(layout: Layout));
-        #[cfg(feature = "1.10.0")]
-        impl_builder!(DatasetCreate: chunk_opts(opts: ChunkOpts));
+        impl_builder!(#[cfg(feature = "1.10.0")] DatasetCreate: chunk_opts(opts: ChunkOpts));
         impl_builder!(DatasetCreate: external(name: &str, offset: usize, size: usize));
-        #[cfg(feature = "1.10.0")]
         impl_builder!(
+            #[cfg(feature = "1.10.0")]
             DatasetCreate: virtual_map<
                 F: AsRef<str>, D: AsRef<str>,
                 E1: Into<Extents>, S1: Into<Selection>, E2: Into<Extents>, S2: Into<Selection>

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -611,7 +611,7 @@ impl DatasetBuilderInner {
         self.with_dapl(|pl| pl.virtual_printf_gap(gap_size));
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) {
         self.with_dapl(|pl| pl.all_coll_metadata_ops(is_collective));
     }
@@ -944,7 +944,7 @@ macro_rules! impl_builder_methods {
         impl_builder!(DatasetAccess: virtual_view(view: VirtualView));
         #[cfg(feature = "1.10.0")]
         impl_builder!(DatasetAccess: virtual_printf_gap(gap_size: usize));
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         impl_builder!(DatasetAccess: all_coll_metadata_ops(is_collective: bool));
 
         impl_builder!(DatasetCreate: create/dcpl);

--- a/src/hl/datatype.rs
+++ b/src/hl/datatype.rs
@@ -128,7 +128,7 @@ pub enum ByteOrder {
     None,
 }
 
-#[cfg(hdf5_1_8_6)]
+#[cfg(feature = "1.8.6")]
 impl From<H5T_order_t> for ByteOrder {
     fn from(order: H5T_order_t) -> Self {
         match order {
@@ -141,7 +141,7 @@ impl From<H5T_order_t> for ByteOrder {
     }
 }
 
-#[cfg(not(hdf5_1_8_6))]
+#[cfg(not(feature = "1.8.6"))]
 impl From<H5T_order_t> for ByteOrder {
     fn from(order: H5T_order_t) -> Self {
         match order {

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -430,9 +430,9 @@ pub mod tests {
             assert!(file.size() > 0);
             let orig_size = fs::metadata(file.filename()).unwrap().len();
             assert!(file.size() > orig_size);
-            #[cfg(hdf5_1_10_0)]
+            #[cfg(feature = "1.10.0")]
             assert_ne!(orig_size, 0);
-            #[cfg(not(hdf5_1_10_0))]
+            #[cfg(not(feature = "1.10.0"))]
             assert_eq!(orig_size, 0);
             assert!(file.flush().is_ok());
             assert!(file.size() > 0);

--- a/src/hl/filters.rs
+++ b/src/hl/filters.rs
@@ -36,6 +36,7 @@ pub enum ScaleOffset {
 #[cfg(feature = "blosc")]
 mod blosc_impl {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[cfg(feature = "blosc")]
     pub enum Blosc {
         BloscLZ,
         LZ4,
@@ -46,18 +47,21 @@ mod blosc_impl {
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[cfg(feature = "blosc")]
     pub enum BloscShuffle {
         None,
         Byte,
         Bit,
     }
 
+    #[cfg(feature = "blosc")]
     impl Default for BloscShuffle {
         fn default() -> Self {
             Self::Byte
         }
     }
 
+    #[cfg(feature = "blosc")]
     impl From<bool> for BloscShuffle {
         fn from(shuffle: bool) -> Self {
             if shuffle {
@@ -68,16 +72,19 @@ mod blosc_impl {
         }
     }
 
+    #[cfg(feature = "blosc")]
     impl Default for Blosc {
         fn default() -> Self {
             Self::BloscLZ
         }
     }
 
+    #[cfg(feature = "blosc")]
     pub fn blosc_get_nthreads() -> u8 {
         h5lock!(super::blosc::blosc_get_nthreads()).max(0).min(255) as _
     }
 
+    #[cfg(feature = "blosc")]
     pub fn blosc_set_nthreads(num_threads: u8) -> u8 {
         use std::os::raw::c_int;
         let nthreads = h5lock!(super::blosc::blosc_set_nthreads(c_int::from(num_threads)));

--- a/src/hl/group.rs
+++ b/src/hl/group.rs
@@ -553,9 +553,9 @@ pub mod tests {
             assert!(group.link_exists("c"));
             assert!(!group.link_exists("a"));
             assert!(!group.link_exists("soft"));
-            #[cfg(not(hdf5_1_10_0))]
+            #[cfg(not(feature = "1.10.0"))]
             assert!(!group.link_exists("/"));
-            #[cfg(hdf5_1_10_0)]
+            #[cfg(feature = "1.10.0")]
             assert!(group.link_exists("/"));
         })
     }

--- a/src/hl/location.rs
+++ b/src/hl/location.rs
@@ -160,6 +160,7 @@ pub enum LocationType {
     Dataset,
     NamedDatatype,
     #[cfg(feature = "1.12.0")]
+    #[cfg_attr(docrs, doc(cfg(feature = "1.12.0")))]
     TypeMap,
 }
 

--- a/src/hl/location.rs
+++ b/src/hl/location.rs
@@ -148,13 +148,11 @@ impl Location {
     }
 }
 
-#[cfg(feature = "1.12.0")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct LocationToken(H5O_token_t);
-
-#[cfg(not(feature = "1.12.0"))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct LocationToken(haddr_t);
+pub struct LocationToken(
+    #[cfg(not(feature = "1.12.0"))] haddr_t,
+    #[cfg(feature = "1.12.0")] H5O_token_t,
+);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LocationType {

--- a/src/hl/location.rs
+++ b/src/hl/location.rs
@@ -5,17 +5,17 @@ use std::ptr;
 
 #[allow(deprecated)]
 use hdf5_sys::h5o::H5Oset_comment;
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 use hdf5_sys::h5o::{
     H5O_info2_t, H5O_token_t, H5Oget_info3, H5Oget_info_by_name3, H5Oopen_by_token,
 };
-#[cfg(not(hdf5_1_10_3))]
+#[cfg(not(feature = "1.10.3"))]
 use hdf5_sys::h5o::{H5Oget_info1, H5Oget_info_by_name1};
-#[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+#[cfg(all(feature = "1.10.3", not(feature = "1.12.0")))]
 use hdf5_sys::h5o::{H5Oget_info2, H5Oget_info_by_name2};
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 use hdf5_sys::h5o::{H5O_INFO_BASIC, H5O_INFO_NUM_ATTRS, H5O_INFO_TIME};
-#[cfg(not(hdf5_1_12_0))]
+#[cfg(not(feature = "1.12.0"))]
 use hdf5_sys::{h5::haddr_t, h5o::H5O_info1_t, h5o::H5Oopen_by_addr};
 use hdf5_sys::{
     h5a::H5Aopen,
@@ -148,11 +148,11 @@ impl Location {
     }
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LocationToken(H5O_token_t);
 
-#[cfg(not(hdf5_1_12_0))]
+#[cfg(not(feature = "1.12.0"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LocationToken(haddr_t);
 
@@ -161,7 +161,7 @@ pub enum LocationType {
     Group,
     Dataset,
     NamedDatatype,
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     TypeMap,
 }
 
@@ -173,7 +173,7 @@ impl From<H5O_type_t> for LocationType {
         match loc_type {
             H5O_type_t::H5O_TYPE_DATASET => Self::Dataset,
             H5O_type_t::H5O_TYPE_NAMED_DATATYPE => Self::NamedDatatype,
-            #[cfg(hdf5_1_12_0)]
+            #[cfg(feature = "1.12.0")]
             H5O_type_t::H5O_TYPE_MAP => Self::TypeMap,
             _ => Self::Group, // see the comment above
         }
@@ -216,7 +216,7 @@ pub struct LocationInfo {
     pub num_attrs: usize,
 }
 
-#[cfg(not(hdf5_1_12_0))]
+#[cfg(not(feature = "1.12.0"))]
 impl From<H5O_info1_t> for LocationInfo {
     fn from(info: H5O_info1_t) -> Self {
         Self {
@@ -233,7 +233,7 @@ impl From<H5O_info1_t> for LocationInfo {
     }
 }
 
-#[cfg(hdf5_1_12_0)]
+#[cfg(feature = "1.12.0")]
 impl From<H5O_info2_t> for LocationInfo {
     fn from(info: H5O_info2_t) -> Self {
         Self {
@@ -250,7 +250,7 @@ impl From<H5O_info2_t> for LocationInfo {
     }
 }
 
-#[cfg(hdf5_1_10_3)]
+#[cfg(feature = "1.10.3")]
 fn info_fields(full: bool) -> c_uint {
     if full {
         H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS | H5O_INFO_TIME
@@ -263,11 +263,11 @@ fn info_fields(full: bool) -> c_uint {
 fn H5O_get_info(loc_id: hid_t, full: bool) -> Result<LocationInfo> {
     let mut info_buf = MaybeUninit::uninit();
     let info_ptr = info_buf.as_mut_ptr();
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     h5call!(H5Oget_info3(loc_id, info_ptr, info_fields(full)))?;
-    #[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+    #[cfg(all(feature = "1.10.3", not(feature = "1.12.0")))]
     h5call!(H5Oget_info2(loc_id, info_ptr, info_fields(full)))?;
-    #[cfg(not(hdf5_1_10_3))]
+    #[cfg(not(feature = "1.10.3"))]
     h5call!(H5Oget_info1(loc_id, info_ptr))?;
     let info = unsafe { info_buf.assume_init() };
     Ok(info.into())
@@ -277,11 +277,11 @@ fn H5O_get_info(loc_id: hid_t, full: bool) -> Result<LocationInfo> {
 fn H5O_get_info_by_name(loc_id: hid_t, name: *const c_char, full: bool) -> Result<LocationInfo> {
     let mut info_buf = MaybeUninit::uninit();
     let info_ptr = info_buf.as_mut_ptr();
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     h5call!(H5Oget_info_by_name3(loc_id, name, info_ptr, info_fields(full), H5P_DEFAULT))?;
-    #[cfg(all(hdf5_1_10_3, not(hdf5_1_12_0)))]
+    #[cfg(all(feature = "1.10.3", not(feature = "1.12.0")))]
     h5call!(H5Oget_info_by_name2(loc_id, name, info_ptr, info_fields(full), H5P_DEFAULT))?;
-    #[cfg(not(hdf5_1_10_3))]
+    #[cfg(not(feature = "1.10.3"))]
     h5call!(H5Oget_info_by_name1(loc_id, name, info_ptr, H5P_DEFAULT))?;
     let info = unsafe { info_buf.assume_init() };
     Ok(info.into())
@@ -289,11 +289,11 @@ fn H5O_get_info_by_name(loc_id: hid_t, name: *const c_char, full: bool) -> Resul
 
 #[allow(non_snake_case)]
 fn H5O_open_by_token(loc_id: hid_t, token: LocationToken) -> Result<Location> {
-    #[cfg(not(hdf5_1_12_0))]
+    #[cfg(not(feature = "1.12.0"))]
     {
         Location::from_id(h5call!(H5Oopen_by_addr(loc_id, token.0))?)
     }
-    #[cfg(hdf5_1_12_0)]
+    #[cfg(feature = "1.12.0")]
     {
         Location::from_id(h5call!(H5Oopen_by_token(loc_id, token.0))?)
     }
@@ -340,7 +340,7 @@ pub mod tests {
     pub fn test_location_info() {
         let new_file = |path| {
             cfg_if::cfg_if! {
-                if #[cfg(hdf5_1_10_2)] {
+                if #[cfg(feature = "1.10.2")] {
                     File::with_options().with_fapl(|p| p.libver_v110()).create(path)
                 } else {
                     File::create(path)
@@ -356,7 +356,7 @@ pub mod tests {
                 assert_eq!(info.num_links, 1);
                 assert_eq!(info.loc_type, LocationType::Group);
                 cfg_if::cfg_if! {
-                    if #[cfg(hdf5_1_10_2)] {
+                    if #[cfg(feature = "1.10.2")] {
                         assert!(info.btime > 0);
                     } else {
                         assert_eq!(info.btime, 0);
@@ -393,7 +393,7 @@ pub mod tests {
                 assert_eq!(info.loc_type, LocationType::Dataset);
                 assert!(info.ctime > 0);
                 cfg_if::cfg_if! {
-                    if #[cfg(hdf5_1_10_2)] {
+                    if #[cfg(feature = "1.10.2")] {
                         assert!(info.btime > 0);
                     } else {
                         assert_eq!(info.btime, 0);

--- a/src/hl/plist/dataset_access.rs
+++ b/src/hl/plist/dataset_access.rs
@@ -9,11 +9,11 @@ use std::fmt::{self, Debug};
 use std::ops::Deref;
 
 use hdf5_sys::h5p::{H5Pcreate, H5Pget_chunk_cache, H5Pset_chunk_cache};
-#[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+#[cfg(all(feature = "1.10.0", h5_have_parallel))]
 use hdf5_sys::h5p::{H5Pget_all_coll_metadata_ops, H5Pset_all_coll_metadata_ops};
-#[cfg(hdf5_1_8_17)]
+#[cfg(feature = "1.8.17")]
 use hdf5_sys::h5p::{H5Pget_efile_prefix, H5Pset_efile_prefix};
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use hdf5_sys::{
     h5d::H5D_vds_view_t,
     h5p::{
@@ -55,14 +55,14 @@ impl Debug for DatasetAccess {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = f.debug_struct("DatasetAccess");
         formatter.field("chunk_cache", &self.chunk_cache());
-        #[cfg(hdf5_1_8_17)]
+        #[cfg(feature = "1.8.17")]
         formatter.field("efile_prefix", &self.efile_prefix());
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         {
             formatter.field("virtual_view", &self.virtual_view());
             formatter.field("virtual_printf_gap", &self.virtual_printf_gap());
         }
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         formatter.field("all_coll_metadata_ops", &self.all_coll_metadata_ops());
         formatter.finish()
     }
@@ -90,21 +90,21 @@ impl Clone for DatasetAccess {
     }
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VirtualView {
     FirstMissing,
     LastAvailable,
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 impl Default for VirtualView {
     fn default() -> Self {
         Self::LastAvailable
     }
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 impl From<H5D_vds_view_t> for VirtualView {
     fn from(view: H5D_vds_view_t) -> Self {
         match view {
@@ -114,7 +114,7 @@ impl From<H5D_vds_view_t> for VirtualView {
     }
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 impl From<VirtualView> for H5D_vds_view_t {
     fn from(v: VirtualView) -> Self {
         match v {
@@ -128,13 +128,13 @@ impl From<VirtualView> for H5D_vds_view_t {
 #[derive(Clone, Debug, Default)]
 pub struct DatasetAccessBuilder {
     chunk_cache: Option<ChunkCache>,
-    #[cfg(hdf5_1_8_17)]
+    #[cfg(feature = "1.8.17")]
     efile_prefix: Option<String>,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     virtual_view: Option<VirtualView>,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     virtual_printf_gap: Option<usize>,
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     all_coll_metadata_ops: Option<bool>,
 }
 
@@ -149,17 +149,17 @@ impl DatasetAccessBuilder {
         let mut builder = Self::default();
         let v = plist.get_chunk_cache()?;
         builder.chunk_cache(v.nslots, v.nbytes, v.w0);
-        #[cfg(hdf5_1_8_17)]
+        #[cfg(feature = "1.8.17")]
         {
             let v = plist.get_efile_prefix()?;
             builder.efile_prefix(&v);
         }
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         {
             builder.virtual_view(plist.get_virtual_view()?);
             builder.virtual_printf_gap(plist.get_virtual_printf_gap()?);
         }
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         builder.all_coll_metadata_ops(plist.get_all_coll_metadata_ops()?);
         Ok(builder)
     }
@@ -169,25 +169,25 @@ impl DatasetAccessBuilder {
         self
     }
 
-    #[cfg(hdf5_1_8_17)]
+    #[cfg(feature = "1.8.17")]
     pub fn efile_prefix(&mut self, prefix: &str) -> &mut Self {
         self.efile_prefix = Some(prefix.into());
         self
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_view(&mut self, view: VirtualView) -> &mut Self {
         self.virtual_view = Some(view);
         self
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_printf_gap(&mut self, gap_size: usize) -> &mut Self {
         self.virtual_printf_gap = Some(gap_size);
         self
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) -> &mut Self {
         self.all_coll_metadata_ops = Some(is_collective);
         self
@@ -197,14 +197,14 @@ impl DatasetAccessBuilder {
         if let Some(v) = self.chunk_cache {
             h5try!(H5Pset_chunk_cache(id, v.nslots as _, v.nbytes as _, v.w0 as _));
         }
-        #[cfg(hdf5_1_8_17)]
+        #[cfg(feature = "1.8.17")]
         {
             if let Some(ref v) = self.efile_prefix {
                 let v = to_cstring(v.as_ref())?;
                 h5try!(H5Pset_efile_prefix(id, v.as_ptr()));
             }
         }
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         {
             if let Some(v) = self.virtual_view {
                 h5try!(H5Pset_virtual_view(id, v.into()));
@@ -213,7 +213,7 @@ impl DatasetAccessBuilder {
                 h5try!(H5Pset_virtual_printf_gap(id, v as _));
             }
         }
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         {
             if let Some(v) = self.all_coll_metadata_ops {
                 h5try!(H5Pset_all_coll_metadata_ops(id, v as _));
@@ -263,46 +263,46 @@ impl DatasetAccess {
         self.get_chunk_cache().unwrap_or_else(|_| ChunkCache::default())
     }
 
-    #[cfg(hdf5_1_8_17)]
+    #[cfg(feature = "1.8.17")]
     #[doc(hidden)]
     pub fn get_efile_prefix(&self) -> Result<String> {
         h5lock!(get_h5_str(|m, s| H5Pget_efile_prefix(self.id(), m, s)))
     }
 
-    #[cfg(hdf5_1_8_17)]
+    #[cfg(feature = "1.8.17")]
     pub fn efile_prefix(&self) -> String {
         self.get_efile_prefix().ok().unwrap_or_else(|| "".into())
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     #[doc(hidden)]
     pub fn get_virtual_view(&self) -> Result<VirtualView> {
         h5get!(H5Pget_virtual_view(self.id()): H5D_vds_view_t).map(Into::into)
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_view(&self) -> VirtualView {
         self.get_virtual_view().ok().unwrap_or_default()
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     #[doc(hidden)]
     pub fn get_virtual_printf_gap(&self) -> Result<usize> {
         h5get!(H5Pget_virtual_printf_gap(self.id()): hsize_t).map(|x| x as _)
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_printf_gap(&self) -> usize {
         self.get_virtual_printf_gap().unwrap_or(0)
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     #[doc(hidden)]
     pub fn get_all_coll_metadata_ops(&self) -> Result<bool> {
         h5get!(H5Pget_all_coll_metadata_ops(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     pub fn all_coll_metadata_ops(&self) -> bool {
         self.get_all_coll_metadata_ops().unwrap_or(false)
     }

--- a/src/hl/plist/dataset_access.rs
+++ b/src/hl/plist/dataset_access.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug};
 use std::ops::Deref;
 
 use hdf5_sys::h5p::{H5Pcreate, H5Pget_chunk_cache, H5Pset_chunk_cache};
-#[cfg(all(feature = "1.10.0", h5_have_parallel))]
+#[cfg(all(feature = "1.10.0", have_parallel))]
 use hdf5_sys::h5p::{H5Pget_all_coll_metadata_ops, H5Pset_all_coll_metadata_ops};
 #[cfg(feature = "1.8.17")]
 use hdf5_sys::h5p::{H5Pget_efile_prefix, H5Pset_efile_prefix};
@@ -62,7 +62,7 @@ impl Debug for DatasetAccess {
             formatter.field("virtual_view", &self.virtual_view());
             formatter.field("virtual_printf_gap", &self.virtual_printf_gap());
         }
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         formatter.field("all_coll_metadata_ops", &self.all_coll_metadata_ops());
         formatter.finish()
     }
@@ -134,7 +134,7 @@ pub struct DatasetAccessBuilder {
     virtual_view: Option<VirtualView>,
     #[cfg(feature = "1.10.0")]
     virtual_printf_gap: Option<usize>,
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     all_coll_metadata_ops: Option<bool>,
 }
 
@@ -159,7 +159,7 @@ impl DatasetAccessBuilder {
             builder.virtual_view(plist.get_virtual_view()?);
             builder.virtual_printf_gap(plist.get_virtual_printf_gap()?);
         }
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         builder.all_coll_metadata_ops(plist.get_all_coll_metadata_ops()?);
         Ok(builder)
     }
@@ -187,7 +187,7 @@ impl DatasetAccessBuilder {
         self
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) -> &mut Self {
         self.all_coll_metadata_ops = Some(is_collective);
         self
@@ -213,7 +213,7 @@ impl DatasetAccessBuilder {
                 h5try!(H5Pset_virtual_printf_gap(id, v as _));
             }
         }
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         {
             if let Some(v) = self.all_coll_metadata_ops {
                 h5try!(H5Pset_all_coll_metadata_ops(id, v as _));
@@ -296,13 +296,13 @@ impl DatasetAccess {
         self.get_virtual_printf_gap().unwrap_or(0)
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     #[doc(hidden)]
     pub fn get_all_coll_metadata_ops(&self) -> Result<bool> {
         h5get!(H5Pget_all_coll_metadata_ops(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     pub fn all_coll_metadata_ops(&self) -> bool {
         self.get_all_coll_metadata_ops().unwrap_or(false)
     }

--- a/src/hl/plist/dataset_access.rs
+++ b/src/hl/plist/dataset_access.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug};
 use std::ops::Deref;
 
 use hdf5_sys::h5p::{H5Pcreate, H5Pget_chunk_cache, H5Pset_chunk_cache};
-#[cfg(all(feature = "1.10.0", have_parallel))]
+#[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
 use hdf5_sys::h5p::{H5Pget_all_coll_metadata_ops, H5Pset_all_coll_metadata_ops};
 #[cfg(feature = "1.8.17")]
 use hdf5_sys::h5p::{H5Pget_efile_prefix, H5Pset_efile_prefix};
@@ -62,7 +62,7 @@ impl Debug for DatasetAccess {
             formatter.field("virtual_view", &self.virtual_view());
             formatter.field("virtual_printf_gap", &self.virtual_printf_gap());
         }
-        #[cfg(all(feature = "1.10.0", have_parallel))]
+        #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
         formatter.field("all_coll_metadata_ops", &self.all_coll_metadata_ops());
         formatter.finish()
     }
@@ -134,7 +134,7 @@ pub struct DatasetAccessBuilder {
     virtual_view: Option<VirtualView>,
     #[cfg(feature = "1.10.0")]
     virtual_printf_gap: Option<usize>,
-    #[cfg(all(feature = "1.10.0", have_parallel))]
+    #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
     all_coll_metadata_ops: Option<bool>,
 }
 
@@ -159,7 +159,7 @@ impl DatasetAccessBuilder {
             builder.virtual_view(plist.get_virtual_view()?);
             builder.virtual_printf_gap(plist.get_virtual_printf_gap()?);
         }
-        #[cfg(all(feature = "1.10.0", have_parallel))]
+        #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
         builder.all_coll_metadata_ops(plist.get_all_coll_metadata_ops()?);
         Ok(builder)
     }
@@ -187,7 +187,7 @@ impl DatasetAccessBuilder {
         self
     }
 
-    #[cfg(all(feature = "1.10.0", have_parallel))]
+    #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) -> &mut Self {
         self.all_coll_metadata_ops = Some(is_collective);
         self
@@ -213,7 +213,7 @@ impl DatasetAccessBuilder {
                 h5try!(H5Pset_virtual_printf_gap(id, v as _));
             }
         }
-        #[cfg(all(feature = "1.10.0", have_parallel))]
+        #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
         {
             if let Some(v) = self.all_coll_metadata_ops {
                 h5try!(H5Pset_all_coll_metadata_ops(id, v as _));
@@ -296,13 +296,13 @@ impl DatasetAccess {
         self.get_virtual_printf_gap().unwrap_or(0)
     }
 
-    #[cfg(all(feature = "1.10.0", have_parallel))]
+    #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
     #[doc(hidden)]
     pub fn get_all_coll_metadata_ops(&self) -> Result<bool> {
         h5get!(H5Pget_all_coll_metadata_ops(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(all(feature = "1.10.0", have_parallel))]
+    #[cfg(all(feature = "1.10.0", feature = "have-parallel"))]
     pub fn all_coll_metadata_ops(&self) -> bool {
         self.get_all_coll_metadata_ops().unwrap_or(false)
     }

--- a/src/hl/plist/dataset_create.rs
+++ b/src/hl/plist/dataset_create.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug};
 use std::ops::Deref;
 use std::ptr;
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use bitflags::bitflags;
 
 use hdf5_sys::h5d::{H5D_alloc_time_t, H5D_fill_time_t, H5D_fill_value_t, H5D_layout_t};
@@ -19,7 +19,7 @@ use hdf5_sys::h5p::{
 };
 use hdf5_sys::h5t::H5Tget_class;
 use hdf5_sys::h5z::H5Z_filter_t;
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use hdf5_sys::{
     h5d::H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS,
     h5p::{
@@ -72,10 +72,10 @@ impl Debug for DatasetCreate {
         formatter.field("fill_value", &self.fill_value_defined());
         formatter.field("chunk", &self.chunk());
         formatter.field("layout", &self.layout());
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         formatter.field("chunk_opts", &self.chunk_opts());
         formatter.field("external", &self.external());
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         formatter.field("virtual_map", &self.virtual_map());
         formatter.field("obj_track_times", &self.obj_track_times());
         formatter.field("attr_phase_change", &self.attr_phase_change());
@@ -111,7 +111,7 @@ pub enum Layout {
     Compact,
     Contiguous,
     Chunked,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     Virtual,
 }
 
@@ -126,7 +126,7 @@ impl From<H5D_layout_t> for Layout {
         match layout {
             H5D_layout_t::H5D_COMPACT => Self::Compact,
             H5D_layout_t::H5D_CHUNKED => Self::Chunked,
-            #[cfg(hdf5_1_10_0)]
+            #[cfg(feature = "1.10.0")]
             H5D_layout_t::H5D_VIRTUAL => Self::Virtual,
             _ => Self::Contiguous,
         }
@@ -138,21 +138,21 @@ impl From<Layout> for H5D_layout_t {
         match layout {
             Layout::Compact => Self::H5D_COMPACT,
             Layout::Chunked => Self::H5D_CHUNKED,
-            #[cfg(hdf5_1_10_0)]
+            #[cfg(feature = "1.10.0")]
             Layout::Virtual => Self::H5D_VIRTUAL,
             Layout::Contiguous => Self::H5D_CONTIGUOUS,
         }
     }
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 bitflags! {
     pub struct ChunkOpts: u32 {
         const DONT_FILTER_PARTIAL_CHUNKS = H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS;
     }
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 impl Default for ChunkOpts {
     fn default() -> Self {
         Self::DONT_FILTER_PARTIAL_CHUNKS
@@ -259,7 +259,7 @@ pub struct ExternalFile {
     pub size: usize,
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VirtualMapping {
     pub src_filename: String,
@@ -270,7 +270,7 @@ pub struct VirtualMapping {
     pub vds_selection: Selection,
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 impl VirtualMapping {
     pub fn new<F, D, E1, S1, E2, S2>(
         src_filename: F, src_dataset: D, src_extents: E1, src_selection: S1, vds_extents: E2,
@@ -305,10 +305,10 @@ pub struct DatasetCreateBuilder {
     fill_value: Option<OwnedDynValue>,
     chunk: Option<Vec<usize>>,
     layout: Option<Layout>,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     chunk_opts: Option<ChunkOpts>,
     external: Vec<ExternalFile>,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     virtual_map: Vec<VirtualMapping>,
     obj_track_times: Option<bool>,
     attr_phase_change: Option<AttrPhaseChange>,
@@ -335,7 +335,7 @@ impl DatasetCreateBuilder {
         }
         let layout = plist.get_layout()?;
         builder.layout(layout);
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         {
             if let Some(v) = plist.get_chunk_opts()? {
                 builder.chunk_opts(v);
@@ -529,7 +529,7 @@ impl DatasetCreateBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn chunk_opts(&mut self, opts: ChunkOpts) -> &mut Self {
         self.chunk_opts = Some(opts);
         self
@@ -540,7 +540,7 @@ impl DatasetCreateBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_map<F, D, E1, S1, E2, S2>(
         &mut self, src_filename: F, src_dataset: D, src_extents: E1, src_selection: S1,
         vds_extents: E2, vds_selection: S2,
@@ -601,7 +601,7 @@ impl DatasetCreateBuilder {
             let v = v.iter().map(|&x| x as _).collect::<Vec<_>>();
             h5try!(H5Pset_chunk(id, v.len() as _, v.as_ptr()));
         }
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         {
             if let Some(v) = self.chunk_opts {
                 h5try!(H5Pset_chunk_opts(id, v.bits() as _));
@@ -778,7 +778,7 @@ impl DatasetCreate {
         self.get_layout().unwrap_or_default()
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     #[doc(hidden)]
     pub fn get_chunk_opts(&self) -> Result<Option<ChunkOpts>> {
         if let Layout::Chunked = self.get_layout()? {
@@ -789,7 +789,7 @@ impl DatasetCreate {
         }
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn chunk_opts(&self) -> Option<ChunkOpts> {
         self.get_chunk_opts().unwrap_or_default()
     }
@@ -827,7 +827,7 @@ impl DatasetCreate {
         self.get_external().unwrap_or_default()
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     #[doc(hidden)]
     pub fn get_virtual_map(&self) -> Result<Vec<VirtualMapping>> {
         sync(|| unsafe {
@@ -863,7 +863,7 @@ impl DatasetCreate {
         })
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn virtual_map(&self) -> Vec<VirtualMapping> {
         self.get_virtual_map().unwrap_or_default()
     }

--- a/src/hl/plist/file_access.rs
+++ b/src/hl/plist/file_access.rs
@@ -47,27 +47,27 @@ use hdf5_sys::h5p::{H5Pget_fapl_direct, H5Pset_fapl_direct};
 #[cfg(feature = "mpio")]
 use hdf5_sys::h5p::{H5Pget_fapl_mpio, H5Pset_fapl_mpio};
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 use hdf5_sys::h5ac::{H5AC_cache_image_config_t, H5AC__CACHE_IMAGE__ENTRY_AGEOUT__NONE};
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 use hdf5_sys::h5f::H5F_libver_t;
-#[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+#[cfg(all(feature = "1.10.0", h5_have_parallel))]
 use hdf5_sys::h5p::{
     H5Pget_all_coll_metadata_ops, H5Pget_coll_metadata_write, H5Pset_all_coll_metadata_ops,
     H5Pset_coll_metadata_write,
 };
-#[cfg(hdf5_1_8_13)]
+#[cfg(feature = "1.8.13")]
 use hdf5_sys::h5p::{H5Pget_core_write_tracking, H5Pset_core_write_tracking};
-#[cfg(hdf5_1_8_7)]
+#[cfg(feature = "1.8.7")]
 use hdf5_sys::h5p::{H5Pget_elink_file_cache_size, H5Pset_elink_file_cache_size};
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 use hdf5_sys::h5p::{
     H5Pget_evict_on_close, H5Pget_mdc_image_config, H5Pget_page_buffer_size, H5Pset_evict_on_close,
     H5Pset_mdc_image_config, H5Pset_page_buffer_size,
 };
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 use hdf5_sys::h5p::{H5Pget_libver_bounds, H5Pset_libver_bounds};
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use hdf5_sys::h5p::{
     H5Pget_mdc_log_options, H5Pget_metadata_read_attempts, H5Pset_mdc_log_options,
     H5Pset_metadata_read_attempts,
@@ -115,25 +115,25 @@ impl Debug for FileAccess {
         formatter.field("fclose_degree", &self.fclose_degree());
         formatter.field("gc_references", &self.gc_references());
         formatter.field("small_data_block_size", &self.small_data_block_size());
-        #[cfg(hdf5_1_10_2)]
+        #[cfg(feature = "1.10.2")]
         formatter.field("libver_bounds", &self.libver_bounds());
-        #[cfg(hdf5_1_8_7)]
+        #[cfg(feature = "1.8.7")]
         formatter.field("elink_file_cache_size", &self.elink_file_cache_size());
         formatter.field("meta_block_size", &self.meta_block_size());
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         formatter.field("page_buffer_size", &self.page_buffer_size());
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         formatter.field("evict_on_close", &self.evict_on_close());
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         formatter.field("mdc_image_config", &self.mdc_image_config());
         formatter.field("sieve_buf_size", &self.sieve_buf_size());
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         formatter.field("metadata_read_attempts", &self.metadata_read_attempts());
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         formatter.field("mdc_log_options", &self.mdc_log_options());
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         formatter.field("all_coll_metadata_ops", &self.all_coll_metadata_ops());
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         formatter.field("coll_metadata_write", &self.coll_metadata_write());
         formatter.field("mdc_config", &self.mdc_config());
         formatter.field("driver", &self.driver());
@@ -167,7 +167,7 @@ impl Clone for FileAccess {
 pub struct CoreDriver {
     pub increment: usize,
     pub filebacked: bool,
-    #[cfg(hdf5_1_8_13)]
+    #[cfg(feature = "1.8.13")]
     pub write_tracking: usize,
 }
 
@@ -176,7 +176,7 @@ impl Default for CoreDriver {
         Self {
             increment: 1024 * 1024,
             filebacked: false,
-            #[cfg(hdf5_1_8_13)]
+            #[cfg(feature = "1.8.13")]
             write_tracking: 0,
         }
     }
@@ -365,7 +365,7 @@ impl SplitDriver {
             mem_lheap: 0,
             mem_object: 0,
         };
-        if cfg!(hdf5_1_8_10) {
+        if cfg!(feature = "1.8.10") {
             layout.mem_gheap = 1; // was changed in 1.8.10
         }
         let is_split = drv.relax
@@ -816,7 +816,7 @@ impl From<H5AC_cache_config_t> for MetadataCacheConfig {
     }
 }
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 mod cache_image_config {
     use super::*;
 
@@ -859,10 +859,10 @@ mod cache_image_config {
     }
 }
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 pub use self::cache_image_config::*;
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheLogOptions {
     pub is_enabled: bool,
@@ -870,14 +870,14 @@ pub struct CacheLogOptions {
     pub start_on_access: bool,
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 impl Default for CacheLogOptions {
     fn default() -> Self {
         Self { is_enabled: false, location: "".into(), start_on_access: false }
     }
 }
 
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 mod libver {
     use super::*;
 
@@ -943,7 +943,7 @@ mod libver {
     }
 }
 
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 pub use self::libver::*;
 
 /// Builder used to create file access property list.
@@ -951,33 +951,33 @@ pub use self::libver::*;
 pub struct FileAccessBuilder {
     file_driver: Option<FileDriver>,
     log_options: LogOptions,
-    #[cfg(hdf5_1_8_13)]
+    #[cfg(feature = "1.8.13")]
     write_tracking: Option<usize>,
     fclose_degree: Option<FileCloseDegree>,
     alignment: Option<Alignment>,
     chunk_cache: Option<ChunkCache>,
-    #[cfg(hdf5_1_8_7)]
+    #[cfg(feature = "1.8.7")]
     elink_file_cache_size: Option<u32>,
     meta_block_size: Option<u64>,
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     page_buffer_size: Option<PageBufferSize>,
     sieve_buf_size: Option<usize>,
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     evict_on_close: Option<bool>,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     metadata_read_attempts: Option<u32>,
     mdc_config: Option<MetadataCacheConfig>,
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     mdc_image_config: Option<CacheImageConfig>,
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     mdc_log_options: Option<CacheLogOptions>,
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     all_coll_metadata_ops: Option<bool>,
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     coll_metadata_write: Option<bool>,
     gc_references: Option<bool>,
     small_data_block_size: Option<u64>,
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     libver_bounds: Option<LibVerBounds>,
 }
 
@@ -999,17 +999,17 @@ impl FileAccessBuilder {
         builder.driver(&drv);
         builder.gc_references(plist.get_gc_references()?);
         builder.small_data_block_size(plist.get_small_data_block_size()?);
-        #[cfg(hdf5_1_10_2)]
+        #[cfg(feature = "1.10.2")]
         {
             let v = plist.get_libver_bounds()?;
             builder.libver_bounds(v.low, v.high);
         }
-        #[cfg(hdf5_1_8_7)]
+        #[cfg(feature = "1.8.7")]
         {
             builder.elink_file_cache_size(plist.get_elink_file_cache_size()?);
         }
         builder.meta_block_size(plist.get_meta_block_size()?);
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         {
             let v = plist.get_page_buffer_size()?;
             builder.page_buffer_size(v.buf_size, v.min_meta_perc, v.min_raw_perc);
@@ -1017,19 +1017,19 @@ impl FileAccessBuilder {
             builder.mdc_image_config(plist.get_mdc_image_config()?.generate_image);
         }
         builder.sieve_buf_size(plist.get_sieve_buf_size()?);
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         {
             builder.metadata_read_attempts(plist.get_metadata_read_attempts()?);
             let v = plist.get_mdc_log_options()?;
             builder.mdc_log_options(v.is_enabled, &v.location, v.start_on_access);
         }
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         {
             builder.all_coll_metadata_ops(plist.get_all_coll_metadata_ops()?);
             builder.coll_metadata_write(plist.get_coll_metadata_write()?);
         }
         builder.mdc_config(&plist.get_mdc_config()?);
-        #[cfg(hdf5_1_8_13)]
+        #[cfg(feature = "1.8.13")]
         {
             if let FileDriver::Core(ref drv) = drv {
                 builder.write_tracking(drv.write_tracking);
@@ -1058,7 +1058,7 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(hdf5_1_8_7)]
+    #[cfg(feature = "1.8.7")]
     pub fn elink_file_cache_size(&mut self, efc_size: u32) -> &mut Self {
         self.elink_file_cache_size = Some(efc_size);
         self
@@ -1069,7 +1069,7 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn page_buffer_size(
         &mut self, buf_size: usize, min_meta_perc: u32, min_raw_perc: u32,
     ) -> &mut Self {
@@ -1082,13 +1082,13 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn evict_on_close(&mut self, evict_on_close: bool) -> &mut Self {
         self.evict_on_close = Some(evict_on_close);
         self
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn metadata_read_attempts(&mut self, attempts: u32) -> &mut Self {
         self.metadata_read_attempts = Some(attempts);
         self
@@ -1099,7 +1099,7 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn mdc_image_config(&mut self, generate_image: bool) -> &mut Self {
         self.mdc_image_config = Some(CacheImageConfig {
             generate_image,
@@ -1109,7 +1109,7 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn mdc_log_options(
         &mut self, is_enabled: bool, location: &str, start_on_access: bool,
     ) -> &mut Self {
@@ -1118,13 +1118,13 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) -> &mut Self {
         self.all_coll_metadata_ops = Some(is_collective);
         self
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     pub fn coll_metadata_write(&mut self, is_collective: bool) -> &mut Self {
         self.coll_metadata_write = Some(is_collective);
         self
@@ -1140,28 +1140,28 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     pub fn libver_bounds(&mut self, low: LibraryVersion, high: LibraryVersion) -> &mut Self {
         self.libver_bounds = Some(LibVerBounds { low, high });
         self
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     pub fn libver_earliest(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::Earliest, LibraryVersion::latest())
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     pub fn libver_v18(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::V18, LibraryVersion::latest())
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     pub fn libver_v110(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::V110, LibraryVersion::latest())
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     pub fn libver_latest(&mut self) -> &mut Self {
         self.libver_bounds(LibraryVersion::latest(), LibraryVersion::latest())
     }
@@ -1206,7 +1206,7 @@ impl FileAccessBuilder {
         self.driver(&FileDriver::Core(CoreDriver::default()))
     }
 
-    #[cfg(hdf5_1_8_13)]
+    #[cfg(feature = "1.8.13")]
     pub fn write_tracking(&mut self, page_size: usize) -> &mut Self {
         self.write_tracking = Some(page_size);
         self
@@ -1278,7 +1278,7 @@ impl FileAccessBuilder {
 
     fn set_core(&self, id: hid_t, drv: &CoreDriver) -> Result<()> {
         h5try!(H5Pset_fapl_core(id, drv.increment as _, drv.filebacked as _));
-        #[cfg(hdf5_1_8_13)]
+        #[cfg(feature = "1.8.13")]
         {
             if let Some(page_size) = self.write_tracking {
                 h5try!(H5Pset_core_write_tracking(id, (page_size > 0) as _, page_size.max(1) as _));
@@ -1422,13 +1422,13 @@ impl FileAccessBuilder {
         if let Some(v) = self.small_data_block_size {
             h5try!(H5Pset_small_data_block_size(id, v as _));
         }
-        #[cfg(hdf5_1_10_2)]
+        #[cfg(feature = "1.10.2")]
         {
             if let Some(v) = self.libver_bounds {
                 h5try!(H5Pset_libver_bounds(id, v.low.into(), v.high.into()));
             }
         }
-        #[cfg(hdf5_1_8_7)]
+        #[cfg(feature = "1.8.7")]
         {
             if let Some(v) = self.elink_file_cache_size {
                 h5try!(H5Pset_elink_file_cache_size(id, v as _));
@@ -1437,7 +1437,7 @@ impl FileAccessBuilder {
         if let Some(v) = self.meta_block_size {
             h5try!(H5Pset_meta_block_size(id, v as _));
         }
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         {
             if let Some(v) = self.page_buffer_size {
                 h5try!(H5Pset_page_buffer_size(
@@ -1457,7 +1457,7 @@ impl FileAccessBuilder {
         if let Some(v) = self.sieve_buf_size {
             h5try!(H5Pset_sieve_buf_size(id, v as _));
         }
-        #[cfg(hdf5_1_10_0)]
+        #[cfg(feature = "1.10.0")]
         {
             if let Some(v) = self.metadata_read_attempts {
                 h5try!(H5Pset_metadata_read_attempts(id, v as _));
@@ -1472,7 +1472,7 @@ impl FileAccessBuilder {
                 ));
             }
         }
-        #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
         {
             if let Some(v) = self.all_coll_metadata_ops {
                 h5try!(H5Pset_all_coll_metadata_ops(id, v as _));
@@ -1521,7 +1521,7 @@ impl FileAccess {
         h5try!(H5Pget_fapl_core(self.id(), &mut increment as *mut _, &mut filebacked as *mut _));
         drv.increment = increment as _;
         drv.filebacked = filebacked > 0;
-        #[cfg(hdf5_1_8_13)]
+        #[cfg(feature = "1.8.13")]
         {
             let mut is_enabled: hbool_t = 0;
             let mut page_size: size_t = 0;
@@ -1672,13 +1672,13 @@ impl FileAccess {
         self.get_chunk_cache().unwrap_or_else(|_| ChunkCache::default())
     }
 
-    #[cfg(hdf5_1_8_7)]
+    #[cfg(feature = "1.8.7")]
     #[doc(hidden)]
     pub fn get_elink_file_cache_size(&self) -> Result<u32> {
         h5get!(H5Pget_elink_file_cache_size(self.id()): c_uint).map(|x| x as _)
     }
 
-    #[cfg(hdf5_1_8_7)]
+    #[cfg(feature = "1.8.7")]
     pub fn elink_file_cache_size(&self) -> u32 {
         self.get_elink_file_cache_size().unwrap_or(0)
     }
@@ -1692,7 +1692,7 @@ impl FileAccess {
         self.get_meta_block_size().unwrap_or(2048)
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     #[doc(hidden)]
     pub fn get_page_buffer_size(&self) -> Result<PageBufferSize> {
         h5get!(H5Pget_page_buffer_size(self.id()): size_t, c_uint, c_uint).map(
@@ -1704,7 +1704,7 @@ impl FileAccess {
         )
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn page_buffer_size(&self) -> PageBufferSize {
         self.get_page_buffer_size().unwrap_or_else(|_| PageBufferSize::default())
     }
@@ -1718,24 +1718,24 @@ impl FileAccess {
         self.get_sieve_buf_size().unwrap_or(64 * 1024)
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     #[doc(hidden)]
     pub fn get_evict_on_close(&self) -> Result<bool> {
         h5get!(H5Pget_evict_on_close(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn evict_on_close(&self) -> bool {
         self.get_evict_on_close().unwrap_or(false)
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     #[doc(hidden)]
     pub fn get_metadata_read_attempts(&self) -> Result<u32> {
         h5get!(H5Pget_metadata_read_attempts(self.id()): c_uint).map(|x| x as _)
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn metadata_read_attempts(&self) -> u32 {
         self.get_metadata_read_attempts().unwrap_or(1)
     }
@@ -1751,7 +1751,7 @@ impl FileAccess {
         self.get_mdc_config().ok().unwrap_or_default()
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     #[doc(hidden)]
     pub fn get_mdc_image_config(&self) -> Result<CacheImageConfig> {
         let mut config: H5AC_cache_image_config_t = unsafe { mem::zeroed() };
@@ -1759,12 +1759,12 @@ impl FileAccess {
         h5call!(H5Pget_mdc_image_config(self.id(), &mut config)).map(|_| config.into())
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn mdc_image_config(&self) -> CacheImageConfig {
         self.get_mdc_image_config().ok().unwrap_or_default()
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     #[doc(hidden)]
     pub fn get_mdc_log_options(&self) -> Result<CacheLogOptions> {
         let mut is_enabled: hbool_t = 0;
@@ -1792,29 +1792,29 @@ impl FileAccess {
         })
     }
 
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     pub fn mdc_log_options(&self) -> CacheLogOptions {
         self.get_mdc_log_options().ok().unwrap_or_default()
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     #[doc(hidden)]
     pub fn get_all_coll_metadata_ops(&self) -> Result<bool> {
         h5get!(H5Pget_all_coll_metadata_ops(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     pub fn all_coll_metadata_ops(&self) -> bool {
         self.get_all_coll_metadata_ops().unwrap_or(false)
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     #[doc(hidden)]
     pub fn get_coll_metadata_write(&self) -> Result<bool> {
         h5get!(H5Pget_coll_metadata_write(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(all(hdf5_1_10_0, h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
     pub fn coll_metadata_write(&self) -> bool {
         self.get_coll_metadata_write().unwrap_or(false)
     }
@@ -1837,19 +1837,19 @@ impl FileAccess {
         self.get_small_data_block_size().unwrap_or(2048)
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     #[doc(hidden)]
     pub fn get_libver_bounds(&self) -> Result<LibVerBounds> {
         h5get!(H5Pget_libver_bounds(self.id()): H5F_libver_t, H5F_libver_t)
             .map(|(low, high)| LibVerBounds { low: low.into(), high: high.into() })
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     pub fn libver_bounds(&self) -> LibVerBounds {
         self.get_libver_bounds().ok().unwrap_or_default()
     }
 
-    #[cfg(hdf5_1_10_2)]
+    #[cfg(feature = "1.10.2")]
     pub fn libver(&self) -> LibraryVersion {
         self.get_libver_bounds().ok().unwrap_or_default().low
     }

--- a/src/hl/plist/file_access.rs
+++ b/src/hl/plist/file_access.rs
@@ -42,7 +42,7 @@ use hdf5_sys::h5p::{
     H5Pset_gc_references, H5Pset_mdc_config, H5Pset_meta_block_size, H5Pset_sieve_buf_size,
     H5Pset_small_data_block_size,
 };
-#[cfg(h5_have_direct)]
+#[cfg(have_direct)]
 use hdf5_sys::h5p::{H5Pget_fapl_direct, H5Pset_fapl_direct};
 #[cfg(feature = "mpio")]
 use hdf5_sys::h5p::{H5Pget_fapl_mpio, H5Pset_fapl_mpio};
@@ -51,7 +51,7 @@ use hdf5_sys::h5p::{H5Pget_fapl_mpio, H5Pset_fapl_mpio};
 use hdf5_sys::h5ac::{H5AC_cache_image_config_t, H5AC__CACHE_IMAGE__ENTRY_AGEOUT__NONE};
 #[cfg(feature = "1.10.2")]
 use hdf5_sys::h5f::H5F_libver_t;
-#[cfg(all(feature = "1.10.0", h5_have_parallel))]
+#[cfg(all(feature = "1.10.0", have_parallel))]
 use hdf5_sys::h5p::{
     H5Pget_all_coll_metadata_ops, H5Pget_coll_metadata_write, H5Pset_all_coll_metadata_ops,
     H5Pset_coll_metadata_write,
@@ -73,7 +73,7 @@ use hdf5_sys::h5p::{
     H5Pset_metadata_read_attempts,
 };
 
-#[cfg(h5_have_direct)]
+#[cfg(have_direct)]
 use crate::globals::H5FD_DIRECT;
 #[cfg(feature = "mpio")]
 use crate::globals::H5FD_MPIO;
@@ -131,9 +131,9 @@ impl Debug for FileAccess {
         formatter.field("metadata_read_attempts", &self.metadata_read_attempts());
         #[cfg(feature = "1.10.0")]
         formatter.field("mdc_log_options", &self.mdc_log_options());
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         formatter.field("all_coll_metadata_ops", &self.all_coll_metadata_ops());
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         formatter.field("coll_metadata_write", &self.coll_metadata_write());
         formatter.field("mdc_config", &self.mdc_config());
         formatter.field("driver", &self.driver());
@@ -451,7 +451,7 @@ mod mpio {
 #[cfg(feature = "mpio")]
 pub use self::mpio::*;
 
-#[cfg(h5_have_direct)]
+#[cfg(have_direct)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DirectDriver {
     pub alignment: usize,
@@ -459,7 +459,7 @@ pub struct DirectDriver {
     pub cbuf_size: usize,
 }
 
-#[cfg(h5_have_direct)]
+#[cfg(have_direct)]
 impl Default for DirectDriver {
     fn default() -> Self {
         Self { alignment: 4096, block_size: 4096, cbuf_size: 16 * 1024 * 1024 }
@@ -477,7 +477,7 @@ pub enum FileDriver {
     Split(SplitDriver),
     #[cfg(feature = "mpio")]
     Mpio(MpioDriver),
-    #[cfg(h5_have_direct)]
+    #[cfg(have_direct)]
     Direct(DirectDriver),
 }
 
@@ -702,8 +702,8 @@ impl Eq for MetadataCacheConfig {}
 
 impl Default for MetadataCacheConfig {
     fn default() -> Self {
-        let min_clean_fraction = if cfg!(h5_have_parallel) { 0.3_f32 } else { 0.01_f32 };
-        let flash_multiple = if cfg!(h5_have_parallel) { 1.0_f32 } else { 1.4_f32 };
+        let min_clean_fraction = if cfg!(have_parallel) { 0.3_f32 } else { 0.01_f32 };
+        let flash_multiple = if cfg!(have_parallel) { 1.0_f32 } else { 1.4_f32 };
         Self {
             rpt_fcn_enabled: false,
             open_trace_file: false,
@@ -971,9 +971,9 @@ pub struct FileAccessBuilder {
     mdc_image_config: Option<CacheImageConfig>,
     #[cfg(feature = "1.10.0")]
     mdc_log_options: Option<CacheLogOptions>,
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     all_coll_metadata_ops: Option<bool>,
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     coll_metadata_write: Option<bool>,
     gc_references: Option<bool>,
     small_data_block_size: Option<u64>,
@@ -1023,7 +1023,7 @@ impl FileAccessBuilder {
             let v = plist.get_mdc_log_options()?;
             builder.mdc_log_options(v.is_enabled, &v.location, v.start_on_access);
         }
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         {
             builder.all_coll_metadata_ops(plist.get_all_coll_metadata_ops()?);
             builder.coll_metadata_write(plist.get_coll_metadata_write()?);
@@ -1118,13 +1118,13 @@ impl FileAccessBuilder {
         self
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     pub fn all_coll_metadata_ops(&mut self, is_collective: bool) -> &mut Self {
         self.all_coll_metadata_ops = Some(is_collective);
         self
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     pub fn coll_metadata_write(&mut self, is_collective: bool) -> &mut Self {
         self.coll_metadata_write = Some(is_collective);
         self
@@ -1251,14 +1251,14 @@ impl FileAccessBuilder {
         self.driver(&FileDriver::Mpio(MpioDriver::try_new(comm, info).unwrap()))
     }
 
-    #[cfg(h5_have_direct)]
+    #[cfg(have_direct)]
     pub fn direct_options(
         &mut self, alignment: usize, block_size: usize, cbuf_size: usize,
     ) -> &mut Self {
         self.driver(&FileDriver::Direct(DirectDriver { alignment, block_size, cbuf_size }))
     }
 
-    #[cfg(h5_have_direct)]
+    #[cfg(have_direct)]
     pub fn direct(&mut self) -> &mut Self {
         self.driver(&FileDriver::Direct(DirectDriver::default()))
     }
@@ -1360,7 +1360,7 @@ impl FileAccessBuilder {
         Ok(())
     }
 
-    #[cfg(h5_have_direct)]
+    #[cfg(have_direct)]
     fn set_direct(id: hid_t, drv: &DirectDriver) -> Result<()> {
         h5try!(H5Pset_fapl_direct(id, drv.alignment as _, drv.block_size as _, drv.cbuf_size as _));
         Ok(())
@@ -1393,7 +1393,7 @@ impl FileAccessBuilder {
             FileDriver::Mpio(drv) => {
                 Self::set_mpio(id, drv)?;
             }
-            #[cfg(h5_have_direct)]
+            #[cfg(have_direct)]
             FileDriver::Direct(drv) => {
                 Self::set_direct(id, drv)?;
             }
@@ -1472,7 +1472,7 @@ impl FileAccessBuilder {
                 ));
             }
         }
-        #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+        #[cfg(all(feature = "1.10.0", have_parallel))]
         {
             if let Some(v) = self.all_coll_metadata_ops {
                 h5try!(H5Pset_all_coll_metadata_ops(id, v as _));
@@ -1593,7 +1593,7 @@ impl FileAccess {
     }
 
     #[doc(hidden)]
-    #[cfg(h5_have_direct)]
+    #[cfg(have_direct)]
     fn get_direct(&self) -> Result<DirectDriver> {
         let res = h5get!(H5Pget_fapl_direct(self.id()): size_t, size_t, size_t)?;
         Ok(DirectDriver { alignment: res.0 as _, block_size: res.1 as _, cbuf_size: res.2 as _ })
@@ -1608,7 +1608,7 @@ impl FileAccess {
                 return self.get_mpio().map(FileDriver::Mpio);
             }
         }
-        #[cfg(h5_have_direct)]
+        #[cfg(have_direct)]
         {
             if drv_id == *H5FD_DIRECT {
                 return self.get_direct().map(FileDriver::Direct);
@@ -1797,24 +1797,24 @@ impl FileAccess {
         self.get_mdc_log_options().ok().unwrap_or_default()
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     #[doc(hidden)]
     pub fn get_all_coll_metadata_ops(&self) -> Result<bool> {
         h5get!(H5Pget_all_coll_metadata_ops(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     pub fn all_coll_metadata_ops(&self) -> bool {
         self.get_all_coll_metadata_ops().unwrap_or(false)
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     #[doc(hidden)]
     pub fn get_coll_metadata_write(&self) -> Result<bool> {
         h5get!(H5Pget_coll_metadata_write(self.id()): hbool_t).map(|x| x > 0)
     }
 
-    #[cfg(all(feature = "1.10.0", h5_have_parallel))]
+    #[cfg(all(feature = "1.10.0", have_parallel))]
     pub fn coll_metadata_write(&self) -> bool {
         self.get_coll_metadata_write().unwrap_or(false)
     }

--- a/src/hl/plist/file_create.rs
+++ b/src/hl/plist/file_create.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 use bitflags::bitflags;
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 use hdf5_sys::h5f::H5F_fspace_strategy_t;
 use hdf5_sys::h5o::{
     H5O_SHMESG_ALL_FLAG, H5O_SHMESG_ATTR_FLAG, H5O_SHMESG_DTYPE_FLAG, H5O_SHMESG_FILL_FLAG,
@@ -19,7 +19,7 @@ use hdf5_sys::h5p::{
     H5Pset_shared_mesg_index, H5Pset_shared_mesg_nindexes, H5Pset_shared_mesg_phase_change,
     H5Pset_sym_k, H5Pset_userblock,
 };
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 use hdf5_sys::h5p::{
     H5Pget_file_space_page_size, H5Pget_file_space_strategy, H5Pset_file_space_page_size,
     H5Pset_file_space_strategy,
@@ -67,7 +67,7 @@ impl Debug for FileCreate {
         formatter.field("obj_track_times", &self.obj_track_times());
         formatter.field("attr_phase_change", &self.attr_phase_change());
         formatter.field("attr_creation_order", &self.attr_creation_order());
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         {
             formatter.field("file_space_page_size", &self.file_space_page_size());
             formatter.field("file_space_strategy", &self.file_space_strategy());
@@ -188,7 +188,7 @@ pub struct SharedMessageIndex {
 }
 
 /// File space handling strategy.
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum FileSpaceStrategy {
     /// Mechanisms used: free-space managers, aggregators or embedded paged
@@ -207,7 +207,7 @@ pub enum FileSpaceStrategy {
     None,
 }
 
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 impl Default for FileSpaceStrategy {
     fn default() -> Self {
         Self::FreeSpaceManager { paged: false, persist: false, threshold: 1 }
@@ -225,9 +225,9 @@ pub struct FileCreateBuilder {
     obj_track_times: Option<bool>,
     attr_phase_change: Option<AttrPhaseChange>,
     attr_creation_order: Option<AttrCreationOrder>,
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     file_space_page_size: Option<u64>,
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     file_space_strategy: Option<FileSpaceStrategy>,
 }
 
@@ -251,7 +251,7 @@ impl FileCreateBuilder {
         let apc = plist.get_attr_phase_change()?;
         builder.attr_phase_change(apc.max_compact, apc.min_dense);
         builder.attr_creation_order(plist.get_attr_creation_order()?);
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         {
             builder.file_space_page_size(plist.get_file_space_page_size()?);
             builder.file_space_strategy(plist.get_file_space_strategy()?);
@@ -339,7 +339,7 @@ impl FileCreateBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     /// Sets the file space page size.
     ///
     /// The minimum size is 512. Setting a value less than 512 will result in
@@ -350,7 +350,7 @@ impl FileCreateBuilder {
         self
     }
 
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     /// Sets the file space handling strategy and persisting free-space values.
     ///
     /// This setting cannot be changed for the life of the file.
@@ -394,7 +394,7 @@ impl FileCreateBuilder {
         if let Some(v) = self.attr_creation_order {
             h5try!(H5Pset_attr_creation_order(id, v.bits() as _));
         }
-        #[cfg(hdf5_1_10_1)]
+        #[cfg(feature = "1.10.1")]
         {
             if let Some(v) = self.file_space_page_size {
                 h5try!(H5Pset_file_space_page_size(id, v as _));
@@ -498,13 +498,13 @@ impl FileCreate {
     }
 
     #[doc(hidden)]
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn get_file_space_page_size(&self) -> Result<u64> {
         h5get!(H5Pget_file_space_page_size(self.id()): hsize_t).map(|x| x as _)
     }
 
     #[doc(hidden)]
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn get_file_space_strategy(&self) -> Result<FileSpaceStrategy> {
         let (strategy, persist, threshold) =
             h5get!(H5Pget_file_space_strategy(self.id()): H5F_fspace_strategy_t, hbool_t, hsize_t)?;
@@ -592,13 +592,13 @@ impl FileCreate {
     }
 
     /// Retrieves the file space page size.
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn file_space_page_size(&self) -> u64 {
         self.get_file_space_page_size().unwrap_or(0)
     }
 
     /// Retrieves the file space handling strategy.
-    #[cfg(hdf5_1_10_1)]
+    #[cfg(feature = "1.10.1")]
     pub fn file_space_strategy(&self) -> FileSpaceStrategy {
         self.get_file_space_strategy().unwrap_or_else(|_| FileSpaceStrategy::default())
     }

--- a/src/hl/selection.rs
+++ b/src/hl/selection.rs
@@ -12,7 +12,7 @@ use hdf5_sys::h5s::{
     H5Sget_simple_extent_ndims, H5Sselect_all, H5Sselect_elements, H5Sselect_hyperslab,
     H5Sselect_none, H5S_SELECT_SET, H5S_UNLIMITED,
 };
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 use hdf5_sys::h5s::{H5Sget_regular_hyperslab, H5Sis_regular_hyperslab};
 
 use crate::hl::extents::Ix;
@@ -44,9 +44,9 @@ unsafe fn set_points_selection(space_id: hid_t, coords: ArrayView2<Ix>) -> Resul
     Ok(())
 }
 
-#[cfg_attr(not(hdf5_1_10_0), allow(unused))]
+#[cfg_attr(not(feature = "1.10.0"), allow(unused))]
 unsafe fn get_regular_hyperslab(space_id: hid_t) -> Result<Option<RawHyperslab>> {
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     {
         if h5check(H5Sis_regular_hyperslab(space_id))? <= 0 {
             return Ok(None);
@@ -1586,7 +1586,8 @@ mod test {
         check(&[1, 2], RawSelection::All, None)?;
         check(&[1, 2], RawSelection::Points(arr2(&[[0, 1], [0, 0]])), None)?;
 
-        let exp = if cfg!(hdf5_1_10_0) { None } else { Some(RawSelection::ComplexHyperslab) };
+        let exp =
+            if cfg!(feature = "1.10.0") { None } else { Some(RawSelection::ComplexHyperslab) };
         check(
             &[8, 9, 10, 11],
             vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 // RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features blosc,lzf
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(all(feature = "mpio", not(h5_have_parallel)))]
+#[cfg(all(feature = "mpio", not(have_parallel)))]
 compile_error!("Enabling \"mpio\" feature requires HDF5 library built with MPI support");
 
 mod export {
@@ -175,7 +175,7 @@ pub fn is_library_threadsafe() -> bool {
     }
     #[cfg(not(feature = "1.8.16"))]
     {
-        cfg!(h5_have_threadsafe)
+        cfg!(have_threadsafe)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::missing_panics_doc))]
 #![cfg_attr(all(feature = "cargo-clippy", test), allow(clippy::cyclomatic_complexity))]
 #![cfg_attr(not(test), allow(dead_code))]
+// To build docs locally:
+// RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features blosc,lzf
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(feature = "mpio", not(h5_have_parallel)))]
 compile_error!("Enabling \"mpio\" feature requires HDF5 library built with MPI support");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,9 @@
 //!
 //! Requires `HDF5` library of version 1.8.4 or later. Newer versions will enable additional
 //! features of the library. Such items are marked in the documentation with a version number
-//! indicating the required version of `HDF5`. The `have_direct` and `have_parallel` features
+//! indicating the required version of `HDF5`. The `have-direct` and `have-parallel` features
 //! also indicates `HDF5` functionality.
+
 #![cfg_attr(feature = "cargo-clippy", warn(clippy::pedantic))]
 #![cfg_attr(feature = "cargo-clippy", warn(clippy::nursery))]
 #![cfg_attr(feature = "cargo-clippy", warn(clippy::all))]
@@ -43,7 +44,7 @@
 // RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features blosc,lzf
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(all(feature = "mpio", not(have_parallel)))]
+#[cfg(all(feature = "mpio", not(feature = "have-parallel")))]
 compile_error!("Enabling \"mpio\" feature requires HDF5 library built with MPI support");
 
 mod export {
@@ -191,7 +192,7 @@ pub fn is_library_threadsafe() -> bool {
     }
     #[cfg(not(feature = "1.8.16"))]
     {
-        cfg!(have_threadsafe)
+        cfg!(feature = "threadsafe")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,19 @@
+//! HDF5 for Rust.
+//!
+//! This crate provides thread-safe Rust bindings and high-level wrappers for the `HDF5`
+//! library API. Some of the features include:
+//!
+//! - Thread-safety with non-threadsafe libhdf5 builds guaranteed via reentrant mutexes.
+//! - Native representation of most HDF5 types, including variable-length strings and arrays.
+//! - Derive-macro for automatic mapping of user structs and enums to `HDF5` types.
+//! - Multi-dimensional array reading/writing interface via `ndarray`.
+//!
+//! Direct low-level bindings are also available and provided in the `hdf5-sys` crate.
+//!
+//! Requires `HDF5` library of version 1.8.4 or later. Newer versions will enable additional
+//! features of the library. Such items are marked in the documentation with a version number
+//! indicating the required version of `HDF5`. The `have_direct` and `have_parallel` features
+//! also indicates `HDF5` functionality.
 #![cfg_attr(feature = "cargo-clippy", warn(clippy::pedantic))]
 #![cfg_attr(feature = "cargo-clippy", warn(clippy::nursery))]
 #![cfg_attr(feature = "cargo-clippy", warn(clippy::all))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ mod export {
     }
 
     pub mod dataset {
-        #[cfg(hdf5_1_10_5)]
+        #[cfg(feature = "1.10.5")]
         pub use crate::hl::dataset::ChunkInfo;
         pub use crate::hl::dataset::{Chunk, Dataset, DatasetBuilder};
         pub use crate::hl::plist::dataset_access::*;
@@ -166,14 +166,14 @@ pub fn library_version() -> (u8, u8, u8) {
 
 /// Returns true if the HDF5 library is threadsafe.
 pub fn is_library_threadsafe() -> bool {
-    #[cfg(hdf5_1_8_16)]
+    #[cfg(feature = "1.8.16")]
     {
         use self::internal_prelude::hbool_t;
         use hdf5_sys::h5::H5is_library_threadsafe;
         let mut ts: hbool_t = 0;
         h5call!(H5is_library_threadsafe(&mut ts)).map(|_| ts > 0).unwrap_or(false)
     }
-    #[cfg(not(hdf5_1_8_16))]
+    #[cfg(not(feature = "1.8.16"))]
     {
         cfg!(h5_have_threadsafe)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,13 +40,13 @@ pub fn string_to_fixed_bytes(s: &str, buf: &mut [c_char]) {
     }
 }
 
-#[cfg(hdf5_1_8_13)]
+#[cfg(feature = "1.8.13")]
 pub fn h5_free_memory(mem: *mut c_void) {
     use hdf5_sys::h5::H5free_memory;
     unsafe { H5free_memory(mem) };
 }
 
-#[cfg(not(hdf5_1_8_13))]
+#[cfg(not(feature = "1.8.13"))]
 pub fn h5_free_memory(mem: *mut c_void) {
     // this may fail in debug builds of HDF5
     use libc::free;

--- a/tests/test_plist.rs
+++ b/tests/test_plist.rs
@@ -337,7 +337,7 @@ fn test_fapl_driver_mpio() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(have_direct)]
+#[cfg(feature = "have-direct")]
 fn test_fapl_driver_direct() -> hdf5::Result<()> {
     let mut b = FileAccess::build();
 
@@ -553,7 +553,7 @@ fn test_fapl_set_page_buffer_size() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(all(feature = "1.10.1", not(have_parallel)))]
+#[cfg(all(feature = "1.10.1", not(feature = "have-parallel")))]
 fn test_fapl_set_evict_on_close() -> hdf5::Result<()> {
     test_pl!(FA, evict_on_close: true);
     test_pl!(FA, evict_on_close: false);

--- a/tests/test_plist.rs
+++ b/tests/test_plist.rs
@@ -160,7 +160,7 @@ fn test_fcpl_attr_creation_order() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 fn test_fcpl_set_file_space_page_size() -> hdf5::Result<()> {
     test_pl!(FC, file_space_page_size: 512);
     test_pl!(FC, file_space_page_size: 999);
@@ -168,7 +168,7 @@ fn test_fcpl_set_file_space_page_size() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 fn test_fcpl_set_file_space_strategy() -> hdf5::Result<()> {
     test_pl!(FC, file_space_strategy: FileSpaceStrategy::PageAggregation);
     test_pl!(FC, file_space_strategy: FileSpaceStrategy::None);
@@ -223,16 +223,16 @@ fn test_fapl_driver_core() -> hdf5::Result<()> {
     let d = check_matches!(b.finish()?.get_driver()?, d, FileDriver::Core(d));
     assert_eq!(d.increment, 1024 * 1024);
     assert_eq!(d.filebacked, false);
-    #[cfg(hdf5_1_8_13)]
+    #[cfg(feature = "1.8.13")]
     assert_eq!(d.write_tracking, 0);
 
     b.core_options(123, true);
-    #[cfg(hdf5_1_8_13)]
+    #[cfg(feature = "1.8.13")]
     b.write_tracking(456);
     let d = check_matches!(b.finish()?.get_driver()?, d, FileDriver::Core(d));
     assert_eq!(d.increment, 123);
     assert_eq!(d.filebacked, true);
-    #[cfg(hdf5_1_8_13)]
+    #[cfg(feature = "1.8.13")]
     assert_eq!(d.write_tracking, 456);
 
     b.core_filebacked(false);
@@ -479,7 +479,7 @@ fn test_fapl_set_mdc_config() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_8_7)]
+#[cfg(feature = "1.8.7")]
 fn test_fapl_set_elink_file_cache_size() -> hdf5::Result<()> {
     test_pl!(FA, elink_file_cache_size: 0);
     test_pl!(FA, elink_file_cache_size: 17);
@@ -487,7 +487,7 @@ fn test_fapl_set_elink_file_cache_size() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 fn test_fapl_set_metadata_read_attempts() -> hdf5::Result<()> {
     test_pl!(FA, metadata_read_attempts: 1);
     test_pl!(FA, metadata_read_attempts: 17);
@@ -495,7 +495,7 @@ fn test_fapl_set_metadata_read_attempts() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 fn test_fapl_set_mdc_log_options() -> hdf5::Result<()> {
     test_pl!(FA, mdc_log_options: is_enabled = true, location = "abc", start_on_access = false,);
     test_pl!(FA, mdc_log_options: is_enabled = false, location = "", start_on_access = true,);
@@ -503,7 +503,7 @@ fn test_fapl_set_mdc_log_options() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(all(hdf5_1_10_0, feature = "mpio"))]
+#[cfg(all(feature = "1.10.0", feature = "mpio"))]
 fn test_fapl_set_all_coll_metadata_ops() -> hdf5::Result<()> {
     test_pl!(FA, all_coll_metadata_ops: true);
     test_pl!(FA, all_coll_metadata_ops: false);
@@ -511,7 +511,7 @@ fn test_fapl_set_all_coll_metadata_ops() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(all(hdf5_1_10_0, feature = "mpio"))]
+#[cfg(all(feature = "1.10.0", feature = "mpio"))]
 fn test_fapl_set_coll_metadata_write() -> hdf5::Result<()> {
     test_pl!(FA, coll_metadata_write: true);
     test_pl!(FA, coll_metadata_write: false);
@@ -519,7 +519,7 @@ fn test_fapl_set_coll_metadata_write() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_2)]
+#[cfg(feature = "1.10.2")]
 fn test_fapl_set_libver_bounds() -> hdf5::Result<()> {
     test_pl!(FA, libver_bounds: low = LibraryVersion::Earliest, high = LibraryVersion::V18);
     test_pl!(FA, libver_bounds: low = LibraryVersion::Earliest, high = LibraryVersion::V110);
@@ -544,7 +544,7 @@ fn test_fapl_set_libver_bounds() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 fn test_fapl_set_page_buffer_size() -> hdf5::Result<()> {
     test_pl!(FA, page_buffer_size: buf_size = 0, min_meta_perc = 0, min_raw_perc = 0);
     test_pl!(FA, page_buffer_size: buf_size = 0, min_meta_perc = 7, min_raw_perc = 9);
@@ -553,7 +553,7 @@ fn test_fapl_set_page_buffer_size() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(all(hdf5_1_10_1, not(h5_have_parallel)))]
+#[cfg(all(feature = "1.10.1", not(h5_have_parallel)))]
 fn test_fapl_set_evict_on_close() -> hdf5::Result<()> {
     test_pl!(FA, evict_on_close: true);
     test_pl!(FA, evict_on_close: false);
@@ -561,7 +561,7 @@ fn test_fapl_set_evict_on_close() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_1)]
+#[cfg(feature = "1.10.1")]
 fn test_fapl_set_mdc_image_config() -> hdf5::Result<()> {
     test_pl!(FA, mdc_image_config: generate_image = true);
     test_pl!(FA, mdc_image_config: generate_image = false);
@@ -580,7 +580,7 @@ fn test_dapl_common() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_8_17)]
+#[cfg(feature = "1.8.17")]
 fn test_dapl_set_efile_prefix() -> hdf5::Result<()> {
     assert_eq!(DA::try_new()?.get_efile_prefix().unwrap(), "".to_owned());
     assert_eq!(DA::try_new()?.efile_prefix(), "".to_owned());
@@ -599,7 +599,7 @@ fn test_dapl_set_chunk_cache() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(all(hdf5_1_10_0, feature = "mpio"))]
+#[cfg(all(feature = "1.10.0", feature = "mpio"))]
 fn test_dapl_set_all_coll_metadata_ops() -> hdf5::Result<()> {
     test_pl!(DA, all_coll_metadata_ops: true);
     test_pl!(DA, all_coll_metadata_ops: false);
@@ -607,7 +607,7 @@ fn test_dapl_set_all_coll_metadata_ops() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 fn test_dapl_set_virtual_view() -> hdf5::Result<()> {
     test_pl!(DA, virtual_view: VirtualView::FirstMissing);
     test_pl!(DA, virtual_view: VirtualView::LastAvailable);
@@ -615,7 +615,7 @@ fn test_dapl_set_virtual_view() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 fn test_dapl_set_virtual_printf_gap() -> hdf5::Result<()> {
     test_pl!(DA, virtual_printf_gap: 0);
     test_pl!(DA, virtual_printf_gap: 123);
@@ -641,12 +641,12 @@ fn test_dcpl_set_chunk() -> hdf5::Result<()> {
     let mut b = DCB::new().chunk([3, 7]).clone();
     assert_eq!(b.layout(Layout::Contiguous).finish()?.layout(), Layout::Chunked);
     assert_eq!(b.layout(Layout::Compact).finish()?.layout(), Layout::Chunked);
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     assert_eq!(b.layout(Layout::Virtual).finish()?.layout(), Layout::Chunked);
     assert!(b.no_chunk().finish()?.chunk().is_none());
     assert!(DCB::new().layout(Layout::Contiguous).finish()?.get_chunk()?.is_none());
     assert!(DCB::new().layout(Layout::Compact).finish()?.get_chunk()?.is_none());
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     assert!(DCB::new().layout(Layout::Virtual).finish()?.get_chunk()?.is_none());
     assert_eq!(DCB::new().layout(Layout::Chunked).finish()?.get_chunk()?, Some(vec![]));
     Ok(())
@@ -658,19 +658,19 @@ fn test_dcpl_set_layout() -> hdf5::Result<()> {
     test_pl!(DC, layout: Layout::Contiguous);
     test_pl!(DC, layout: Layout::Compact);
     test_pl!(DC, layout: Layout::Chunked);
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     test_pl!(DC, layout: Layout::Virtual);
     Ok(())
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 #[test]
 fn test_dcpl_set_chunk_opts() -> hdf5::Result<()> {
     assert!(DC::try_new()?.get_chunk_opts()?.is_none());
     let mut b = DCB::new();
     assert!(b.layout(Layout::Contiguous).finish()?.get_chunk_opts()?.is_none());
     assert!(b.layout(Layout::Compact).finish()?.get_chunk_opts()?.is_none());
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     assert!(b.layout(Layout::Virtual).finish()?.get_chunk_opts()?.is_none());
     b.layout(Layout::Chunked);
     assert_eq!(b.finish()?.get_chunk_opts()?, Some(ChunkOpts::empty()));
@@ -692,7 +692,7 @@ fn test_dcpl_set_alloc_time() -> hdf5::Result<()> {
     check_matches!(b.finish()?.get_alloc_time()?, (), AllocTime::Early);
     b.layout(Layout::Chunked);
     check_matches!(b.finish()?.get_alloc_time()?, (), AllocTime::Incr);
-    #[cfg(hdf5_1_10_0)]
+    #[cfg(feature = "1.10.0")]
     {
         b.layout(Layout::Virtual);
         check_matches!(b.finish()?.get_alloc_time()?, (), AllocTime::Incr);
@@ -782,7 +782,7 @@ fn test_dcpl_external() -> hdf5::Result<()> {
     Ok(())
 }
 
-#[cfg(hdf5_1_10_0)]
+#[cfg(feature = "1.10.0")]
 #[test]
 fn test_dcpl_virtual_map() -> hdf5::Result<()> {
     use hdf5::Hyperslab;

--- a/tests/test_plist.rs
+++ b/tests/test_plist.rs
@@ -337,7 +337,7 @@ fn test_fapl_driver_mpio() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(h5_have_direct)]
+#[cfg(have_direct)]
 fn test_fapl_driver_direct() -> hdf5::Result<()> {
     let mut b = FileAccess::build();
 
@@ -553,7 +553,7 @@ fn test_fapl_set_page_buffer_size() -> hdf5::Result<()> {
 }
 
 #[test]
-#[cfg(all(feature = "1.10.1", not(h5_have_parallel)))]
+#[cfg(all(feature = "1.10.1", not(have_parallel)))]
 fn test_fapl_set_evict_on_close() -> hdf5::Result<()> {
     test_pl!(FA, evict_on_close: true);
     test_pl!(FA, evict_on_close: false);


### PR DESCRIPTION
1. Enable `doc_cfg` for nightly builds (on docs.rs and locally if enabled)
2. (Experimental) Replace `hdf5_1_2_3` config flags with `feature = "1.2.3"`. This will produce annotations like "Enabled on **crate feature** 1.10.0 only" in the docs instead of "Enabled on `hdf5_1_10_0` only". If I understand correctly, this will also allow the users to refer to these as `hdf5/1.10.0` externally (?). Features can be named as "hdf5-1.10.0" but that would look a bit ugly in the docs (with the numbers only, it looks pretty neat, see below for examples).
3. (TODO) we should definitely build the docs on the latest HDF5 version available (1.12.1?).
4. (TODO) ideally, we want mpio/blosc/lzf on docs.rs as well (the latter two are already there).
5. Should `h5_have_parallel` and such be renamed to `feature = "have-parallel"`?

Note: support for period for feature names has been only recently added to cargo (circa 1.50).

Related: #141.