### PR TITLE
0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 - Renamed `filters::gzip_available()` to `deflate_available()` (the old name is
   present but marked as deprecated).
+- Code dependent on HDF5 version in `hdf5` and `hdf5-sys` crates now uses features
+  instead of cfg options: `cfg(feature = "1.10.1")` instead of `cfg(hdf5_1_10_1)`.
+  The main initial reason for that is for HDF5 versions to show up in the official
+  documentation on docs.rs.
+- Similar to the above, there's `have-direct`, `have-parallel` and `have-threadsafe`
+  features that reflect the build configuration of the underlying HDF5 library.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.8.1
+
+Release date: Nov 21, 2021.
 
 ### Added
 
 - `Error` now implements `From<Infallible>`, which allows passing convertible
   extents (like tuples of integers) where `impl TryInto<Extents>` is required.
-- Support for HDF5 versions 1.12.1 and 1.10.8
+- Support for HDF5 versions 1.12.1 and 1.10.8.
 - `#[derive(H5Type)]` now supports structs / tuple structs with `repr(packed)`.
 - `#[derive(H5Type)]` now supports structs / tuple structs with 
   `repr(transparent)` (the generated HDF5 type is equivalent to the type of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5"
-version = "0.8.0"  # !V
+version = "0.8.1"  # !V
 authors = ["Ivan Smirnov <i.s.smirnov@gmail.com>"]
 keywords = ["hdf5"]
 license = "MIT OR Apache-2.0"
@@ -34,9 +34,9 @@ ndarray = "0.15"
 paste = "1.0"
 mpi-sys = { version = "0.1", optional = true }
 errno = { version = "0.2", optional = true }
-hdf5-sys = { path = "hdf5-sys", version = "0.8.0" }  # !V
-hdf5-types = { path = "hdf5-types", version = "0.8.0" }  # !V
-hdf5-derive = { path = "hdf5-derive", version = "0.8.0" }  # !V
+hdf5-sys = { path = "hdf5-sys", version = "0.8.1" }  # !V
+hdf5-types = { path = "hdf5-types", version = "0.8.1" }  # !V
+hdf5-derive = { path = "hdf5-derive", version = "0.8.1" }  # !V
 blosc-sys = { version = "0.1.1", package = "blosc-src", optional = true }
 lzf-sys = { version = "0.1", optional = true }
 cfg-if = "1.0"

--- a/hdf5-derive/Cargo.toml
+++ b/hdf5-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-derive"
-version = "0.8.0"  # !V
+version = "0.8.1"  # !V
 authors = ["Ivan Smirnov <i.s.smirnov@gmail.com>"]
 keywords = ["hdf5"]
 license = "MIT OR Apache-2.0"

--- a/hdf5-src/Cargo.toml
+++ b/hdf5-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-src"
-version = "0.8.0"  # !V
+version = "0.8.1"  # !V
 authors = ["Ivan Smirnov <i.s.smirnov@gmail.com>"]
 keywords = ["hdf5"]
 license-file = "ext/hdf5/COPYING"

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-sys"
-version = "0.8.0"  # !V
+version = "0.8.1"  # !V
 authors = ["Ivan Smirnov <i.s.smirnov@gmail.com>"]
 keywords = ["hdf5"]
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ readme = "README.md"
 libc = "0.2"
 mpi-sys = { version = "0.1", optional = true }
 libz-sys = { version = "1.0.25", optional = true, default-features = false }
-hdf5-src = { path = "../hdf5-src", version = "0.8.0", optional = true }  # !V
+hdf5-src = { path = "../hdf5-src", version = "0.8.1", optional = true }  # !V
 
 # Please see README for further explanation of these feature flags
 [features]

--- a/hdf5-types/Cargo.toml
+++ b/hdf5-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-types"
-version = "0.8.0"  # !V
+version = "0.8.1"  # !V
 authors = ["Ivan Smirnov <i.s.smirnov@gmail.com>"]
 keywords = ["hdf5"]
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ h5-alloc = []
 [dependencies]
 ascii = "1.0"
 libc = "0.2"
-hdf5-sys = { version = "0.8.0", path = "../hdf5-sys" }  # !V
+hdf5-sys = { version = "0.8.1", path = "../hdf5-sys" }  # !V
 cfg-if = "1.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Updated the changelog re: switch to using `feature = "..."` for the sake of better docs (anything else?).

Other than that, I think 0.8.1 should be released now as it fixes serious bugs in filters.