### PR TITLE
Add support for `#[repr(packed)]` and `#[repr(transparent)]` in hdf5-derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `Error` now implements `From<Infallible>`, which allows passing convertible
   extents (like tuples of integers) where `impl TryInto<Extents>` is required.
 - Support for HDF5 versions 1.12.1 and 1.10.8
+- `#[derive(H5Type)]` now supports structs / tuple structs with `repr(packed)`.
+- `#[derive(H5Type)]` now supports structs / tuple structs with 
+  `repr(transparent)` (the generated HDF5 type is equivalent to the type of
+  the field and is not compound).
 
 ### Changed
 

--- a/hdf5-derive/src/lib.rs
+++ b/hdf5-derive/src/lib.rs
@@ -61,6 +61,12 @@ where
     }
 }
 
+fn impl_transparent(ty: &Type) -> TokenStream {
+    quote! {
+        <#ty as _h5::types::H5Type>::type_descriptor()
+    }
+}
+
 fn impl_enum(names: Vec<Ident>, values: Vec<Expr>, repr: &Ident) -> TokenStream {
     let size = Ident::new(
         &format!(
@@ -149,12 +155,18 @@ fn impl_trait(
                 if fields.is_empty() {
                     panic!("Cannot derive H5Type for empty structs");
                 }
-                find_repr(attrs, &["C", "packed"])
-                    .expect("H5Type requires #[repr(C)] or #[repr(packed)] for structs");
-                let types = pluck(fields.iter(), |f| f.ty.clone());
-                let fields = pluck(fields.iter(), |f| f.ident.clone().unwrap());
-                let names = fields.iter().map(|f| f.to_string()).collect::<Vec<_>>();
-                impl_compound(ty, ty_generics, &fields, &names, &types)
+                if find_repr(attrs, &["C", "packed", "transparent"]).expect(
+                    "H5Type requires repr(C), repr(packed) or repr(transparent) for structs",
+                ) == "transparent"
+                {
+                    assert_eq!(fields.len(), 1);
+                    impl_transparent(&fields[0].ty)
+                } else {
+                    let types = pluck(fields.iter(), |f| f.ty.clone());
+                    let fields = pluck(fields.iter(), |f| f.ident.clone().unwrap());
+                    let names = fields.iter().map(|f| f.to_string()).collect::<Vec<_>>();
+                    impl_compound(ty, ty_generics, &fields, &names, &types)
+                }
             }
             Fields::Unnamed(ref fields) => {
                 let (index, fields): (Vec<Index>, Vec<_>) = fields
@@ -167,11 +179,17 @@ fn impl_trait(
                 if fields.is_empty() {
                     panic!("Cannot derive H5Type for empty tuple structs");
                 }
-                find_repr(attrs, &["C", "packed"])
-                    .expect("H5Type requires #[repr(C)] or #[repr(packed)] for structs");
-                let names = (0..fields.len()).map(|f| f.to_string()).collect::<Vec<_>>();
-                let types = pluck(fields.iter(), |f| f.ty.clone());
-                impl_compound(ty, ty_generics, &index, &names, &types)
+                if find_repr(attrs, &["C", "packed", "transparent"]).expect(
+                    "H5Type requires repr(C), repr(packed) or repr(transparent) for tuple structs",
+                ) == "transparent"
+                {
+                    assert_eq!(fields.len(), 1);
+                    impl_transparent(&fields[0].ty)
+                } else {
+                    let names = (0..fields.len()).map(|f| f.to_string()).collect::<Vec<_>>();
+                    let types = pluck(fields.iter(), |f| f.ty.clone());
+                    impl_compound(ty, ty_generics, &index, &names, &types)
+                }
             }
         },
         Data::Enum(ref data) => {

--- a/hdf5-derive/src/lib.rs
+++ b/hdf5-derive/src/lib.rs
@@ -149,7 +149,8 @@ fn impl_trait(
                 if fields.is_empty() {
                     panic!("Cannot derive H5Type for empty structs");
                 }
-                find_repr(attrs, &["C"]).expect("H5Type requires #[repr(C)] for structs");
+                find_repr(attrs, &["C", "packed"])
+                    .expect("H5Type requires #[repr(C)] or #[repr(packed)] for structs");
                 let types = pluck(fields.iter(), |f| f.ty.clone());
                 let fields = pluck(fields.iter(), |f| f.ident.clone().unwrap());
                 let names = fields.iter().map(|f| f.to_string()).collect::<Vec<_>>();
@@ -166,7 +167,8 @@ fn impl_trait(
                 if fields.is_empty() {
                     panic!("Cannot derive H5Type for empty tuple structs");
                 }
-                find_repr(attrs, &["C"]).expect("H5Type requires #[repr(C)] for structs");
+                find_repr(attrs, &["C", "packed"])
+                    .expect("H5Type requires #[repr(C)] or #[repr(packed)] for structs");
                 let names = (0..fields.len()).map(|f| f.to_string()).collect::<Vec<_>>();
                 let types = pluck(fields.iter(), |f| f.ty.clone());
                 impl_compound(ty, ty_generics, &index, &names, &types)

--- a/hdf5-derive/tests/compile-fail/struct-c-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/struct-c-repr.stderr
@@ -1,7 +1,0 @@
-error: proc-macro derive panicked
- --> $DIR/struct-c-repr.rs:4:10
-  |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: H5Type requires #[repr(C)] for structs

--- a/hdf5-derive/tests/compile-fail/struct-no-repr.rs
+++ b/hdf5-derive/tests/compile-fail/struct-no-repr.rs
@@ -3,7 +3,9 @@ use hdf5_derive::H5Type;
 
 #[derive(H5Type)]
 //~^ ERROR proc-macro derive
-//~^^ HELP H5Type requires #[repr(C)] for structs
-struct Foo(i64);
+//~^^ HELP H5Type requires #[repr(C)] or #[repr(packed)] for structs
+struct Foo {
+    bar: i64,
+}
 
 fn main() {}

--- a/hdf5-derive/tests/compile-fail/struct-no-repr.rs
+++ b/hdf5-derive/tests/compile-fail/struct-no-repr.rs
@@ -3,7 +3,7 @@ use hdf5_derive::H5Type;
 
 #[derive(H5Type)]
 //~^ ERROR proc-macro derive
-//~^^ HELP H5Type requires #[repr(C)] or #[repr(packed)] for structs
+//~^^ HELP H5Type requires repr(C), repr(packed) or repr(transparent) for structs
 struct Foo {
     bar: i64,
 }

--- a/hdf5-derive/tests/compile-fail/struct-no-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/struct-no-repr.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> $DIR/struct-no-repr.rs:4:10
+  |
+4 | #[derive(H5Type)]
+  |          ^^^^^^
+  |
+  = help: message: H5Type requires #[repr(C)] or #[repr(packed)] for structs

--- a/hdf5-derive/tests/compile-fail/struct-no-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/struct-no-repr.stderr
@@ -4,4 +4,4 @@ error: proc-macro derive panicked
 4 | #[derive(H5Type)]
   |          ^^^^^^
   |
-  = help: message: H5Type requires #[repr(C)] or #[repr(packed)] for structs
+  = help: message: H5Type requires repr(C), repr(packed) or repr(transparent) for structs

--- a/hdf5-derive/tests/compile-fail/tuple-struct-c-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/tuple-struct-c-repr.stderr
@@ -1,7 +1,0 @@
-error: proc-macro derive panicked
- --> $DIR/tuple-struct-c-repr.rs:4:10
-  |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: H5Type requires #[repr(C)] for structs

--- a/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.rs
+++ b/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.rs
@@ -3,7 +3,7 @@ use hdf5_derive::H5Type;
 
 #[derive(H5Type)]
 //~^ ERROR proc-macro derive
-//~^^ HELP H5Type requires #[repr(C)] or #[repr(packed)] for structs
+//~^^ HELP H5Type requires repr(C), repr(packed) or repr(transparent) for tuple structs
 struct Foo(i64);
 
 fn main() {}

--- a/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.rs
+++ b/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.rs
@@ -3,9 +3,7 @@ use hdf5_derive::H5Type;
 
 #[derive(H5Type)]
 //~^ ERROR proc-macro derive
-//~^^ HELP H5Type requires #[repr(C)] for structs
-struct Foo {
-    bar: i64,
-}
+//~^^ HELP H5Type requires #[repr(C)] or #[repr(packed)] for structs
+struct Foo(i64);
 
 fn main() {}

--- a/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> $DIR/tuple-struct-no-repr.rs:4:10
+  |
+4 | #[derive(H5Type)]
+  |          ^^^^^^
+  |
+  = help: message: H5Type requires #[repr(C)] or #[repr(packed)] for structs

--- a/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.stderr
@@ -4,4 +4,4 @@ error: proc-macro derive panicked
 4 | #[derive(H5Type)]
   |          ^^^^^^
   |
-  = help: message: H5Type requires #[repr(C)] or #[repr(packed)] for structs
+  = help: message: H5Type requires repr(C), repr(packed) or repr(transparent) for tuple structs

--- a/hdf5-derive/tests/test.rs
+++ b/hdf5-derive/tests/test.rs
@@ -1,3 +1,6 @@
+// due to compiler wrongfully complaining re: Copy impl missing for packed struct
+#![allow(unaligned_references)]
+
 #[macro_use]
 extern crate hdf5_derive;
 
@@ -29,6 +32,41 @@ struct B {
 #[derive(H5Type)]
 #[repr(C)]
 struct T(i64, pub u64);
+
+#[derive(H5Type, Copy, Clone)]
+#[repr(packed)]
+struct P1 {
+    x: u8,
+    y: u64,
+}
+
+#[derive(H5Type, Copy, Clone)]
+#[repr(packed)]
+struct P2(i8, u32);
+
+#[test]
+fn test_compound_packed() {
+    assert_eq!(
+        P1::type_descriptor(),
+        TD::Compound(CompoundType {
+            fields: vec![
+                CompoundField::typed::<u8>("x", 0, 0),
+                CompoundField::typed::<u64>("y", 1, 1),
+            ],
+            size: 9,
+        })
+    );
+    assert_eq!(
+        P2::type_descriptor(),
+        TD::Compound(CompoundType {
+            fields: vec![
+                CompoundField::typed::<i8>("0", 0, 0),
+                CompoundField::typed::<u32>("1", 1, 1),
+            ],
+            size: 5,
+        })
+    );
+}
 
 #[test]
 fn test_compound_simple() {

--- a/hdf5-derive/tests/test.rs
+++ b/hdf5-derive/tests/test.rs
@@ -44,6 +44,16 @@ struct P1 {
 #[repr(packed)]
 struct P2(i8, u32);
 
+#[derive(H5Type)]
+#[repr(transparent)]
+struct T1 {
+    _x: u64,
+}
+
+#[derive(H5Type)]
+#[repr(transparent)]
+struct T2(i32);
+
 #[test]
 fn test_compound_packed() {
     assert_eq!(
@@ -66,6 +76,12 @@ fn test_compound_packed() {
             size: 5,
         })
     );
+}
+
+#[test]
+fn test_compound_transparent() {
+    assert_eq!(T1::type_descriptor(), u64::type_descriptor(),);
+    assert_eq!(T2::type_descriptor(), i32::type_descriptor(),);
 }
 
 #[test]


### PR DESCRIPTION
Closes #187.