### PR TITLE
Simplify feature expansion in macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fixed a bug where `H5Pget_fapl_direct` was only included when HDF5 was compiled
+  with feature `have-parallel` instead of `have-direct`.
+
 ## 0.8.1
 
 Release date: Nov 21, 2021.

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -535,7 +535,7 @@ extern "C" {
     pub fn H5Pset_fapl_direct(
         fapl_id: hid_t, alignment: size_t, block_size: size_t, cbuf_size: size_t,
     ) -> herr_t;
-    #[cfg(feature = "have-parallel")]
+    #[cfg(feature = "have-direct")]
     pub fn H5Pget_fapl_direct(
         fapl_id: hid_t, alignment: *mut size_t, block_size: *mut size_t, cbuf_size: *mut size_t,
     ) -> herr_t;

--- a/src/hl/dataset.rs
+++ b/src/hl/dataset.rs
@@ -908,11 +908,11 @@ macro_rules! impl_builder {
         }
     };
     (
-        $(#[cfg(feature = $feature:literal)])* $(#[cfg(all($(feature = $features:literal),*))])*
+        $(#[$meta:meta])*
         $plist:ident: $name:ident($($var:ident: $ty:ty),*)
     ) => {
         paste::paste! {
-            $(#[cfg(feature = $feature)])* $(#[cfg(all($(feature = $features),*))])*
+            $(#[$meta])*
             #[inline] #[must_use] #[doc =
                 "\u{21b3} [`" $plist "Builder::" $name "`]"
                 "(crate::plist::" $plist "Builder::" $name ")"
@@ -923,11 +923,11 @@ macro_rules! impl_builder {
         }
     };
     (
-        $(#[cfg(feature = $feature:literal)])* $(#[cfg(all($(feature = $features:literal),*))])*
+        $(#[$meta:meta])*
         $plist:ident: $name:ident<$($gid:ident: $gty:path),+>($($var:ident: $ty:ty),*)
     ) => {
         paste::paste! {
-            $(#[cfg(feature = $feature)])* $(#[cfg(all($(feature = $features),*))])*
+            $(#[$meta])*
             #[inline] #[must_use] #[doc =
                 "\u{21b3} [`" $plist "Builder::" $name "`]"
                 "(crate::plist::" $plist "Builder::" $name ")"


### PR DESCRIPTION
It turns out there is a fragment specifier for features: https://veykril.github.io/tlborm/decl-macros/minutiae/fragment-specifiers.html#meta