### PR TITLE
Support hdf5 version 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable]
-        version: ["1.8", "1.10", "1.12"]
+        version: ["1.8", "1.10", "1.12", "1.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -213,10 +213,14 @@ jobs:
             VERSION=1.10.0
             DL_PATH=windows/extra/hdf5-1.10.0-win64-VS2015-shared.zip
             echo "MSI_PATH=hdf5\\HDF5-1.10.0-win64.msi" >> $GITHUB_ENV
-          else
+          elif [[ "${{matrix.version}}" == "1.12" ]]; then
             VERSION=1.12.0
             DL_PATH=hdf5-1.12.0-Std-win10_64-vs16.zip
             echo "MSI_PATH=hdf\\HDF5-1.12.0-win64.msi" >> $GITHUB_ENV
+          else
+            VERSION=1.13.0
+            DL_PATH=windows/hdf5-1.13.0-Std-win10_64-vs16.zip
+            echo "MSI_PATH=hdf\\HDF5-1.13.0-win64.msi" >> $GITHUB_ENV
           fi
           BASE_URL=https://support.hdfgroup.org/ftp/HDF5/prev-releases
           echo "DL_URL=$BASE_URL/hdf5-${{matrix.version}}/hdf5-$VERSION/bin/$DL_PATH" >> $GITHUB_ENV

--- a/hdf5-src/Cargo.toml
+++ b/hdf5-src/Cargo.toml
@@ -32,7 +32,6 @@ hl = []
 zlib = ["libz-sys"]
 deprecated = []
 threadsafe = []
-default = ["deprecated"]
 
 [dependencies]
 libz-sys = { version = "1.0.25", features = ["static"], optional = true, default-features=false }

--- a/hdf5-src/Cargo.toml
+++ b/hdf5-src/Cargo.toml
@@ -32,6 +32,7 @@ hl = []
 zlib = ["libz-sys"]
 deprecated = []
 threadsafe = []
+default = ["deprecated"]
 
 [dependencies]
 libz-sys = { version = "1.0.25", features = ["static"], optional = true, default-features=false }

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 mpi-sys = { version = "0.1", optional = true }
 libz-sys = { version = "1.0.25", optional = true, default-features = false }
 hdf5-src = { path = "../hdf5-src", version = "0.8.1", optional = true }  # !V
+paste = "1.0.6"
 
 # Please see README for further explanation of these feature flags
 [features]

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -18,7 +18,6 @@ libc = "0.2"
 mpi-sys = { version = "0.1", optional = true }
 libz-sys = { version = "1.0.25", optional = true, default-features = false }
 hdf5-src = { path = "../hdf5-src", version = "0.8.1", optional = true }  # !V
-paste = "1.0.6"
 
 # Please see README for further explanation of these feature flags
 [features]

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -29,7 +29,7 @@ impl Version {
     }
 
     pub fn parse(s: &str) -> Option<Self> {
-        let re = Regex::new(r"^(1)\.(8|10|12)\.(\d\d?)(_\d+)?(-patch\d+)?$").ok()?;
+        let re = Regex::new(r"^(1)\.(8|10|12|13)\.(\d\d?)(_\d+)?(-patch\d+)?$").ok()?;
         let captures = re.captures(s)?;
         Some(Self {
             major: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
@@ -612,6 +612,7 @@ impl Config {
         let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-21]
         vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-8]
         vs.extend((0..=1).map(|v| Version::new(1, 12, v))); // 1.12.[0-1]
+        vs.extend((0..=0).map(|v| Version::new(1, 13, v))); // 1.13.[0-0]
         for v in vs.into_iter().filter(|&v| version >= v) {
             println!("cargo:rustc-cfg=feature=\"{}.{}.{}\"", v.major, v.minor, v.micro);
             println!("cargo:version_{}_{}_{}=1", v.major, v.minor, v.micro);

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -8,8 +8,17 @@ use crate::internal_prelude::*;
 
 pub type herr_t = c_int;
 pub type htri_t = c_int;
+
+#[cfg(not(feature = "1.13.0"))]
 pub type hsize_t = c_ulonglong;
+#[cfg(feature = "1.13.0")]
+pub type hsize_t = c_ulong;
+
+#[cfg(not(feature = "1.13.0"))]
 pub type hssize_t = c_longlong;
+#[cfg(feature = "1.13.0")]
+pub type hssize_t = c_long;
+
 pub type haddr_t = uint64_t;
 
 #[cfg(all(feature = "1.10.0", have_stdbool_h))]

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -106,3 +106,12 @@ extern "C" {
         reg_size: *mut size_t, arr_size: *mut size_t, blk_size: *mut size_t, fac_size: *mut size_t,
     ) -> herr_t;
 }
+
+#[cfg(feature = "1.13.0")]
+type H5_atclose_func_t = Option<extern "C" fn(ctx: *mut c_void)>;
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5atclose(func: H5_atclose_func_t, ctx: *mut c_void) -> herr_t;
+    pub fn H5is_library_terminating(is_terminating: *mut hbool_t) -> herr_t;
+}

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -21,9 +21,9 @@ pub type hssize_t = i64;
 
 pub type haddr_t = u64;
 
-#[cfg(all(feature = "1.10.0", have_stdbool_h))]
+#[cfg(any(all(feature = "1.10.0", have_stdbool_h), feature = "1.13.0"))]
 pub type hbool_t = u8;
-#[cfg(any(not(feature = "1.10.0"), not(have_stdbool_h)))]
+#[cfg(not(any(all(feature = "1.10.0", have_stdbool_h), feature = "1.13.0")))]
 pub type hbool_t = c_uint;
 
 #[repr(C)]

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -12,14 +12,14 @@ pub type htri_t = c_int;
 #[cfg(not(feature = "1.13.0"))]
 pub type hsize_t = c_ulonglong;
 #[cfg(feature = "1.13.0")]
-pub type hsize_t = c_ulong;
+pub type hsize_t = u64;
 
 #[cfg(not(feature = "1.13.0"))]
 pub type hssize_t = c_longlong;
 #[cfg(feature = "1.13.0")]
-pub type hssize_t = c_long;
+pub type hssize_t = i64;
 
-pub type haddr_t = uint64_t;
+pub type haddr_t = u64;
 
 #[cfg(all(feature = "1.10.0", have_stdbool_h))]
 pub type hbool_t = u8;

--- a/hdf5-sys/src/h5a.rs
+++ b/hdf5-sys/src/h5a.rs
@@ -122,3 +122,61 @@ extern "C" {
         loc_id: hid_t, attr_num: *mut c_uint, op: H5A_operator1_t, op_data: *mut c_void,
     ) -> herr_t;
 }
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Aclose_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Acreate_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        attr_name: *const c_char, type_id: hid_t, space_id: hid_t, acpl_id: hid_t, aapl_id: hid_t,
+        es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Acreate_by_name_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        obj_name: *const c_char, attr_name: *const c_char, type_id: hid_t, space_id: hid_t,
+        acpl_id: hid_t, aapl_id: hid_t, lapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Aexists_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, obj_id: hid_t,
+        attr_name: *const c_char, exists: *mut hbool_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Aexists_by_name_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        obj_name: *const c_char, attr_name: *const c_char, exists: *mut hbool_t, lapl_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Aopen_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, obj_id: hid_t,
+        attr_name: *const c_char, aapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Aopen_by_idx_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        obj_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t, n: c_ulong,
+        aapl_id: hid_t, lapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Aopen_by_name_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        obj_name: *const c_char, attr_name: *const c_char, aapl_id: hid_t, lapl_id: hid_t,
+        es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Aread_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,
+        dtype_id: hid_t, buf: *mut c_void, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Arename_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        old_name: *const c_char, new_name: *const c_char, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Arename_by_name_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        obj_name: *const c_char, old_attr_name: *const c_char, new_attr_name: *const c_char,
+        lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Awrite_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,
+        type_id: hid_t, buf: *const c_void, es_id: hid_t,
+    ) -> herr_t;
+}

--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -286,3 +286,52 @@ extern "C" {
     ) -> herr_t;
     pub fn H5Dget_num_chunks(dset_id: hid_t, fspace_id: hid_t, nchunks: *mut hsize_t) -> herr_t;
 }
+
+#[cfg(feature = "1.13.0")]
+pub type H5D_chunk_iter_op_t = Option<
+    extern "C" fn(
+        offset: *const hsize_t,
+        filter_mask: u32,
+        addr: haddr_t,
+        nbytes: u32,
+        op_data: *mut c_void,
+    ) -> c_int,
+>;
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Dchunk_iter(
+        dset_id: hid_t, dxpl: hid_t, cb: H5D_chunk_iter_op_t, op_data: *mut c_void,
+    ) -> herr_t;
+    pub fn H5Dclose_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Dcreate_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, type_id: hid_t, space_id: hid_t, lcpl_id: hid_t, dcpl_id: hid_t,
+        dapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Dget_space_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
+        es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Dopen_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, dapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Dread_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
+        mem_type_id: hid_t, mem_space_id: hid_t, file_space_id: hid_t, dxpl_id: hid_t,
+        buf: *mut c_void, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Dset_extent_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
+        size: *mut c_ulong, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Dwrite_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
+        mem_type_id: hid_t, mem_space_id: hid_t, file_space_id: hid_t, dxpl_id: hid_t,
+        buf: *const c_void, es_id: hid_t,
+    ) -> herr_t;
+}

--- a/hdf5-sys/src/h5e.rs
+++ b/hdf5-sys/src/h5e.rs
@@ -130,6 +130,11 @@ extern "C" {
     pub fn H5Eget_major(maj: H5E_major_t) -> *mut c_char;
     #[deprecated(note = "deprecated in HDF5 1.8.0")]
     pub fn H5Eget_minor(min: H5E_minor_t) -> *mut c_char;
+
+    #[cfg(feature = "1.13.0")]
+    pub fn H5Eappend_stack(
+        dst_stack_id: hid_t, src_stack_id: hid_t, close_source_stack: hbool_t,
+    ) -> herr_t;
 }
 
 pub use self::globals::*;
@@ -295,6 +300,22 @@ mod globals {
     extern_static!(H5E_CANTUNLOCKFILE, H5E_CANTUNLOCKFILE_g);
     #[cfg(feature = "1.12.1")]
     extern_static!(H5E_LIB, H5E_LIB_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_BADID, H5E_BADID_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTCANCEL, H5E_CANTCANCEL_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTFIND, H5E_CANTFIND_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTPUT, H5E_CANTPUT_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTWAIT, H5E_CANTWAIT_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_EVENTSET, H5E_EVENTSET_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_ID, H5E_ID_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_UNMOUNT, H5E_UNMOUNT_g);
 }
 
 #[cfg(all(target_env = "msvc", not(feature = "static")))]
@@ -459,4 +480,20 @@ mod globals {
     extern_static!(H5E_CANTUNLOCKFILE, __imp_H5E_CANTUNLOCKFILE_g);
     #[cfg(feature = "1.12.1")]
     extern_static!(H5E_LIB, __imp_H5E_LIB_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_BADID, __imp_H5E_BADID_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTCANCEL, __imp_H5E_CANTCANCEL_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTFIND, __imp_H5E_CANTFIND_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTPUT, __imp_H5E_CANTPUT_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_CANTWAIT, __imp_H5E_CANTWAIT_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_EVENTSET, __imp_H5E_EVENTSET_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_ID, __imp_H5E_ID_g);
+    #[cfg(feature = "1.13.0")]
+    extern_static!(H5E_UNMOUNT, __imp_H5E_UNMOUNT_g);
 }

--- a/hdf5-sys/src/h5e.rs
+++ b/hdf5-sys/src/h5e.rs
@@ -166,6 +166,7 @@ mod globals {
     extern_static!(H5E_RS, H5E_RS_g);
     extern_static!(H5E_HEAP, H5E_HEAP_g);
     extern_static!(H5E_OHDR, H5E_OHDR_g);
+    #[cfg(not(feature = "1.13.0"))]
     extern_static!(H5E_ATOM, H5E_ATOM_g);
     extern_static!(H5E_ATTR, H5E_ATTR_g);
     extern_static!(H5E_NONE_MAJOR, H5E_NONE_MAJOR_g);
@@ -241,6 +242,7 @@ mod globals {
     extern_static!(H5E_BADFILE, H5E_BADFILE_g);
     extern_static!(H5E_TRUNCATED, H5E_TRUNCATED_g);
     extern_static!(H5E_MOUNT, H5E_MOUNT_g);
+    #[cfg(not(feature = "1.13.0"))]
     extern_static!(H5E_BADATOM, H5E_BADATOM_g);
     extern_static!(H5E_BADGROUP, H5E_BADGROUP_g);
     extern_static!(H5E_CANTREGISTER, H5E_CANTREGISTER_g);
@@ -346,6 +348,7 @@ mod globals {
     extern_static!(H5E_RS, __imp_H5E_RS_g);
     extern_static!(H5E_HEAP, __imp_H5E_HEAP_g);
     extern_static!(H5E_OHDR, __imp_H5E_OHDR_g);
+    #[cfg(not(feature = "1.13.0"))]
     extern_static!(H5E_ATOM, __imp_H5E_ATOM_g);
     extern_static!(H5E_ATTR, __imp_H5E_ATTR_g);
     extern_static!(H5E_NONE_MAJOR, __imp_H5E_NONE_MAJOR_g);
@@ -421,6 +424,7 @@ mod globals {
     extern_static!(H5E_BADFILE, __imp_H5E_BADFILE_g);
     extern_static!(H5E_TRUNCATED, __imp_H5E_TRUNCATED_g);
     extern_static!(H5E_MOUNT, __imp_H5E_MOUNT_g);
+    #[cfg(not(feature = "1.13.0"))]
     extern_static!(H5E_BADATOM, __imp_H5E_BADATOM_g);
     extern_static!(H5E_BADGROUP, __imp_H5E_BADGROUP_g);
     extern_static!(H5E_CANTREGISTER, __imp_H5E_CANTREGISTER_g);

--- a/hdf5-sys/src/h5es.rs
+++ b/hdf5-sys/src/h5es.rs
@@ -2,6 +2,7 @@
 use crate::internal_prelude::*;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5ES_err_info_t {
     api_cname: *mut c_char,
     api_args: *mut c_char,
@@ -19,6 +20,7 @@ pub struct H5ES_err_info_t {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5ES_op_info_t {
     api_cname: *const c_char,
     api_args: *mut c_char,
@@ -34,6 +36,7 @@ pub struct H5ES_op_info_t {
 }
 
 #[repr(C)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum H5ES_status_t {
     H5ES_STATUS_IN_PROGRESS,
     H5ES_STATUS_SUCCEED,

--- a/hdf5-sys/src/h5es.rs
+++ b/hdf5-sys/src/h5es.rs
@@ -1,0 +1,84 @@
+//! Event set module
+use crate::internal_prelude::*;
+
+#[repr(C)]
+pub struct H5ES_err_info_t {
+    api_cname: *mut c_char,
+    api_args: *mut c_char,
+
+    app_file_name: *mut c_char,
+    app_func_name: *mut c_char,
+    app_line_num: c_uint,
+
+    op_ins_count: u64,
+    op_ins_ts: u64,
+    op_exec_ts: u64,
+    op_exec_time: u64,
+
+    err_stack_id: hid_t,
+}
+
+#[repr(C)]
+pub struct H5ES_op_info_t {
+    api_cname: *const c_char,
+    api_args: *mut c_char,
+
+    app_file_name: *const c_char,
+    app_func_name: *const c_char,
+    app_line_num: c_uint,
+
+    op_ins_count: u64,
+    op_ins_ts: u64,
+    op_exec_ts: u64,
+    op_exec_time: u64,
+}
+
+#[repr(C)]
+pub enum H5ES_status_t {
+    H5ES_STATUS_IN_PROGRESS,
+    H5ES_STATUS_SUCCEED,
+    H5ES_STATUS_CANCELED,
+    H5ES_STATUS_FAIL,
+}
+
+pub type H5ES_event_complete_func_t = Option<
+    extern "C" fn(
+        op_info: *mut H5ES_op_info_t,
+        status: H5ES_status_t,
+        err_stack: hid_t,
+        ctx: *mut c_void,
+    ) -> c_int,
+>;
+
+pub type H5ES_event_insert_func_t =
+    Option<extern "C" fn(op_info: *const H5ES_op_info_t, ctx: *mut c_void) -> c_int>;
+
+extern "C" {
+    pub fn H5ESinsert_request(es_id: hid_t, connector_id: hid_t, request: *mut c_void) -> herr_t;
+}
+
+extern "C" {
+    pub fn H5EScancel(
+        es_id: hid_t, num_not_canceled: *mut size_t, err_occured: *mut hbool_t,
+    ) -> herr_t;
+    pub fn H5ESclose(es_id: hid_t) -> herr_t;
+    pub fn H5EScreate() -> hid_t;
+    pub fn H5ESfree_err_info(num_err_info: size_t, err_info: *mut H5ES_err_info_t) -> herr_t;
+    pub fn H5ESget_count(es_id: hid_t, count: *mut size_t) -> herr_t;
+    pub fn H5ESget_err_count(es_id: hid_t, num_errs: *mut size_t) -> herr_t;
+    pub fn H5ESget_err_info(
+        es_id: hid_t, num_err_info: size_t, err_info: *mut H5ES_err_info_t,
+        err_cleared: *mut size_t,
+    ) -> herr_t;
+    pub fn H5ESget_err_status(es_id: hid_t, err_occured: *mut hbool_t) -> herr_t;
+    pub fn H5ESget_op_counter(es_id: hid_t, counter: *mut u64) -> herr_t;
+    pub fn H5ESregister_complete_func(
+        es_id: hid_t, func: H5ES_event_complete_func_t, ctx: *mut c_void,
+    ) -> herr_t;
+    pub fn H5ESregister_insert_func(
+        es_id: hid_t, func: H5ES_event_insert_func_t, ctx: *mut c_void,
+    ) -> herr_t;
+    pub fn H5ESwait(
+        es_id: hid_t, timeout: u64, num_in_progress: *mut size_t, err_occured: *mut hbool_t,
+    ) -> herr_t;
+}

--- a/hdf5-sys/src/h5es.rs
+++ b/hdf5-sys/src/h5es.rs
@@ -2,7 +2,7 @@
 use crate::internal_prelude::*;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct H5ES_err_info_t {
     api_cname: *mut c_char,
     api_args: *mut c_char,
@@ -20,7 +20,7 @@ pub struct H5ES_err_info_t {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct H5ES_op_info_t {
     api_cname: *const c_char,
     api_args: *mut c_char,

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -175,7 +175,10 @@ extern "C" {
     pub fn H5Fget_freespace(file_id: hid_t) -> hssize_t;
     pub fn H5Fget_filesize(file_id: hid_t, size: *mut hsize_t) -> herr_t;
     pub fn H5Fget_mdc_config(file_id: hid_t, config_ptr: *mut H5AC_cache_config_t) -> herr_t;
+    #[cfg(not(feature = "1.13.0"))]
     pub fn H5Fset_mdc_config(file_id: hid_t, config_ptr: *mut H5AC_cache_config_t) -> herr_t;
+    #[cfg(feature = "1.13.0")]
+    pub fn H5Fset_mdc_config(file_id: hid_t, config_ptr: *const H5AC_cache_config_t) -> herr_t;
     pub fn H5Fget_mdc_hit_rate(file_id: hid_t, hit_rate_ptr: *mut c_double) -> herr_t;
     pub fn H5Fget_mdc_size(
         file_id: hid_t, max_size_ptr: *mut size_t, min_clean_size_ptr: *mut size_t,

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -371,3 +371,27 @@ extern "C" {
     pub fn H5Fget_dset_no_attrs_hint(file_id: hid_t, minimize: *mut hbool_t) -> herr_t;
     pub fn H5Fset_dset_no_attrs_hint(file_id: hid_t, minimize: hbool_t) -> herr_t;
 }
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Fclose_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, file_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Fcreate_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint,
+        filename: *const c_char, flags: c_uint, fcpl_id: hid_t, fapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Fflush_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, object_id: hid_t,
+        scope: H5F_scope_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Fopen_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint,
+        filename: *const c_char, flags: c_uint, access_plit: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5reopen_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, file_id: hid_t,
+        es_id: hid_t,
+    ) -> hid_t;
+}

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -126,7 +126,11 @@ pub enum H5F_libver_t {
     H5F_LIBVER_EARLIEST = 0,
     H5F_LIBVER_V18 = 1,
     H5F_LIBVER_V110 = 2,
-    H5F_LIBVER_NBOUNDS = 3,
+    #[cfg(feature = "1.12.0")]
+    H5F_LIBVER_V112 = 3,
+    #[cfg(feature = "1.13.0")]
+    H5F_LIBVER_V114 = 4,
+    H5F_LIBVER_NBOUNDS,
 }
 
 #[cfg(feature = "1.10.2")]

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -211,6 +211,16 @@ pub struct H5FD_class_t {
     >,
     pub unlock:
         Option<extern "C" fn(file: *mut H5FD_t, oid: *mut c_uchar, last: hbool_t) -> herr_t>,
+    pub del: Option<extern "C" fn(name: *const c_char, fapl: hid_t) -> herr_t>,
+    pub ctl: Option<
+        extern "C" fn(
+            file: *mut H5FD_t,
+            op_code: u64,
+            flags: u64,
+            input: *const c_char,
+            output: *mut *mut c_void,
+        ) -> herr_t,
+    >,
     pub fl_map: [H5FD_mem_t; 7usize],
 }
 

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -119,9 +119,13 @@ pub const H5FD_LOG_ALL: c_ulonglong = H5FD_LOG_FREE
     | H5FD_LOG_LOC_IO
     | H5FD_LOG_META_IO;
 
+pub type H5FD_class_value_t = c_int;
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5FD_class_t {
+    #[cfg(feature = "1.13.0")]
+    pub value: H5FD_class_value_t,
     pub name: *const c_char,
     pub maxaddr: haddr_t,
     pub fc_degree: H5F_close_degree_t,
@@ -450,4 +454,18 @@ pub mod splitter {
 #[cfg(feature = "1.10.2")]
 extern "C" {
     pub fn H5FDdriver_query(driver_id: hid_t, flags: *mut c_ulong) -> herr_t;
+}
+
+#[cfg(feature = "1.13.0")]
+type H5FD_perform_init_func_t = Option<extern "C" fn() -> hid_t>;
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5FDctl(
+        file: *mut H5FD_t, op_cod: u64, flags: u64, input: *const c_void, output: *mut *mut c_void,
+    ) -> herr_t;
+    pub fn H5FDdelete(name: *const c_char, fapl_id: hid_t) -> herr_t;
+    pub fn H5FDis_driver_registered_by_name(driver_name: *const c_char) -> htri_t;
+    pub fn H5FDis_driver_registered_by_value(driver_value: H5FD_class_value_t) -> htri_t;
+    pub fn H5FDperform_init(p: H5FD_perform_init_func_t) -> hid_t;
 }

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -372,7 +372,7 @@ extern "C" {
     pub fn H5FDunlock(file: *mut H5FD_t) -> herr_t;
 }
 
-#[cfg(feature = "1.10.6")]
+#[cfg(all(feature = "1.10.6", not(feature = "1.13.0")))]
 pub mod hdfs {
     use super::*;
     pub const H5FD__CURR_HDFS_FAPL_T_VERSION: c_uint = 1;

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -8,6 +8,7 @@ use crate::internal_prelude::*;
 
 use crate::h5f::{H5F_close_degree_t, H5F_mem_t};
 
+#[cfg(not(feature = "1.13.0"))]
 pub const H5_HAVE_VFL: c_uint = 1;
 
 pub const H5FD_VFD_DEFAULT: c_uint = 0;
@@ -129,6 +130,8 @@ pub struct H5FD_class_t {
     pub name: *const c_char,
     pub maxaddr: haddr_t,
     pub fc_degree: H5F_close_degree_t,
+    #[cfg(feature = "1.13.0")]
+    pub terminate: Option<extern "C" fn() -> herr_t>,
     pub sb_size: Option<extern "C" fn(file: *mut H5FD_t) -> hsize_t>,
     pub sb_encode:
         Option<extern "C" fn(file: *mut H5FD_t, name: *mut c_char, p: *mut c_uchar) -> herr_t>,

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -214,7 +214,9 @@ pub struct H5FD_class_t {
     >,
     pub unlock:
         Option<extern "C" fn(file: *mut H5FD_t, oid: *mut c_uchar, last: hbool_t) -> herr_t>,
+    #[cfg(feature = "1.13.0")]
     pub del: Option<extern "C" fn(name: *const c_char, fapl: hid_t) -> herr_t>,
+    #[cfg(feature = "1.13.0")]
     pub ctl: Option<
         extern "C" fn(
             file: *mut H5FD_t,

--- a/hdf5-sys/src/h5g.rs
+++ b/hdf5-sys/src/h5g.rs
@@ -137,3 +137,32 @@ pub struct H5G_stat_t {
     linklen: size_t,
     ohdr: H5O_stat_t,
 }
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Gclose_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, group_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Gcreate_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, lcpl_id: hid_t, gcpl_id: hid_t, gapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Gget_info_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        ginfo: *mut H5G_info_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Gget_info_by_idx_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t, n: c_ulong,
+        ginfo: *mut H5G_info_t, lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Gget_info_by_name_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, ginfo: *mut H5G_info_t, lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Gopen_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, gapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+}

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -42,7 +42,11 @@ pub type hid_t = c_int;
 
 pub const H5I_INVALID_HID: hid_t = -1;
 
+#[cfg(not(feature = "1.13.0"))]
 pub type H5I_free_t = Option<extern "C" fn(arg1: *mut c_void) -> herr_t>;
+#[cfg(feature = "1.13.0")]
+pub type H5I_free_t = Option<extern "C" fn(*mut c_void, *mut *mut c_void) -> herr_t>;
+
 pub type H5I_search_func_t =
     Option<extern "C" fn(obj: *mut c_void, id: hid_t, key: *mut c_void) -> c_int>;
 #[cfg(feature = "1.12.0")]

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -71,3 +71,18 @@ extern "C" {
     pub fn H5Itype_exists(type_: H5I_type_t) -> htri_t;
     pub fn H5Iis_valid(id: hid_t) -> htri_t;
 }
+
+#[cfg(feature = "1.13.0")]
+pub type H5I_future_realize_func_t =
+    Option<extern "C" fn(future_object: *mut c_void, actual_object_id: *mut hid_t) -> herr_t>;
+
+#[cfg(feature = "1.13.0")]
+pub type H5I_future_discard_func_t = Option<extern "C" fn(future_object: *mut c_void) -> herr_t>;
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Iregister_future(
+        type_: H5I_type_t, object: *const c_void, realize_cb: H5I_future_realize_func_t,
+        discard_cb: H5I_future_discard_func_t,
+    ) -> hid_t;
+}

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -29,6 +29,8 @@ pub enum H5I_type_t {
     H5I_ERROR_STACK,
     #[cfg(feature = "1.12.0")]
     H5I_SPACE_SEL_ITER,
+    #[cfg(feature = "1.13.0")]
+    H5I_EVENTSET,
     H5I_NTYPES,
 }
 

--- a/hdf5-sys/src/h5l.rs
+++ b/hdf5-sys/src/h5l.rs
@@ -335,3 +335,36 @@ pub use self::{
 pub use self::{
     H5L_info2_t as H5L_info_t, H5L_iterate2_t as H5L_iterate_t, H5Literate2 as H5Literate,
 };
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Lcreate_hard_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, cur_loc_id: hid_t,
+        cur_name: *const c_char, new_loc_id: hid_t, new_name: *const c_char, lcpl_id: hid_t,
+        lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Lcreate_soft_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint,
+        link_target: *const c_char, link_loc_id: hid_t, link_name: *const c_char, lcpl_id: hid_t,
+        lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Ldelete_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Ldelete_by_idx_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t, n: c_ulong,
+        lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Lexists_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, exists: *mut hbool_t, lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Literate_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, group_id: hid_t,
+        idx_type: H5_index_t, order: H5_iter_order_t, idx_p: *mut c_ulong, op: H5L_iterate2_t,
+        op_data: *mut c_void, es_id: hid_t,
+    ) -> herr_t;
+
+}

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -475,3 +475,37 @@ mod globals {
     use super::H5O_token_t as id_t;
     extern_static!(H5O_TOKEN_UNDEF, __imp_H5O_TOKEN_UNDEF_g);
 }
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Oclose_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, object_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Ocopy_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, src_loc_id: hid_t,
+        src_name: *const c_char, dst_loc_id: hid_t, dst_name: *const c_char, ocpypl_id: hid_t,
+        lcpl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Oflush_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, obj_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Oget_info_by_name_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, oinfo: *mut H5O_info2_t, fields: c_uint, lapl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Oopen_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, lapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Oopen_by_idx_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        group_name: *const c_char, idx_type: H5_index_t, order: H5_iter_order_t, n: c_ulong,
+        lapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Orefresh_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, oid: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+}

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -17,6 +17,9 @@ use crate::h5o::H5O_mcdt_search_cb_t;
 #[cfg(feature = "1.10.1")]
 use crate::{h5ac::H5AC_cache_image_config_t, h5f::H5F_fspace_strategy_t};
 
+#[cfg(feature = "1.13.0")]
+use crate::{h5fd::H5FD_class_value_t, h5s::H5S_seloper_t};
+
 pub const H5P_CRT_ORDER_TRACKED: c_uint = 0x0001;
 pub const H5P_CRT_ORDER_INDEXED: c_uint = 0x0002;
 
@@ -787,4 +790,22 @@ extern "C" {
     pub fn H5Pget_vol_id(plist_id: hid_t, vol_id: *mut hid_t) -> herr_t;
     pub fn H5Pget_vol_info(plist_id: hid_t, vol_info: *mut *mut c_void) -> herr_t;
     pub fn H5Pset_vol(plist_id: hid_t, new_vol_id: hid_t, new_vol_id: *const c_void) -> herr_t;
+}
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Pget_driver_config_str(
+        fapl_id: hid_t, config_buf: *mut c_char, buf_size: size_t,
+    ) -> ssize_t;
+    pub fn H5Pget_vol_cap_flags(plist_id: hid_t, cap_flags: *mut c_uint) -> herr_t;
+    pub fn H5Pset_dataset_io_hyperslab_selection(
+        plist_id: hid_t, rank: c_uint, op: H5S_seloper_t, start: *const hsize_t,
+        stride: *const hsize_t, count: *const hsize_t, block: *const hsize_t,
+    ) -> herr_t;
+    pub fn H5Pset_driver_by_name(
+        plist_id: hid_t, driver_name: *const c_char, driver_config: *const c_char,
+    ) -> herr_t;
+    pub fn H5Pset_driver_by_value(
+        plist_id: hid_t, driver_value: H5FD_class_value_t, driver_config: *const c_char,
+    ) -> herr_t;
 }

--- a/hdf5-sys/src/h5r.rs
+++ b/hdf5-sys/src/h5r.rs
@@ -119,3 +119,19 @@ extern "C" {
     pub fn H5Ropen_object(ref_ptr: *const H5R_ref_t, rapl_id: hid_t, oapl_id: hid_t) -> hid_t;
     pub fn H5Ropen_region(ref_ptr: *const H5R_ref_t, rapl_id: hid_t, oapl_id: hid_t) -> hid_t;
 }
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Ropen_attr_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint,
+        ref_ptr: *mut H5R_ref_t, rapl_id: hid_t, aapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Ropen_object_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint,
+        ref_ptr: *mut H5R_ref_t, rapl_id: hid_t, oapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+    pub fn H5Ropen_region_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint,
+        ref_ptr: *mut H5R_ref_t, rapl_id: hid_t, oapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+}

--- a/hdf5-sys/src/h5t.rs
+++ b/hdf5-sys/src/h5t.rs
@@ -550,3 +550,20 @@ extern "C" {
 extern "C" {
     pub fn H5Treclaim(type_id: hid_t, space_id: hid_t, dxpl_id: hid_t, buf: *mut c_void) -> herr_t;
 }
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5Tclose_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, type_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Tcommit_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, type_id: hid_t, lcpl_id: hid_t, tcpl_id: hid_t, tapl_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5Topen_async(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, tapl_id: hid_t, es_id: hid_t,
+    ) -> hid_t;
+}

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -1,10 +1,10 @@
 //! Using the Virtual Object Layer
-#![cfg(feature = "1.12.0")]
+#![cfg(feature = "1.13.0")]
 
+use std::fmt::{self, Debug};
 use std::mem::ManuallyDrop;
 
 use crate::internal_prelude::*;
-#[cfg(feature = "1.13.0")]
 use crate::{
     h5a::{H5A_info_t, H5A_operator2_t},
     h5d::H5D_space_status_t,
@@ -17,11 +17,6 @@ use crate::{
 
 pub type H5VL_class_value_t = c_int;
 
-// Incomplete type
-#[cfg(not(feature = "1.13.0"))]
-pub type H5VL_class_t = c_void;
-
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_info_class_t {
@@ -35,7 +30,6 @@ pub struct H5VL_info_class_t {
     pub from_str: Option<extern "C" fn(str: *const c_char, info: *mut *mut c_void) -> herr_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_wrap_class_t {
@@ -49,7 +43,6 @@ pub struct H5VL_wrap_class_t {
     pub free_wrap_ctx: Option<extern "C" fn(wrap_ctx: *mut c_void) -> herr_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_attr_get_t {
@@ -61,35 +54,30 @@ pub enum H5VL_attr_get_t {
     H5VL_ATTR_GET_TYPE,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_acpl {
     pub acpl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_space {
     pub space_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_storage_size {
     pub data_size: *mut hsize_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_type {
     pub type_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_get_name_args_t {
@@ -99,7 +87,6 @@ pub struct H5VL_attr_get_name_args_t {
     pub attr_name_len: *mut size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_get_info_args_t {
@@ -108,9 +95,7 @@ pub struct H5VL_attr_get_info_args_t {
     pub ainfo: *mut H5A_info_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub union H5VL_attr_get_args_t_union {
     pub get_acpl: ManuallyDrop<H5VL_attr_get_args_t_union_get_acpl>,
     pub get_info: ManuallyDrop<H5VL_attr_get_info_args_t>,
@@ -120,15 +105,32 @@ pub union H5VL_attr_get_args_t_union {
     pub get_type: ManuallyDrop<H5VL_attr_get_args_t_union_get_type>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_attr_get_args_t {
     pub op_type: H5VL_attr_get_t,
     pub args: H5VL_attr_get_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_attr_get_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_attr_get_t::H5VL_ATTR_GET_ACPL => s.field("args", &self.args.get_acpl),
+                H5VL_attr_get_t::H5VL_ATTR_GET_INFO => s.field("args", &self.args.get_info),
+                H5VL_attr_get_t::H5VL_ATTR_GET_NAME => s.field("args", &self.args.get_name),
+                H5VL_attr_get_t::H5VL_ATTR_GET_SPACE => s.field("args", &self.args.get_space),
+                H5VL_attr_get_t::H5VL_ATTR_GET_STORAGE_SIZE => {
+                    s.field("args", &self.args.get_storage_size)
+                }
+                H5VL_attr_get_t::H5VL_ATTR_GET_TYPE => s.field("args", &self.args.get_type),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_attr_specific_t {
@@ -139,14 +141,12 @@ pub enum H5VL_attr_specific_t {
     H5VL_ATTR_RENAME,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_specific_args_t_union_del {
     pub name: *const c_char,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_specific_args_t_union_exists {
@@ -154,7 +154,6 @@ pub struct H5VL_attr_specific_args_t_union_exists {
     pub exists: *mut hbool_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_specific_args_t_union_rename {
@@ -162,7 +161,6 @@ pub struct H5VL_attr_specific_args_t_union_rename {
     pub new_name: *const c_char,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_iterate_args_t {
@@ -173,7 +171,6 @@ pub struct H5VL_attr_iterate_args_t {
     pub op_data: *mut c_void,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_delete_by_idx_args_t {
@@ -182,9 +179,7 @@ pub struct H5VL_attr_delete_by_idx_args_t {
     pub n: hsize_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub union H5VL_attr_specific_args_t_union {
     pub del: ManuallyDrop<H5VL_attr_specific_args_t_union_del>,
     pub delete_by_idx: ManuallyDrop<H5VL_attr_delete_by_idx_args_t>,
@@ -193,15 +188,31 @@ pub union H5VL_attr_specific_args_t_union {
     pub rename: ManuallyDrop<H5VL_attr_specific_args_t_union_rename>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_attr_specific_args_t {
     pub op_type: H5VL_attr_specific_t,
     pub args: H5VL_attr_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_attr_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_attr_specific_t::H5VL_ATTR_DELETE => s.field("args", &self.args.del),
+                H5VL_attr_specific_t::H5VL_ATTR_DELETE_BY_IDX => {
+                    s.field("args", &self.args.delete_by_idx)
+                }
+                H5VL_attr_specific_t::H5VL_ATTR_EXISTS => s.field("args", &self.args.exists),
+                H5VL_attr_specific_t::H5VL_ATTR_ITER => s.field("args", &self.args.iterate),
+                H5VL_attr_specific_t::H5VL_ATTR_RENAME => s.field("args", &self.args.rename),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_attr_class_t {
@@ -275,7 +286,6 @@ pub struct H5VL_attr_class_t {
         Option<extern "C" fn(attr: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_dataset_specific_t {
@@ -284,45 +294,56 @@ pub enum H5VL_dataset_specific_t {
     H5VL_DATASET_REFRESH,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
-pub union H5VL_dataset_specific_args_t_union_set_extent {
+pub struct H5VL_dataset_specific_args_t_union_set_extent {
     pub size: *const hsize_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
-pub union H5VL_dataset_specific_args_t_union_flush {
+pub struct H5VL_dataset_specific_args_t_union_flush {
     pub dset_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
-pub union H5VL_dataset_specific_args_t_union_refresh {
+pub struct H5VL_dataset_specific_args_t_union_refresh {
     pub dset_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub union H5VL_dataset_specific_args_t_union {
     pub set_extent: ManuallyDrop<H5VL_dataset_specific_args_t_union_set_extent>,
     pub flush: ManuallyDrop<H5VL_dataset_specific_args_t_union_flush>,
     pub refresh: ManuallyDrop<H5VL_dataset_specific_args_t_union_refresh>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_dataset_specific_args_t {
     pub op_type: H5VL_dataset_specific_t,
     pub args: H5VL_dataset_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_dataset_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_dataset_specific_t::H5VL_DATASET_SET_EXTENT => {
+                    s.field("args", &self.args.set_extent)
+                }
+                H5VL_dataset_specific_t::H5VL_DATASET_FLUSH => s.field("args", &self.args.flush),
+                H5VL_dataset_specific_t::H5VL_DATASET_REFRESH => {
+                    s.field("args", &self.args.refresh)
+                }
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_dataset_get_t {
@@ -334,49 +355,42 @@ pub enum H5VL_dataset_get_t {
     H5VL_DATASET_GET_TYPE,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_dapl {
     pub dapl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_dcpl {
     pub dcpl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_space {
     pub space_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_space_status {
     pub status: *mut H5D_space_status_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_storage_size {
     pub storage_size: *mut hsize_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_type {
     pub type_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_dataset_get_args_t_union {
     pub get_dapl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dapl>,
@@ -387,15 +401,34 @@ pub union H5VL_dataset_get_args_t_union {
     pub get_type: ManuallyDrop<H5VL_dataset_get_args_t_union_get_type>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t {
     pub op_type: H5VL_dataset_get_t,
     pub args: H5VL_dataset_get_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_dataset_get_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_dataset_get_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_dataset_get_t::H5VL_DATASET_GET_DAPL => s.field("args", &self.args.get_dapl),
+                H5VL_dataset_get_t::H5VL_DATASET_GET_DCPL => s.field("args", &self.args.get_dcpl),
+                H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE => s.field("args", &self.args.get_space),
+                H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE_STATUS => {
+                    s.field("args", &self.args.get_space_status)
+                }
+                H5VL_dataset_get_t::H5VL_DATASET_GET_STORAGE_SIZE => {
+                    s.field("args", &self.args.get_storage_size)
+                }
+                H5VL_dataset_get_t::H5VL_DATASET_GET_TYPE => s.field("args", &self.args.get_type),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_dataset_class_t {
@@ -473,7 +506,6 @@ pub struct H5VL_dataset_class_t {
         Option<extern "C" fn(dset: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_file_specific_t {
@@ -484,65 +516,53 @@ pub enum H5VL_file_specific_t {
     H5VL_FILE_IS_EQUAL,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_datatype_specific_args_t_union_flush {
-    pub obj_type: H5I_type_t,
-    pub scope: H5F_scope_t,
+    pub type_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
-pub struct H5VL_datatype_specific_args_t_union_reopen {
-    pub file: *mut *mut c_void,
+pub struct H5VL_datatype_specific_args_t_union_refresh {
+    pub type_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_specific_args_t_union_is_accessible {
-    pub filename: *const c_char,
-    pub fapl_id: hid_t,
-    pub accessible: *mut hbool_t,
-}
-
-#[cfg(feature = "1.13.0")]
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_specific_args_t_union_del {
-    pub filename: *const c_char,
-    pub fapl_id: hid_t,
-}
-
-#[cfg(feature = "1.13.0")]
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_specific_args_t_union_is_equal {
-    pub obj2: *mut c_void,
-    pub same_file: *mut hbool_t,
-}
-
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_datatype_specific_args_t_union {
     pub flush: ManuallyDrop<H5VL_datatype_specific_args_t_union_flush>,
-    pub reopen: ManuallyDrop<H5VL_datatype_specific_args_t_union_reopen>,
-    pub is_accessible: ManuallyDrop<H5VL_datatype_specific_args_t_union_is_accessible>,
-    pub del: ManuallyDrop<H5VL_datatype_specific_args_t_union_del>,
-    pub is_equal: ManuallyDrop<H5VL_datatype_specific_args_t_union_is_equal>,
+    pub refresh: ManuallyDrop<H5VL_datatype_specific_args_t_union_refresh>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum H5VL_datatype_specific_t {
+    H5VL_DATATYPE_FLUSH,
+    H5VL_DATATYPE_REFRESH,
+}
+
+#[repr(C)]
 pub struct H5VL_datatype_specific_args_t {
-    pub op_type: H5VL_file_specific_t,
+    pub op_type: H5VL_datatype_specific_t,
     pub args: H5VL_datatype_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_datatype_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_datatype_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_datatype_specific_t::H5VL_DATATYPE_FLUSH => s.field("args", &self.args.flush),
+                H5VL_datatype_specific_t::H5VL_DATATYPE_REFRESH => {
+                    s.field("args", &self.args.refresh)
+                }
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_datatype_get_t {
@@ -551,14 +571,12 @@ pub enum H5VL_datatype_get_t {
     H5VL_DATATYPE_GET_TCPL,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_datatype_get_args_t_union_get_binary_size {
     pub size: *mut size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_datatype_get_args_t_union_get_binary {
@@ -566,14 +584,12 @@ pub struct H5VL_datatype_get_args_t_union_get_binary {
     pub buf_size: size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_datatype_get_args_t_union_get_tcpl {
     pub tcpl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_datatype_get_args_t_union {
     pub get_binary_size: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary_size>,
@@ -581,15 +597,31 @@ pub union H5VL_datatype_get_args_t_union {
     pub get_tcpl: ManuallyDrop<H5VL_datatype_get_args_t_union_get_tcpl>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_datatype_get_args_t {
     pub op_type: H5VL_datatype_get_t,
     pub args: H5VL_datatype_get_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_datatype_get_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_datatype_get_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY_SIZE => {
+                    s.field("args", &self.args.get_binary_size)
+                }
+                H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY => {
+                    s.field("args", &self.args.get_binary)
+                }
+                H5VL_datatype_get_t::H5VL_DATATYPE_GET_TCPL => s.field("args", &self.args.get_tcpl),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_datatype_class_t {
@@ -644,7 +676,6 @@ pub struct H5VL_datatype_class_t {
         Option<extern "C" fn(dt: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_flush {
@@ -652,14 +683,12 @@ pub struct H5VL_file_specific_args_t_union_flush {
     pub scope: H5F_scope_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_reopen {
     pub file: *mut *mut c_void,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_is_accessible {
@@ -668,7 +697,6 @@ pub struct H5VL_file_specific_args_t_union_is_accessible {
     pub accessible: *mut hbool_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_del {
@@ -676,7 +704,6 @@ pub struct H5VL_file_specific_args_t_union_del {
     pub fapl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_is_equal {
@@ -684,7 +711,6 @@ pub struct H5VL_file_specific_args_t_union_is_equal {
     pub same_file: *mut hbool_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_file_specific_args_t_union {
     pub flush: ManuallyDrop<H5VL_file_specific_args_t_union_flush>,
@@ -694,15 +720,31 @@ pub union H5VL_file_specific_args_t_union {
     pub is_equal: ManuallyDrop<H5VL_file_specific_args_t_union_is_equal>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_file_specific_args_t {
     pub op_type: H5VL_file_specific_t,
     pub args: H5VL_file_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_file_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_file_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_file_specific_t::H5VL_FILE_FLUSH => s.field("args", &self.args.flush),
+                H5VL_file_specific_t::H5VL_FILE_REOPEN => s.field("args", &self.args.reopen),
+                H5VL_file_specific_t::H5VL_FILE_IS_ACCESSIBLE => {
+                    s.field("args", &self.args.is_accessible)
+                }
+                H5VL_file_specific_t::H5VL_FILE_DELETE => s.field("args", &self.args.del),
+                H5VL_file_specific_t::H5VL_FILE_IS_EQUAL => s.field("args", &self.args.is_equal),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_cont_info_t {
@@ -712,42 +754,36 @@ pub struct H5VL_file_cont_info_t {
     pub blob_id_size: size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_cont_info {
     pub info: *mut H5VL_file_cont_info_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_fapl {
     pub fapl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_fcpl {
     pub fcpl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_fileno {
     pub fileno: *mut c_ulong,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_intent {
     pub flags: *mut c_uint,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_obj_count {
@@ -755,7 +791,6 @@ pub struct H5VL_file_get_args_t_union_get_obj_count {
     pub count: *mut size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_obj_ids_args_t {
@@ -765,7 +800,6 @@ pub struct H5VL_file_get_obj_ids_args_t {
     pub count: *mut size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_get_name_args_t {
@@ -775,7 +809,6 @@ pub struct H5VL_file_get_name_args_t {
     pub file_name_len: *mut size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_file_get_args_t_union {
     pub get_cont_info: ManuallyDrop<H5VL_file_get_args_t_union_get_cont_info>,
@@ -788,7 +821,6 @@ pub union H5VL_file_get_args_t_union {
     pub get_obj_ids: ManuallyDrop<H5VL_file_get_obj_ids_args_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_file_get_t {
@@ -802,15 +834,36 @@ pub enum H5VL_file_get_t {
     H5VL_FILE_GET_OBJ_IDS,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_file_get_args_t {
     pub op_type: H5VL_file_get_t,
     pub args: H5VL_file_get_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_file_get_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_file_get_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_file_get_t::H5VL_FILE_GET_CONT_INFO => {
+                    s.field("args", &self.args.get_cont_info)
+                }
+                H5VL_file_get_t::H5VL_FILE_GET_FAPL => s.field("args", &self.args.get_fapl),
+                H5VL_file_get_t::H5VL_FILE_GET_FCPL => s.field("args", &self.args.get_fcpl),
+                H5VL_file_get_t::H5VL_FILE_GET_FILENO => s.field("args", &self.args.get_fileno),
+                H5VL_file_get_t::H5VL_FILE_GET_INTENT => s.field("args", &self.args.get_intent),
+                H5VL_file_get_t::H5VL_FILE_GET_NAME => s.field("args", &self.args.get_name),
+                H5VL_file_get_t::H5VL_FILE_GET_OBJ_COUNT => {
+                    s.field("args", &self.args.get_obj_count)
+                }
+                H5VL_file_get_t::H5VL_FILE_GET_OBJ_IDS => s.field("args", &self.args.get_obj_ids),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_file_class_t {
@@ -861,7 +914,6 @@ pub struct H5VL_file_class_t {
         Option<extern "C" fn(file: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_group_specific_t {
@@ -871,7 +923,6 @@ pub enum H5VL_group_specific_t {
     H5VL_GROUP_REFRESH,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_group_spec_mount_args_t {
@@ -880,28 +931,24 @@ pub struct H5VL_group_spec_mount_args_t {
     pub fmpl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_group_specific_args_t_union_unmount {
     pub name: *const c_char,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_group_specific_args_t_union_flush {
     pub grp_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_group_specific_args_t_union_refresh {
     pub grp_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_group_specific_args_t_union {
     pub mount: ManuallyDrop<H5VL_group_spec_mount_args_t>,
@@ -910,15 +957,28 @@ pub union H5VL_group_specific_args_t_union {
     pub refresh: ManuallyDrop<H5VL_group_specific_args_t_union_refresh>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_group_specific_args_t {
     pub op_type: H5VL_group_specific_t,
     pub args: H5VL_group_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_group_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_group_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_group_specific_t::H5VL_GROUP_MOUNT => s.field("args", &self.args.mount),
+                H5VL_group_specific_t::H5VL_GROUP_UNMOUNT => s.field("args", &self.args.unmount),
+                H5VL_group_specific_t::H5VL_GROUP_FLUSH => s.field("args", &self.args.flush),
+                H5VL_group_specific_t::H5VL_GROUP_REFRESH => s.field("args", &self.args.refresh),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_group_get_info_args_t {
@@ -926,21 +986,18 @@ pub struct H5VL_group_get_info_args_t {
     pub ginfo: *mut H5G_info_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_group_get_args_t_union_get_gcpl {
     pub gcpl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_group_get_args_t_union {
     pub get_gcpl: ManuallyDrop<H5VL_group_get_args_t_union_get_gcpl>,
     pub get_info: ManuallyDrop<H5VL_group_get_info_args_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_group_get_t {
@@ -948,15 +1005,26 @@ pub enum H5VL_group_get_t {
     H5VL_GROUP_GET_INFO,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_group_get_args_t {
     pub op_type: H5VL_group_get_t,
     pub args: H5VL_group_get_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_group_get_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_group_get_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_group_get_t::H5VL_GROUP_GET_GCPL => s.field("args", &self.args.get_gcpl),
+                H5VL_group_get_t::H5VL_GROUP_GET_INFO => s.field("args", &self.args.get_info),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_group_class_t {
@@ -1011,7 +1079,6 @@ pub struct H5VL_group_class_t {
         Option<extern "C" fn(grp: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_iterate_args_t {
@@ -1023,21 +1090,18 @@ pub struct H5VL_link_iterate_args_t {
     pub op_data: *mut c_void,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_specific_args_t_union_exists {
     pub exists: *mut hbool_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_link_specific_args_t_union {
     pub exists: ManuallyDrop<H5VL_link_specific_args_t_union_exists>,
     pub iterate: ManuallyDrop<H5VL_link_iterate_args_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_link_specific_t {
@@ -1046,22 +1110,33 @@ pub enum H5VL_link_specific_t {
     H5VL_LINK_ITER,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_link_specific_args_t {
     pub op_type: H5VL_link_specific_t,
     pub args: H5VL_link_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_link_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_link_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_link_specific_t::H5VL_LINK_DELETE => s.field("args", &"delete"),
+                H5VL_link_specific_t::H5VL_LINK_EXISTS => s.field("args", &self.args.exists),
+                H5VL_link_specific_t::H5VL_LINK_ITER => s.field("args", &self.args.iterate),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_get_args_t_union_get_info {
     pub linfo: *mut H5L_info2_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_get_args_t_union_get_name {
@@ -1070,7 +1145,6 @@ pub struct H5VL_link_get_args_t_union_get_name {
     pub name_len: *mut size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_get_args_t_union_get_val {
@@ -1078,7 +1152,6 @@ pub struct H5VL_link_get_args_t_union_get_val {
     pub buf: *mut c_void,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_link_get_args_t_union {
     pub get_info: ManuallyDrop<H5VL_link_get_args_t_union_get_info>,
@@ -1086,7 +1159,6 @@ pub union H5VL_link_get_args_t_union {
     pub get_val: ManuallyDrop<H5VL_link_get_args_t_union_get_val>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_link_get_t {
@@ -1095,15 +1167,27 @@ pub enum H5VL_link_get_t {
     H5VL_LINK_GET_VAL,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_link_get_args_t {
     pub op_type: H5VL_link_get_t,
     pub args: H5VL_link_get_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_link_get_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_link_get_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_link_get_t::H5VL_LINK_GET_INFO => s.field("args", &self.args.get_info),
+                H5VL_link_get_t::H5VL_LINK_GET_NAME => s.field("args", &self.args.get_name),
+                H5VL_link_get_t::H5VL_LINK_GET_VAL => s.field("args", &self.args.get_val),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_link_create_t {
@@ -1112,7 +1196,6 @@ pub enum H5VL_link_create_t {
     H5VL_LINK_CREATE_UD,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_create_args_t_union_hard {
@@ -1120,14 +1203,12 @@ pub struct H5VL_link_create_args_t_union_hard {
     pub curr_loc_params: H5VL_loc_params_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_create_args_t_union_soft {
     pub target: *const c_char,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_create_args_t_union_ud {
@@ -1136,7 +1217,6 @@ pub struct H5VL_link_create_args_t_union_ud {
     pub buf_size: size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_link_create_args_t_union {
     pub hard: ManuallyDrop<H5VL_link_create_args_t_union_hard>,
@@ -1144,15 +1224,27 @@ pub union H5VL_link_create_args_t_union {
     pub ud: ManuallyDrop<H5VL_link_create_args_t_union_ud>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_link_create_args_t {
     pub op_type: H5VL_link_create_t,
     pub args: H5VL_link_create_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_link_create_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_link_create_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_link_create_t::H5VL_LINK_CREATE_HARD => s.field("args", &self.args.hard),
+                H5VL_link_create_t::H5VL_LINK_CREATE_SOFT => s.field("args", &self.args.soft),
+                H5VL_link_create_t::H5VL_LINK_CREATE_UD => s.field("args", &self.args.ud),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_link_class_t {
@@ -1220,7 +1312,6 @@ pub struct H5VL_link_class_t {
     >,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_visit_args_t {
@@ -1231,42 +1322,36 @@ pub struct H5VL_object_visit_args_t {
     pub op_data: *mut c_void,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_change_rc {
     pub delta: c_int,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_exists {
     pub exists: *mut hbool_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_lookup {
     pub token_ptr: *mut H5O_token_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_flush {
     pub obj_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_refresh {
     pub obj_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_object_specific_args_t_union {
     pub change_rc: ManuallyDrop<H5VL_object_specific_args_t_union_change_rc>,
@@ -1277,7 +1362,6 @@ pub union H5VL_object_specific_args_t_union {
     pub refresh: ManuallyDrop<H5VL_object_specific_args_t_union_refresh>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_object_specific_t {
@@ -1289,15 +1373,32 @@ pub enum H5VL_object_specific_t {
     H5VL_OBJECT_REFRESH,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_object_specific_args_t {
     pub op_type: H5VL_object_specific_t,
     pub args: H5VL_object_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_object_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_object_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_object_specific_t::H5VL_OBJECT_CHANGE_REF_COUNT => {
+                    s.field("args", &self.args.change_rc)
+                }
+                H5VL_object_specific_t::H5VL_OBJECT_EXISTS => s.field("args", &self.args.exists),
+                H5VL_object_specific_t::H5VL_OBJECT_LOOKUP => s.field("args", &self.args.lookup),
+                H5VL_object_specific_t::H5VL_OBJECT_VISIT => s.field("args", &self.args.visit),
+                H5VL_object_specific_t::H5VL_OBJECT_FLUSH => s.field("args", &self.args.flush),
+                H5VL_object_specific_t::H5VL_OBJECT_REFRESH => s.field("args", &self.args.refresh),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_object_get_t {
@@ -1307,14 +1408,12 @@ pub enum H5VL_object_get_t {
     H5VL_OBJECT_GET_INFO,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_file {
     pub file: *mut *mut c_void,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_name {
@@ -1323,14 +1422,12 @@ pub struct H5VL_object_get_args_t_union_get_name {
     pub name_len: *mut size_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_type {
     pub obj_type: *mut H5O_type_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_info {
@@ -1338,7 +1435,6 @@ pub struct H5VL_object_get_args_t_union_get_info {
     pub oinfo: *mut H5O_info2_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_object_get_args_t_union {
     pub get_file: ManuallyDrop<H5VL_object_get_args_t_union_get_file>,
@@ -1347,15 +1443,28 @@ pub union H5VL_object_get_args_t_union {
     pub get_info: ManuallyDrop<H5VL_object_get_args_t_union_get_info>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_object_get_args_t {
     pub op_type: H5VL_object_get_t,
     pub args: H5VL_object_get_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_object_get_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_object_get_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_object_get_t::H5VL_OBJECT_GET_FILE => s.field("args", &self.args.get_file),
+                H5VL_object_get_t::H5VL_OBJECT_GET_NAME => s.field("args", &self.args.get_name),
+                H5VL_object_get_t::H5VL_OBJECT_GET_TYPE => s.field("args", &self.args.get_type),
+                H5VL_object_get_t::H5VL_OBJECT_GET_INFO => s.field("args", &self.args.get_info),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_object_class_t {
@@ -1410,7 +1519,6 @@ pub struct H5VL_object_class_t {
         ) -> herr_t,
     >,
 }
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_get_conn_lvl_t {
@@ -1418,7 +1526,6 @@ pub enum H5VL_get_conn_lvl_t {
     H5VL_GET_CONN_LVL_TERM,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_introspect_class_t {
@@ -1440,7 +1547,6 @@ pub struct H5VL_introspect_class_t {
     >,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_request_status_t {
@@ -1451,7 +1557,6 @@ pub enum H5VL_request_status_t {
     H5VL_REQUEST_STATUS_CANCELED,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_request_specific_t {
@@ -1459,14 +1564,12 @@ pub enum H5VL_request_specific_t {
     H5VL_REQUEST_GET_EXEC_TIME,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_request_specific_args_t_union_get_err_stack {
     pub err_stack_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_request_specific_args_t_union_get_exec_time {
@@ -1474,26 +1577,39 @@ pub struct H5VL_request_specific_args_t_union_get_exec_time {
     pub exec_time: *mut u64,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_request_specific_args_t_union {
     pub get_err_stack: ManuallyDrop<H5VL_request_specific_args_t_union_get_err_stack>,
     pub get_exec_time: ManuallyDrop<H5VL_request_specific_args_t_union_get_exec_time>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_request_specific_args_t {
     pub op_type: H5VL_request_specific_t,
     pub args: H5VL_request_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_request_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_blob_specific_args_t");
+        s.field("op_type", &self.op_type);
+        unsafe {
+            match self.op_type {
+                H5VL_request_specific_t::H5VL_REQUEST_GET_ERR_STACK => {
+                    s.field("args", &self.args.get_err_stack)
+                }
+                H5VL_request_specific_t::H5VL_REQUEST_GET_EXEC_TIME => {
+                    s.field("args", &self.args.get_exec_time)
+                }
+            }
+        };
+        s.finish()
+    }
+}
+
 pub type H5VL_request_notify_t =
     Option<extern "C" fn(ctx: *mut c_void, status: H5VL_request_status_t) -> herr_t>;
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_request_class_t {
@@ -1531,15 +1647,27 @@ pub union H5VL_blob_specific_args_t_union {
     pub is_null: ManuallyDrop<H5VL_blob_specific_args_t_union_is_null>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_blob_specific_args_t {
     pub op_type: H5VL_blob_specific_t,
     pub args: H5VL_blob_specific_args_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_blob_specific_args_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_blob_specific_args_t");
+        s.field("op_type", &self.op_type);
+        let s = unsafe {
+            match self.op_type {
+                H5VL_blob_specific_t::H5VL_BLOB_DELETE => s.field("args", &"delete"),
+                H5VL_blob_specific_t::H5VL_BLOB_ISNULL => s.field("args", &self.args.is_null),
+                H5VL_blob_specific_t::H5VL_BLOB_SETNULL => s.field("args", &"setnull"),
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_blob_class_t {
@@ -1577,7 +1705,6 @@ pub struct H5VL_blob_class_t {
     >,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_token_class_t {
@@ -1607,7 +1734,6 @@ pub struct H5VL_token_class_t {
     >,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_class_t {
@@ -1661,7 +1787,6 @@ extern "C" {
     pub fn H5VLunregister_connector(vol_id: hid_t) -> herr_t;
 }
 
-#[cfg(feature = "1.12.1")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_subclass_t {
@@ -1680,14 +1805,12 @@ pub enum H5VL_subclass_t {
     H5VL_SUBCLS_TOKEN,
 }
 
-#[cfg(feature = "1.12.1")]
 extern "C" {
     pub fn H5VLquery_optional(
         obj_id: hid_t, subcls: H5VL_subclass_t, opt_type: c_int, supported: *mut hbool_t,
     ) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_loc_type_t {
@@ -1697,7 +1820,6 @@ pub enum H5VL_loc_type_t {
     H5VL_OBJECT_BY_TOKEN,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_loc_by_name_t {
@@ -1705,7 +1827,6 @@ pub struct H5VL_loc_by_name_t {
     pub lapl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_loc_by_idx_t {
@@ -1716,14 +1837,12 @@ pub struct H5VL_loc_by_idx_t {
     pub lapl_id: hid_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_loc_by_token_t {
     pub token: *mut H5O_token_t,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
 pub union H5VL_loc_params_t_union {
     pub loc_by_token: ManuallyDrop<H5VL_loc_by_token_t>,
@@ -1731,16 +1850,35 @@ pub union H5VL_loc_params_t_union {
     pub loc_by_idx: ManuallyDrop<H5VL_loc_by_idx_t>,
 }
 
-#[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Debug)]
 pub struct H5VL_loc_params_t {
     pub obj_type: H5I_type_t,
     pub type_: H5VL_loc_type_t,
     pub loc_data: H5VL_loc_params_t_union,
 }
 
-#[cfg(feature = "1.13.0")]
+impl Debug for H5VL_loc_params_t {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("H5VL_lov_params_t");
+        s.field("obj_type", &self.obj_type).field("type", &self.type_);
+        unsafe {
+            match self.type_ {
+                H5VL_loc_type_t::H5VL_OBJECT_BY_SELF => s.field("loc_data", &"by_self"),
+                H5VL_loc_type_t::H5VL_OBJECT_BY_NAME => {
+                    s.field("loc_data", &self.loc_data.loc_by_name)
+                }
+                H5VL_loc_type_t::H5VL_OBJECT_BY_IDX => {
+                    s.field("loc_data", &self.loc_data.loc_by_idx)
+                }
+                H5VL_loc_type_t::H5VL_OBJECT_BY_TOKEN => {
+                    s.field("loc_data", &self.loc_data.loc_by_token)
+                }
+            }
+        };
+        s.finish()
+    }
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct H5VL_optional_args_t {
@@ -1748,7 +1886,6 @@ pub struct H5VL_optional_args_t {
     pub args: *mut c_void,
 }
 
-#[cfg(feature = "1.13.0")]
 extern "C" {
     pub fn H5VLattr_optional_op(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,
@@ -1792,7 +1929,6 @@ extern "C" {
     pub fn H5VLunregister_opt_operation(subcls: H5VL_subclass_t, op_name: *const c_char) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
 extern "C" {
     pub fn H5VLfinish_lib_state() -> herr_t;
     pub fn H5VLintrospect_get_cap_flags(
@@ -1801,7 +1937,6 @@ extern "C" {
     pub fn H5VLstart_lib_state() -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
 extern "C" {
     pub fn H5VLobject_is_native(obj_id: hid_t, is_native: *mut hbool_t) -> herr_t;
 }

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -1,11 +1,1529 @@
 //! Using the Virtual Object Layer
 #![cfg(feature = "1.12.0")]
+
+use std::mem::ManuallyDrop;
+
 use crate::internal_prelude::*;
+#[cfg(feature = "1.13.0")]
+use crate::{
+    h5a::{H5A_info_t, H5A_operator2_t},
+    h5d::H5D_space_status_t,
+    h5f::H5F_scope_t,
+    h5g::H5G_info_t,
+    h5i::H5I_type_t,
+    h5l::{H5L_info2_t, H5L_iterate2_t, H5L_type_t},
+    h5o::{H5O_info2_t, H5O_iterate2_t, H5O_token_t, H5O_type_t},
+};
 
 pub type H5VL_class_value_t = c_int;
 
 // Incomplete type
+#[cfg(not(feature = "1.13.0"))]
 pub type H5VL_class_t = c_void;
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_info_class_t {
+    pub size: size_t,
+    pub copy: Option<extern "C" fn(info: *const c_void) -> *mut c_void>,
+    pub cmp: Option<
+        extern "C" fn(cmp_value: *mut c_int, info1: *const c_void, info2: *const c_void) -> herr_t,
+    >,
+    pub free: Option<extern "C" fn(info: *mut c_void) -> herr_t>,
+    pub to_str: Option<extern "C" fn(info: *const c_void, str: *mut *mut c_char) -> herr_t>,
+    pub from_str: Option<extern "C" fn(str: *const c_char, info: *mut *mut c_void) -> herr_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_wrap_class_t {
+    pub get_object: Option<extern "C" fn(obj: *const c_void) -> *mut c_void>,
+    pub get_wrap_ctx:
+        Option<extern "C" fn(obj: *const c_void, wrap_ctx: *mut *mut c_void) -> herr_t>,
+    pub wrap_object: Option<
+        extern "C" fn(obj: *mut c_void, obj_type: H5I_type_t, wrap_ctx: *mut c_void) -> *mut c_void,
+    >,
+    pub unwrap_object: Option<extern "C" fn(obj: *mut c_void) -> *mut c_void>,
+    pub free_wrap_ctx: Option<extern "C" fn(wrap_ctx: *mut c_void) -> herr_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_attr_get_t {
+    H5VL_ATTR_GET_ACPL,
+    H5VL_ATTR_GET_INFO,
+    H5VL_ATTR_GET_NAME,
+    H5VL_ATTR_GET_SPACE,
+    H5VL_ATTR_GET_STORAGE_SIZE,
+    H5VL_ATTR_GET_TYPE,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_get_args_t_union_get_acpl {
+    pub acpl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_get_args_t_union_get_space {
+    pub space_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_get_args_t_union_get_storage_size {
+    pub data_size: *mut hsize_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_get_args_t_union_get_type {
+    pub type_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_get_name_args_t {
+    pub loc_params: H5VL_loc_params_t,
+    pub buf_size: size_t,
+    pub buf: *mut c_char,
+    pub attr_name_len: *mut size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_get_info_args_t {
+    pub loc_params: H5VL_loc_params_t,
+    pub attr_name: *const c_char,
+    pub ainfo: *mut H5A_info_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_attr_get_args_t_union {
+    pub get_acpl: ManuallyDrop<H5VL_attr_get_args_t_union_get_acpl>,
+    pub get_info: ManuallyDrop<H5VL_attr_get_info_args_t>,
+    pub get_name: ManuallyDrop<H5VL_attr_get_name_args_t>,
+    pub get_space: ManuallyDrop<H5VL_attr_get_args_t_union_get_space>,
+    pub get_storage_size: ManuallyDrop<H5VL_attr_get_args_t_union_get_storage_size>,
+    pub get_type: ManuallyDrop<H5VL_attr_get_args_t_union_get_type>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_get_args_t {
+    pub op_type: H5VL_attr_get_t,
+    pub args: H5VL_attr_get_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_attr_specific_t {
+    H5VL_ATTR_DELETE,
+    H5VL_ATTR_DELETE_BY_IDX,
+    H5VL_ATTR_EXISTS,
+    H5VL_ATTR_ITER,
+    H5VL_ATTR_RENAME,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_specific_args_t_union_del {
+    pub name: *const c_char,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_specific_args_t_union_exists {
+    pub name: *const c_char,
+    pub exists: *mut hbool_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_specific_args_t_union_rename {
+    pub old_name: *const c_char,
+    pub new_name: *const c_char,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_iterate_args_t {
+    pub idx_type: H5_index_t,
+    pub order: H5_iter_order_t,
+    pub idx: *mut hsize_t,
+    pub op: H5A_operator2_t,
+    pub op_data: *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_delete_by_idx_args_t {
+    pub idx_type: H5_index_t,
+    pub order: H5_iter_order_t,
+    pub n: hsize_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_attr_specific_args_t_union {
+    pub del: ManuallyDrop<H5VL_attr_specific_args_t_union_del>,
+    pub delete_by_idx: ManuallyDrop<H5VL_attr_delete_by_idx_args_t>,
+    pub exists: ManuallyDrop<H5VL_attr_specific_args_t_union_exists>,
+    pub iterate: ManuallyDrop<H5VL_attr_iterate_args_t>,
+    pub rename: ManuallyDrop<H5VL_attr_specific_args_t_union_rename>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_specific_args_t {
+    pub op_type: H5VL_attr_specific_t,
+    pub args: H5VL_attr_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_attr_class_t {
+    pub create: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            attr_name: *const c_char,
+            type_id: hid_t,
+            space_id: hid_t,
+            acpl_id: hid_t,
+            aapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub open: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            attr_name: *const c_char,
+            aapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub read: Option<
+        extern "C" fn(
+            attr: *mut c_void,
+            mem_type_id: hid_t,
+            buf: *mut c_void,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub write: Option<
+        extern "C" fn(
+            attr: *mut c_void,
+            mem_type_id: hid_t,
+            buf: *const c_void,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_attr_get_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            args: *mut H5VL_attr_specific_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub close:
+        Option<extern "C" fn(attr: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_dataset_specific_t {
+    H5VL_DATASET_SET_EXTENT,
+    H5VL_DATASET_FLUSH,
+    H5VL_DATASET_REFRESH,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_dataset_specific_args_t_union_set_extent {
+    pub size: *const hsize_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_dataset_specific_args_t_union_flush {
+    pub dset_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_dataset_specific_args_t_union_refresh {
+    pub dset_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_dataset_specific_args_t_union {
+    pub set_extent: ManuallyDrop<H5VL_dataset_specific_args_t_union_set_extent>,
+    pub flush: ManuallyDrop<H5VL_dataset_specific_args_t_union_flush>,
+    pub refresh: ManuallyDrop<H5VL_dataset_specific_args_t_union_refresh>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_specific_args_t {
+    pub op_type: H5VL_dataset_specific_t,
+    pub args: H5VL_dataset_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_dataset_get_t {
+    H5VL_DATASET_GET_DAPL,
+    H5VL_DATASET_GET_DCPL,
+    H5VL_DATASET_GET_SPACE,
+    H5VL_DATASET_GET_SPACE_STATUS,
+    H5VL_DATASET_GET_STORAGE_SIZE,
+    H5VL_DATASET_GET_TYPE,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_get_args_t_union_get_dapl {
+    pub dapl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_get_args_t_union_get_dcpl {
+    pub dcpl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_get_args_t_union_get_space {
+    pub space_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_get_args_t_union_get_space_status {
+    pub status: *mut H5D_space_status_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_get_args_t_union_get_storage_size {
+    pub storage_size: *mut hsize_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_get_args_t_union_get_type {
+    pub type_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_dataset_get_args_t_union {
+    pub get_dapl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dapl>,
+    pub get_dcpl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dcpl>,
+    pub get_space: ManuallyDrop<H5VL_dataset_get_args_t_union_get_space>,
+    pub get_space_status: ManuallyDrop<H5VL_dataset_get_args_t_union_get_space_status>,
+    pub get_storage_size: ManuallyDrop<H5VL_dataset_get_args_t_union_get_storage_size>,
+    pub get_type: ManuallyDrop<H5VL_dataset_get_args_t_union_get_type>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_get_args_t {
+    pub op_type: H5VL_dataset_get_t,
+    pub args: H5VL_dataset_get_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_dataset_class_t {
+    pub create: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            name: *const c_char,
+            lcpl_id: hid_t,
+            type_id: hid_t,
+            space_id: hid_t,
+            dcpl_id: hid_t,
+            dapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub open: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            name: *const c_char,
+            dapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub read: Option<
+        extern "C" fn(
+            dset: *mut c_void,
+            mem_type_id: hid_t,
+            mem_space_id: hid_t,
+            file_space_id: hid_t,
+            dxpl_id: hid_t,
+            buf: *mut c_void,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub write: Option<
+        extern "C" fn(
+            dset: *mut c_void,
+            mem_type_id: hid_t,
+            mem_space_id: hid_t,
+            file_space_id: hid_t,
+            dxpl_id: hid_t,
+            buf: *const c_void,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_dataset_get_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_dataset_specific_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub close:
+        Option<extern "C" fn(dset: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_file_specific_t {
+    H5VL_FILE_FLUSH,
+    H5VL_FILE_REOPEN,
+    H5VL_FILE_IS_ACCESSIBLE,
+    H5VL_FILE_DELETE,
+    H5VL_FILE_IS_EQUAL,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_specific_args_t_union_flush {
+    pub obj_type: H5I_type_t,
+    pub scope: H5F_scope_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_specific_args_t_union_reopen {
+    pub file: *mut *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_specific_args_t_union_is_accessible {
+    pub filename: *const c_char,
+    pub fapl_id: hid_t,
+    pub accessible: *mut hbool_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_specific_args_t_union_del {
+    pub filename: *const c_char,
+    pub fapl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_specific_args_t_union_is_equal {
+    pub obj2: *mut c_void,
+    pub same_file: *mut hbool_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_datatype_specific_args_t_union {
+    pub flush: ManuallyDrop<H5VL_datatype_specific_args_t_union_flush>,
+    pub reopen: ManuallyDrop<H5VL_datatype_specific_args_t_union_reopen>,
+    pub is_accessible: ManuallyDrop<H5VL_datatype_specific_args_t_union_is_accessible>,
+    pub del: ManuallyDrop<H5VL_datatype_specific_args_t_union_del>,
+    pub is_equal: ManuallyDrop<H5VL_datatype_specific_args_t_union_is_equal>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_specific_args_t {
+    pub op_type: H5VL_file_specific_t,
+    pub args: H5VL_datatype_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_datatype_get_t {
+    H5VL_DATATYPE_GET_BINARY_SIZE,
+    H5VL_DATATYPE_GET_BINARY,
+    H5VL_DATATYPE_GET_TCPL,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_get_args_t_union_get_binary_size {
+    pub size: *mut size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_get_args_t_union_get_binary {
+    pub buf: *mut c_void,
+    pub buf_size: size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_get_args_t_union_get_tcpl {
+    pub tcpl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_datatype_get_args_t_union {
+    pub get_binary_size: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary_size>,
+    pub get_binary: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary>,
+    pub get_tcpl: ManuallyDrop<H5VL_datatype_get_args_t_union_get_tcpl>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_get_args_t {
+    pub op_type: H5VL_datatype_get_t,
+    pub args: H5VL_datatype_get_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_datatype_class_t {
+    pub commit: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            name: *const c_char,
+            type_id: hid_t,
+            lcpl_id: hid_t,
+            tcpl_id: hid_t,
+            tapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub open: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            name: *const c_char,
+            tapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_datatype_get_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_datatype_specific_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub close:
+        Option<extern "C" fn(dt: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_specific_args_t_union_flush {
+    pub obj_type: H5I_type_t,
+    pub scope: H5F_scope_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_specific_args_t_union_reopen {
+    pub file: *mut *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_specific_args_t_union_is_accessible {
+    pub filename: *const c_char,
+    pub fapl_id: hid_t,
+    pub accessible: *mut hbool_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_specific_args_t_union_del {
+    pub filename: *const c_char,
+    pub fapl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_specific_args_t_union_is_equal {
+    pub obj2: *mut c_void,
+    pub same_file: *mut hbool_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_file_specific_args_t_union {
+    pub flush: ManuallyDrop<H5VL_file_specific_args_t_union_flush>,
+    pub reopen: ManuallyDrop<H5VL_file_specific_args_t_union_reopen>,
+    pub is_accessible: ManuallyDrop<H5VL_file_specific_args_t_union_is_accessible>,
+    pub del: ManuallyDrop<H5VL_file_specific_args_t_union_del>,
+    pub is_equal: ManuallyDrop<H5VL_file_specific_args_t_union_is_equal>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_specific_args_t {
+    pub op_type: H5VL_file_specific_t,
+    pub args: H5VL_file_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_cont_info_t {
+    pub version: c_uint,
+    pub feature_flags: u64,
+    pub token_size: size_t,
+    pub blob_id_size: size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_args_t_union_get_cont_info {
+    pub info: *mut H5VL_file_cont_info_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_args_t_union_get_fapl {
+    pub fapl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_args_t_union_get_fcpl {
+    pub fcpl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_args_t_union_get_fileno {
+    pub fileno: *mut c_ulong,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_args_t_union_get_intent {
+    pub flags: *mut c_uint,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_args_t_union_get_obj_count {
+    pub types: c_uint,
+    pub count: *mut size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_obj_ids_args_t {
+    pub types: c_uint,
+    pub max_objs: size_t,
+    pub old_list: *mut hid_t,
+    pub count: *mut size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_name_args_t {
+    pub r#type: H5I_type_t,
+    pub buf_size: size_t,
+    pub buf: *mut c_char,
+    pub file_name_len: *mut size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_file_get_args_t_union {
+    pub get_cont_info: ManuallyDrop<H5VL_file_get_args_t_union_get_cont_info>,
+    pub get_fapl: ManuallyDrop<H5VL_file_get_args_t_union_get_fapl>,
+    pub get_fcpl: ManuallyDrop<H5VL_file_get_args_t_union_get_fcpl>,
+    pub get_fileno: ManuallyDrop<H5VL_file_get_args_t_union_get_fileno>,
+    pub get_intent: ManuallyDrop<H5VL_file_get_args_t_union_get_intent>,
+    pub get_name: ManuallyDrop<H5VL_file_get_name_args_t>,
+    pub get_obj_count: ManuallyDrop<H5VL_file_get_args_t_union_get_obj_count>,
+    pub get_obj_ids: ManuallyDrop<H5VL_file_get_obj_ids_args_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_file_get_t {
+    H5VL_FILE_GET_CONT_INFO,
+    H5VL_FILE_GET_FAPL,
+    H5VL_FILE_GET_FCPL,
+    H5VL_FILE_GET_FILENO,
+    H5VL_FILE_GET_INTENT,
+    H5VL_FILE_GET_NAME,
+    H5VL_FILE_GET_OBJ_COUNT,
+    H5VL_FILE_GET_OBJ_IDS,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_get_args_t {
+    pub op_type: H5VL_file_get_t,
+    pub args: H5VL_file_get_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_file_class_t {
+    pub create: Option<
+        extern "C" fn(
+            name: *const c_char,
+            flags: c_uint,
+            fcpl_id: hid_t,
+            fapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub open: Option<
+        extern "C" fn(
+            name: *const c_char,
+            flags: c_uint,
+            fapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_file_get_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_file_specific_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub close:
+        Option<extern "C" fn(file: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_group_specific_t {
+    H5VL_GROUP_MOUNT,
+    H5VL_GROUP_UNMOUNT,
+    H5VL_GROUP_FLUSH,
+    H5VL_GROUP_REFRESH,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_spec_mount_args_t {
+    pub name: *const c_char,
+    pub child_file: *mut c_void,
+    pub fmpl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_specific_args_t_union_unmount {
+    pub name: *const c_char,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_specific_args_t_union_flush {
+    pub grp_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_specific_args_t_union_refresh {
+    pub grp_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_group_specific_args_t_union {
+    pub mount: ManuallyDrop<H5VL_group_spec_mount_args_t>,
+    pub unmount: ManuallyDrop<H5VL_group_specific_args_t_union_unmount>,
+    pub flush: ManuallyDrop<H5VL_group_specific_args_t_union_flush>,
+    pub refresh: ManuallyDrop<H5VL_group_specific_args_t_union_refresh>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_specific_args_t {
+    pub op_type: H5VL_group_specific_t,
+    pub args: H5VL_group_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_get_info_args_t {
+    pub loc_params: H5VL_loc_params_t,
+    pub ginfo: *mut H5G_info_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_get_args_t_union_get_gcpl {
+    pub gcpl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_group_get_args_t_union {
+    pub get_gcpl: ManuallyDrop<H5VL_group_get_args_t_union_get_gcpl>,
+    pub get_info: ManuallyDrop<H5VL_group_get_info_args_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_group_get_t {
+    H5VL_GROUP_GET_GCPL,
+    H5VL_GROUP_GET_INFO,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_get_args_t {
+    pub op_type: H5VL_group_get_t,
+    pub args: H5VL_group_get_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_group_class_t {
+    pub create: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            name: *const c_char,
+            lcpl_id: hid_t,
+            gcpl_id: hid_t,
+            gapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub open: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+
+            name: *const c_char,
+            gapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_group_get_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_group_specific_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub close:
+        Option<extern "C" fn(grp: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_iterate_args_t {
+    pub recursive: hbool_t,
+    pub idx_type: H5_index_t,
+    pub order: H5_iter_order_t,
+    pub idx_p: *mut hsize_t,
+    pub op: H5L_iterate2_t,
+    pub op_data: *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_specific_args_t_union_exists {
+    pub exists: *mut hbool_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_link_specific_args_t_union {
+    pub exists: ManuallyDrop<H5VL_link_specific_args_t_union_exists>,
+    pub iterate: ManuallyDrop<H5VL_link_iterate_args_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_link_specific_t {
+    H5VL_LINK_DELETE,
+    H5VL_LINK_EXISTS,
+    H5VL_LINK_ITER,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_specific_args_t {
+    pub op_type: H5VL_link_specific_t,
+    pub args: H5VL_link_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_get_args_t_union_get_info {
+    pub linfo: *mut H5L_info2_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_get_args_t_union_get_name {
+    pub name_size: size_t,
+    pub name: *mut c_char,
+    pub name_len: *mut size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_get_args_t_union_get_val {
+    pub buf_size: size_t,
+    pub buf: *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_link_get_args_t_union {
+    pub get_info: ManuallyDrop<H5VL_link_get_args_t_union_get_info>,
+    pub get_name: ManuallyDrop<H5VL_link_get_args_t_union_get_name>,
+    pub get_val: ManuallyDrop<H5VL_link_get_args_t_union_get_val>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_link_get_t {
+    H5VL_LINK_GET_INFO,
+    H5VL_LINK_GET_NAME,
+    H5VL_LINK_GET_VAL,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_get_args_t {
+    pub op_type: H5VL_link_get_t,
+    pub args: H5VL_link_get_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_link_create_t {
+    H5VL_LINK_CREATE_HARD,
+    H5VL_LINK_CREATE_SOFT,
+    H5VL_LINK_CREATE_UD,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_create_args_t_union_hard {
+    pub curr_obj: *mut c_void,
+    pub curr_loc_params: H5VL_loc_params_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_create_args_t_union_soft {
+    pub target: *const c_char,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_create_args_t_union_ud {
+    pub r#type: H5L_type_t,
+    pub buf: *const c_void,
+    pub buf_size: size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_link_create_args_t_union {
+    pub hard: ManuallyDrop<H5VL_link_create_args_t_union_hard>,
+    pub soft: ManuallyDrop<H5VL_link_create_args_t_union_soft>,
+    pub ud: ManuallyDrop<H5VL_link_create_args_t_union_ud>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_create_args_t {
+    pub op_type: H5VL_link_create_t,
+    pub args: H5VL_link_create_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_link_class_t {
+    pub create: Option<
+        extern "C" fn(
+            args: *mut H5VL_link_create_args_t,
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            lcpl_id: hid_t,
+            lapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub copy: Option<
+        extern "C" fn(
+            src_obj: *mut c_void,
+            loc_params1: *const H5VL_loc_params_t,
+            dest_obj: *mut c_void,
+            loc_params2: *const H5VL_loc_params_t,
+            lcpl_id: hid_t,
+            lapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub r#move: Option<
+        extern "C" fn(
+            src_obj: *mut c_void,
+            loc_params1: *const H5VL_loc_params_t,
+            dest_obj: *mut c_void,
+            loc_params2: *const H5VL_loc_params_t,
+            lcpl_id: hid_t,
+            lapl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            args: *mut H5VL_link_get_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            args: *mut H5VL_link_specific_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_visit_args_t {
+    pub idx_type: H5_index_t,
+    pub order: H5_iter_order_t,
+    pub fields: c_uint,
+    pub op: H5O_iterate2_t,
+    pub op_data: *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_specific_args_t_union_change_rc {
+    pub delta: c_int,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_specific_args_t_union_exists {
+    pub exists: *mut hbool_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_specific_args_t_union_lookup {
+    pub token_ptr: *mut H5O_token_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_specific_args_t_union_flush {
+    pub obj_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_specific_args_t_union_refresh {
+    pub obj_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_object_specific_args_t_union {
+    pub change_rc: ManuallyDrop<H5VL_object_specific_args_t_union_change_rc>,
+    pub exists: ManuallyDrop<H5VL_object_specific_args_t_union_exists>,
+    pub lookup: ManuallyDrop<H5VL_object_specific_args_t_union_lookup>,
+    pub visit: ManuallyDrop<H5VL_object_visit_args_t>,
+    pub flush: ManuallyDrop<H5VL_object_specific_args_t_union_flush>,
+    pub refresh: ManuallyDrop<H5VL_object_specific_args_t_union_refresh>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_object_specific_t {
+    H5VL_OBJECT_CHANGE_REF_COUNT,
+    H5VL_OBJECT_EXISTS,
+    H5VL_OBJECT_LOOKUP,
+    H5VL_OBJECT_VISIT,
+    H5VL_OBJECT_FLUSH,
+    H5VL_OBJECT_REFRESH,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_specific_args_t {
+    pub op_type: H5VL_object_specific_t,
+    pub args: H5VL_object_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_object_get_t {
+    H5VL_OBJECT_GET_FILE,
+    H5VL_OBJECT_GET_NAME,
+    H5VL_OBJECT_GET_TYPE,
+    H5VL_OBJECT_GET_INFO,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_get_args_t_union_get_file {
+    pub file: *mut *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_get_args_t_union_get_name {
+    pub buf_size: size_t,
+    pub buf: *mut c_char,
+    pub name_len: *mut size_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_get_args_t_union_get_type {
+    pub obj_type: *mut H5O_type_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_get_args_t_union_get_info {
+    pub fields: c_uint,
+    pub oinfo: *mut H5O_info2_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_object_get_args_t_union {
+    pub get_file: ManuallyDrop<H5VL_object_get_args_t_union_get_file>,
+    pub get_name: ManuallyDrop<H5VL_object_get_args_t_union_get_name>,
+    pub get_type: ManuallyDrop<H5VL_object_get_args_t_union_get_type>,
+    pub get_info: ManuallyDrop<H5VL_object_get_args_t_union_get_info>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_get_args_t {
+    pub op_type: H5VL_object_get_t,
+    pub args: H5VL_object_get_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_object_class_t {
+    pub open: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            opened_type: *mut H5I_type_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub copy: Option<
+        extern "C" fn(
+            src_obj: *mut c_void,
+            loc_params1: *const H5VL_loc_params_t,
+            src_name: *const c_char,
+            dest_obj: *mut c_void,
+            loc_params2: *const H5VL_loc_params_t,
+            dst_name: *const c_char,
+            ocpypl_id: hid_t,
+            lcpl_id: hid_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            args: *mut H5VL_object_get_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            args: *mut H5VL_object_specific_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            loc_params: *const H5VL_loc_params_t,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+}
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_get_conn_lvl_t {
+    H5VL_GET_CONN_LVL_CURR,
+    H5VL_GET_CONN_LVL_TERM,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_introspect_class_t {
+    pub get_conn_cls: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            lvl: H5VL_get_conn_lvl_t,
+            conn_cls: *const *const H5VL_class_t,
+        ) -> herr_t,
+    >,
+    pub get_cap_flags: Option<extern "C" fn(info: *const c_void, cap_flags: *mut c_uint) -> herr_t>,
+    pub opt_query: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            cls: H5VL_subclass_t,
+            opt_type: c_int,
+            flags: *mut u64,
+        ) -> herr_t,
+    >,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_request_status_t {
+    H5VL_REQUEST_STATUS_IN_PROGRESS,
+    H5VL_REQUEST_STATUS_SUCCEED,
+    H5VL_REQUEST_STATUS_FAIL,
+    H5VL_REQUEST_STATUS_CANT_CANCEL,
+    H5VL_REQUEST_STATUS_CANCELED,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub enum H5VL_request_specific_t {
+    H5VL_REQUEST_GET_ERR_STACK,
+    H5VL_REQUEST_GET_EXEC_TIME,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_request_specific_args_t_union_get_err_stack {
+    pub err_stack_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_request_specific_args_t_union_get_exec_time {
+    pub exec_ts: *mut u64,
+    pub exec_time: *mut u64,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_request_specific_args_t_union {
+    pub get_err_stack: ManuallyDrop<H5VL_request_specific_args_t_union_get_err_stack>,
+    pub get_exec_time: ManuallyDrop<H5VL_request_specific_args_t_union_get_exec_time>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_request_specific_args_t {
+    pub op_type: H5VL_request_specific_t,
+    pub args: H5VL_request_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+pub type H5VL_request_notify_t =
+    Option<extern "C" fn(ctx: *mut c_void, status: H5VL_request_status_t) -> herr_t>;
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_request_class_t {
+    pub wait: Option<
+        extern "C" fn(req: *mut c_void, timeout: u64, status: *mut H5VL_request_status_t) -> herr_t,
+    >,
+    pub notify: Option<
+        extern "C" fn(req: *mut c_void, cb: H5VL_request_notify_t, ctx: *mut c_void) -> herr_t,
+    >,
+    pub cancel:
+        Option<extern "C" fn(req: *mut c_void, status: *mut H5VL_request_status_t) -> herr_t>,
+    pub specific:
+        Option<extern "C" fn(req: *mut c_void, args: *mut H5VL_request_specific_args_t) -> herr_t>,
+    pub optional:
+        Option<extern "C" fn(req: *mut c_void, args: *mut H5VL_optional_args_t) -> herr_t>,
+    pub free: Option<extern "C" fn(req: *mut c_void) -> herr_t>,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum H5VL_blob_specific_t {
+    H5VL_BLOB_DELETE,
+    H5VL_BLOB_ISNULL,
+    H5VL_BLOB_SETNULL,
+}
+
+#[repr(C)]
+pub struct H5VL_blob_specific_args_t_union_is_null {
+    pub isnull: *mut hbool_t,
+}
+
+#[repr(C)]
+pub union H5VL_blob_specific_args_t_union {
+    pub is_null: ManuallyDrop<H5VL_blob_specific_args_t_union_is_null>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_blob_specific_args_t {
+    pub op_type: H5VL_blob_specific_t,
+    pub args: H5VL_blob_specific_args_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_blob_class_t {
+    pub put: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            buf: *const c_void,
+            size: size_t,
+            blob_id: *mut c_void,
+            ctx: *mut c_void,
+        ) -> herr_t,
+    >,
+    pub get: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            blob_id: *const c_void,
+            buf: *mut c_void,
+            size: size_t,
+            ctx: *mut c_void,
+        ) -> herr_t,
+    >,
+    pub specific: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            blob_id: *mut c_void,
+            args: *mut H5VL_blob_specific_args_t,
+        ) -> herr_t,
+    >,
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            blob_id: *mut c_void,
+            args: *mut H5VL_optional_args_t,
+        ) -> herr_t,
+    >,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_token_class_t {
+    pub cmp: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            token1: *const H5O_token_t,
+            token2: *const H5O_token_t,
+            cmp_value: *mut c_int,
+        ) -> herr_t,
+    >,
+    pub to_str: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            obj_type: H5I_type_t,
+            token: *const H5O_token_t,
+            token_str: *mut *mut c_char,
+        ) -> herr_t,
+    >,
+    pub from_str: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            obj_type: H5I_type_t,
+            token_str: *const c_char,
+            token: *mut H5O_token_t,
+        ) -> herr_t,
+    >,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_class_t {
+    pub version: c_uint,
+    pub value: H5VL_class_value_t,
+    pub name: *const c_char,
+    pub conn_version: c_uint,
+    pub cap_flags: c_uint,
+    pub initialize: Option<extern "C" fn(vipl_id: hid_t) -> herr_t>,
+    pub terminate: Option<extern "C" fn() -> herr_t>,
+
+    pub info_cls: H5VL_info_class_t,
+    pub wrap_cls: H5VL_wrap_class_t,
+
+    pub attr_cls: H5VL_attr_class_t,
+    pub dataset_cls: H5VL_dataset_class_t,
+    pub datatype_cls: H5VL_datatype_class_t,
+    pub file_cl: H5VL_file_class_t,
+    pub group_cls: H5VL_group_class_t,
+    pub link_cls: H5VL_link_class_t,
+    pub object_cls: H5VL_object_class_t,
+
+    pub introspect_cls: H5VL_introspect_class_t,
+    pub request_cls: H5VL_request_class_t,
+    pub blob_cls: H5VL_blob_class_t,
+    pub token_cls: H5VL_token_class_t,
+
+    pub optional: Option<
+        extern "C" fn(
+            obj: *mut c_void,
+            args: *mut H5VL_optional_args_t,
+            dxpl_id: hid_t,
+            req: *mut *mut c_void,
+        ) -> herr_t,
+    >,
+}
 
 extern "C" {
     pub fn H5VLclose(connector_id: hid_t) -> herr_t;
@@ -51,9 +1569,58 @@ extern "C" {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum H5VL_loc_type_t {
+    H5VL_OBJECT_BY_SELF,
+    H5VL_OBJECT_BY_NAME,
+    H5VL_OBJECT_BY_IDX,
+    H5VL_OBJECT_BY_TOKEN,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_loc_by_name_t {
+    pub name: *const c_char,
+    pub lapl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_loc_by_idx_t {
+    pub name: *const c_char,
+    pub idx_type: H5_index_t,
+    pub order: H5_iter_order_t,
+    pub n: hsize_t,
+    pub lapl_id: hid_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_loc_by_token_t {
+    pub token: *mut H5O_token_t,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub union H5VL_loc_params_t_union {
+    pub loc_by_token: ManuallyDrop<H5VL_loc_by_token_t>,
+    pub loc_by_name: ManuallyDrop<H5VL_loc_by_name_t>,
+    pub loc_by_idx: ManuallyDrop<H5VL_loc_by_idx_t>,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_loc_params_t {
+    pub obj_type: H5I_type_t,
+    pub type_: H5VL_loc_type_t,
+    pub loc_data: H5VL_loc_params_t_union,
+}
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
 pub struct H5VL_optional_args_t {
-    op_type: c_int,
-    args: *mut c_void,
+    pub op_type: c_int,
+    pub args: *mut c_void,
 }
 
 #[cfg(feature = "1.13.0")]

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -48,3 +48,68 @@ extern "C" {
         obj_id: hid_t, subcls: H5VL_subclass_t, opt_type: c_int, supported: *mut hbool_t,
     ) -> herr_t;
 }
+
+#[cfg(feature = "1.13.0")]
+#[repr(C)]
+pub struct H5VL_optional_args_t {
+    op_type: c_int,
+    args: *mut c_void,
+}
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5VLattr_optional_op(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,
+        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5VLdataset_optional_op(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
+        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5VLdatatype_optional_op(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, type_id: hid_t,
+        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5VLfile_optional_op(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, file_id: hid_t,
+        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5VLfind_opt_operation(
+        subcls: H5VL_subclass_t, op_name: *const c_char, op_val: *mut c_int,
+    ) -> herr_t;
+    pub fn H5VLgroup_optional_op(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, group_id: hid_t,
+        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5VLlink_optional_op(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, lapl_id: hid_t, args: *mut H5VL_optional_args_t, dxpl_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5VLobject_optional_op(
+        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+        name: *const c_char, lapl_id: hid_t, args: *mut H5VL_optional_args_t, dxpl_id: hid_t,
+        es_id: hid_t,
+    ) -> herr_t;
+    pub fn H5VLregister_opt_operation(
+        subcls: H5VL_subclass_t, op_name: *const c_char, op_val: *mut c_int,
+    ) -> herr_t;
+    pub fn H5VLrequest_optional_op(
+        req: *mut c_void, connector_id: hid_t, args: *mut H5VL_optional_args_t,
+    ) -> herr_t;
+    pub fn H5VLunregister_opt_operation(subcls: H5VL_subclass_t, op_name: *const c_char) -> herr_t;
+}
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5VLfinish_lib_state() -> herr_t;
+    pub fn H5VLintrospect_get_cap_flags(
+        info: *const c_void, connector_id: hid_t, cap_flags: *mut c_uint,
+    ) -> herr_t;
+    pub fn H5VLstart_lib_state() -> herr_t;
+}
+
+#[cfg(feature = "1.13.0")]
+extern "C" {
+    pub fn H5VLobject_is_native(obj_id: hid_t, is_native: *mut hbool_t) -> herr_t;
+}

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -23,6 +23,7 @@ pub type H5VL_class_t = c_void;
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_info_class_t {
     pub size: size_t,
     pub copy: Option<extern "C" fn(info: *const c_void) -> *mut c_void>,
@@ -36,6 +37,7 @@ pub struct H5VL_info_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_wrap_class_t {
     pub get_object: Option<extern "C" fn(obj: *const c_void) -> *mut c_void>,
     pub get_wrap_ctx:
@@ -49,6 +51,7 @@ pub struct H5VL_wrap_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_attr_get_t {
     H5VL_ATTR_GET_ACPL,
     H5VL_ATTR_GET_INFO,
@@ -60,30 +63,35 @@ pub enum H5VL_attr_get_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_acpl {
     pub acpl_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_space {
     pub space_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_storage_size {
     pub data_size: *mut hsize_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_get_args_t_union_get_type {
     pub type_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_get_name_args_t {
     pub loc_params: H5VL_loc_params_t,
     pub buf_size: size_t,
@@ -93,6 +101,7 @@ pub struct H5VL_attr_get_name_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_get_info_args_t {
     pub loc_params: H5VL_loc_params_t,
     pub attr_name: *const c_char,
@@ -101,6 +110,7 @@ pub struct H5VL_attr_get_info_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub union H5VL_attr_get_args_t_union {
     pub get_acpl: ManuallyDrop<H5VL_attr_get_args_t_union_get_acpl>,
     pub get_info: ManuallyDrop<H5VL_attr_get_info_args_t>,
@@ -112,6 +122,7 @@ pub union H5VL_attr_get_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_get_args_t {
     pub op_type: H5VL_attr_get_t,
     pub args: H5VL_attr_get_args_t_union,
@@ -119,6 +130,7 @@ pub struct H5VL_attr_get_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_attr_specific_t {
     H5VL_ATTR_DELETE,
     H5VL_ATTR_DELETE_BY_IDX,
@@ -129,12 +141,14 @@ pub enum H5VL_attr_specific_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_specific_args_t_union_del {
     pub name: *const c_char,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_specific_args_t_union_exists {
     pub name: *const c_char,
     pub exists: *mut hbool_t,
@@ -142,6 +156,7 @@ pub struct H5VL_attr_specific_args_t_union_exists {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_specific_args_t_union_rename {
     pub old_name: *const c_char,
     pub new_name: *const c_char,
@@ -149,6 +164,7 @@ pub struct H5VL_attr_specific_args_t_union_rename {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_iterate_args_t {
     pub idx_type: H5_index_t,
     pub order: H5_iter_order_t,
@@ -159,6 +175,7 @@ pub struct H5VL_attr_iterate_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_delete_by_idx_args_t {
     pub idx_type: H5_index_t,
     pub order: H5_iter_order_t,
@@ -167,6 +184,7 @@ pub struct H5VL_attr_delete_by_idx_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub union H5VL_attr_specific_args_t_union {
     pub del: ManuallyDrop<H5VL_attr_specific_args_t_union_del>,
     pub delete_by_idx: ManuallyDrop<H5VL_attr_delete_by_idx_args_t>,
@@ -177,6 +195,7 @@ pub union H5VL_attr_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_specific_args_t {
     pub op_type: H5VL_attr_specific_t,
     pub args: H5VL_attr_specific_args_t_union,
@@ -184,6 +203,7 @@ pub struct H5VL_attr_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_attr_class_t {
     pub create: Option<
         extern "C" fn(
@@ -257,6 +277,7 @@ pub struct H5VL_attr_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_dataset_specific_t {
     H5VL_DATASET_SET_EXTENT,
     H5VL_DATASET_FLUSH,
@@ -265,24 +286,28 @@ pub enum H5VL_dataset_specific_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub union H5VL_dataset_specific_args_t_union_set_extent {
     pub size: *const hsize_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub union H5VL_dataset_specific_args_t_union_flush {
     pub dset_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub union H5VL_dataset_specific_args_t_union_refresh {
     pub dset_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub union H5VL_dataset_specific_args_t_union {
     pub set_extent: ManuallyDrop<H5VL_dataset_specific_args_t_union_set_extent>,
     pub flush: ManuallyDrop<H5VL_dataset_specific_args_t_union_flush>,
@@ -291,6 +316,7 @@ pub union H5VL_dataset_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_specific_args_t {
     pub op_type: H5VL_dataset_specific_t,
     pub args: H5VL_dataset_specific_args_t_union,
@@ -298,6 +324,7 @@ pub struct H5VL_dataset_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_dataset_get_t {
     H5VL_DATASET_GET_DAPL,
     H5VL_DATASET_GET_DCPL,
@@ -309,36 +336,42 @@ pub enum H5VL_dataset_get_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_dapl {
     pub dapl_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_dcpl {
     pub dcpl_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_space {
     pub space_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_space_status {
     pub status: *mut H5D_space_status_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_storage_size {
     pub storage_size: *mut hsize_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t_union_get_type {
     pub type_id: hid_t,
 }
@@ -356,6 +389,7 @@ pub union H5VL_dataset_get_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_get_args_t {
     pub op_type: H5VL_dataset_get_t,
     pub args: H5VL_dataset_get_args_t_union,
@@ -363,6 +397,7 @@ pub struct H5VL_dataset_get_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_dataset_class_t {
     pub create: Option<
         extern "C" fn(
@@ -440,6 +475,7 @@ pub struct H5VL_dataset_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_file_specific_t {
     H5VL_FILE_FLUSH,
     H5VL_FILE_REOPEN,
@@ -450,6 +486,7 @@ pub enum H5VL_file_specific_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_specific_args_t_union_flush {
     pub obj_type: H5I_type_t,
     pub scope: H5F_scope_t,
@@ -457,12 +494,14 @@ pub struct H5VL_datatype_specific_args_t_union_flush {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_specific_args_t_union_reopen {
     pub file: *mut *mut c_void,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_specific_args_t_union_is_accessible {
     pub filename: *const c_char,
     pub fapl_id: hid_t,
@@ -471,6 +510,7 @@ pub struct H5VL_datatype_specific_args_t_union_is_accessible {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_specific_args_t_union_del {
     pub filename: *const c_char,
     pub fapl_id: hid_t,
@@ -478,6 +518,7 @@ pub struct H5VL_datatype_specific_args_t_union_del {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_specific_args_t_union_is_equal {
     pub obj2: *mut c_void,
     pub same_file: *mut hbool_t,
@@ -495,6 +536,7 @@ pub union H5VL_datatype_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_specific_args_t {
     pub op_type: H5VL_file_specific_t,
     pub args: H5VL_datatype_specific_args_t_union,
@@ -502,6 +544,7 @@ pub struct H5VL_datatype_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_datatype_get_t {
     H5VL_DATATYPE_GET_BINARY_SIZE,
     H5VL_DATATYPE_GET_BINARY,
@@ -510,12 +553,14 @@ pub enum H5VL_datatype_get_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_get_args_t_union_get_binary_size {
     pub size: *mut size_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_get_args_t_union_get_binary {
     pub buf: *mut c_void,
     pub buf_size: size_t,
@@ -523,6 +568,7 @@ pub struct H5VL_datatype_get_args_t_union_get_binary {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_get_args_t_union_get_tcpl {
     pub tcpl_id: hid_t,
 }
@@ -537,6 +583,7 @@ pub union H5VL_datatype_get_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_get_args_t {
     pub op_type: H5VL_datatype_get_t,
     pub args: H5VL_datatype_get_args_t_union,
@@ -544,6 +591,7 @@ pub struct H5VL_datatype_get_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_datatype_class_t {
     pub commit: Option<
         extern "C" fn(
@@ -598,6 +646,7 @@ pub struct H5VL_datatype_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_flush {
     pub obj_type: H5I_type_t,
     pub scope: H5F_scope_t,
@@ -605,12 +654,14 @@ pub struct H5VL_file_specific_args_t_union_flush {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_reopen {
     pub file: *mut *mut c_void,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_is_accessible {
     pub filename: *const c_char,
     pub fapl_id: hid_t,
@@ -619,6 +670,7 @@ pub struct H5VL_file_specific_args_t_union_is_accessible {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_del {
     pub filename: *const c_char,
     pub fapl_id: hid_t,
@@ -626,6 +678,7 @@ pub struct H5VL_file_specific_args_t_union_del {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_specific_args_t_union_is_equal {
     pub obj2: *mut c_void,
     pub same_file: *mut hbool_t,
@@ -643,6 +696,7 @@ pub union H5VL_file_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_specific_args_t {
     pub op_type: H5VL_file_specific_t,
     pub args: H5VL_file_specific_args_t_union,
@@ -650,6 +704,7 @@ pub struct H5VL_file_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_cont_info_t {
     pub version: c_uint,
     pub feature_flags: u64,
@@ -659,36 +714,42 @@ pub struct H5VL_file_cont_info_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_cont_info {
     pub info: *mut H5VL_file_cont_info_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_fapl {
     pub fapl_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_fcpl {
     pub fcpl_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_fileno {
     pub fileno: *mut c_ulong,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_intent {
     pub flags: *mut c_uint,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_args_t_union_get_obj_count {
     pub types: c_uint,
     pub count: *mut size_t,
@@ -696,6 +757,7 @@ pub struct H5VL_file_get_args_t_union_get_obj_count {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_obj_ids_args_t {
     pub types: c_uint,
     pub max_objs: size_t,
@@ -705,6 +767,7 @@ pub struct H5VL_file_get_obj_ids_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_name_args_t {
     pub r#type: H5I_type_t,
     pub buf_size: size_t,
@@ -727,6 +790,7 @@ pub union H5VL_file_get_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_file_get_t {
     H5VL_FILE_GET_CONT_INFO,
     H5VL_FILE_GET_FAPL,
@@ -740,6 +804,7 @@ pub enum H5VL_file_get_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_get_args_t {
     pub op_type: H5VL_file_get_t,
     pub args: H5VL_file_get_args_t_union,
@@ -747,6 +812,7 @@ pub struct H5VL_file_get_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_file_class_t {
     pub create: Option<
         extern "C" fn(
@@ -797,6 +863,7 @@ pub struct H5VL_file_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_group_specific_t {
     H5VL_GROUP_MOUNT,
     H5VL_GROUP_UNMOUNT,
@@ -806,6 +873,7 @@ pub enum H5VL_group_specific_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_spec_mount_args_t {
     pub name: *const c_char,
     pub child_file: *mut c_void,
@@ -814,18 +882,21 @@ pub struct H5VL_group_spec_mount_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_specific_args_t_union_unmount {
     pub name: *const c_char,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_specific_args_t_union_flush {
     pub grp_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_specific_args_t_union_refresh {
     pub grp_id: hid_t,
 }
@@ -841,6 +912,7 @@ pub union H5VL_group_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_specific_args_t {
     pub op_type: H5VL_group_specific_t,
     pub args: H5VL_group_specific_args_t_union,
@@ -848,6 +920,7 @@ pub struct H5VL_group_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_get_info_args_t {
     pub loc_params: H5VL_loc_params_t,
     pub ginfo: *mut H5G_info_t,
@@ -855,6 +928,7 @@ pub struct H5VL_group_get_info_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_get_args_t_union_get_gcpl {
     pub gcpl_id: hid_t,
 }
@@ -868,6 +942,7 @@ pub union H5VL_group_get_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_group_get_t {
     H5VL_GROUP_GET_GCPL,
     H5VL_GROUP_GET_INFO,
@@ -875,6 +950,7 @@ pub enum H5VL_group_get_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_get_args_t {
     pub op_type: H5VL_group_get_t,
     pub args: H5VL_group_get_args_t_union,
@@ -882,6 +958,7 @@ pub struct H5VL_group_get_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_group_class_t {
     pub create: Option<
         extern "C" fn(
@@ -936,6 +1013,7 @@ pub struct H5VL_group_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_iterate_args_t {
     pub recursive: hbool_t,
     pub idx_type: H5_index_t,
@@ -947,6 +1025,7 @@ pub struct H5VL_link_iterate_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_specific_args_t_union_exists {
     pub exists: *mut hbool_t,
 }
@@ -960,6 +1039,7 @@ pub union H5VL_link_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_link_specific_t {
     H5VL_LINK_DELETE,
     H5VL_LINK_EXISTS,
@@ -968,6 +1048,7 @@ pub enum H5VL_link_specific_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_specific_args_t {
     pub op_type: H5VL_link_specific_t,
     pub args: H5VL_link_specific_args_t_union,
@@ -975,12 +1056,14 @@ pub struct H5VL_link_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_get_args_t_union_get_info {
     pub linfo: *mut H5L_info2_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_get_args_t_union_get_name {
     pub name_size: size_t,
     pub name: *mut c_char,
@@ -989,6 +1072,7 @@ pub struct H5VL_link_get_args_t_union_get_name {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_get_args_t_union_get_val {
     pub buf_size: size_t,
     pub buf: *mut c_void,
@@ -1004,6 +1088,7 @@ pub union H5VL_link_get_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_link_get_t {
     H5VL_LINK_GET_INFO,
     H5VL_LINK_GET_NAME,
@@ -1012,6 +1097,7 @@ pub enum H5VL_link_get_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_get_args_t {
     pub op_type: H5VL_link_get_t,
     pub args: H5VL_link_get_args_t_union,
@@ -1019,6 +1105,7 @@ pub struct H5VL_link_get_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_link_create_t {
     H5VL_LINK_CREATE_HARD,
     H5VL_LINK_CREATE_SOFT,
@@ -1027,6 +1114,7 @@ pub enum H5VL_link_create_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_create_args_t_union_hard {
     pub curr_obj: *mut c_void,
     pub curr_loc_params: H5VL_loc_params_t,
@@ -1034,12 +1122,14 @@ pub struct H5VL_link_create_args_t_union_hard {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_create_args_t_union_soft {
     pub target: *const c_char,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_create_args_t_union_ud {
     pub r#type: H5L_type_t,
     pub buf: *const c_void,
@@ -1056,6 +1146,7 @@ pub union H5VL_link_create_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_create_args_t {
     pub op_type: H5VL_link_create_t,
     pub args: H5VL_link_create_args_t_union,
@@ -1063,6 +1154,7 @@ pub struct H5VL_link_create_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_link_class_t {
     pub create: Option<
         extern "C" fn(
@@ -1130,6 +1222,7 @@ pub struct H5VL_link_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_visit_args_t {
     pub idx_type: H5_index_t,
     pub order: H5_iter_order_t,
@@ -1140,30 +1233,35 @@ pub struct H5VL_object_visit_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_change_rc {
     pub delta: c_int,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_exists {
     pub exists: *mut hbool_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_lookup {
     pub token_ptr: *mut H5O_token_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_flush {
     pub obj_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_specific_args_t_union_refresh {
     pub obj_id: hid_t,
 }
@@ -1181,6 +1279,7 @@ pub union H5VL_object_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_object_specific_t {
     H5VL_OBJECT_CHANGE_REF_COUNT,
     H5VL_OBJECT_EXISTS,
@@ -1192,6 +1291,7 @@ pub enum H5VL_object_specific_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_specific_args_t {
     pub op_type: H5VL_object_specific_t,
     pub args: H5VL_object_specific_args_t_union,
@@ -1199,6 +1299,7 @@ pub struct H5VL_object_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_object_get_t {
     H5VL_OBJECT_GET_FILE,
     H5VL_OBJECT_GET_NAME,
@@ -1208,12 +1309,14 @@ pub enum H5VL_object_get_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_file {
     pub file: *mut *mut c_void,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_name {
     pub buf_size: size_t,
     pub buf: *mut c_char,
@@ -1222,12 +1325,14 @@ pub struct H5VL_object_get_args_t_union_get_name {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_type {
     pub obj_type: *mut H5O_type_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_get_args_t_union_get_info {
     pub fields: c_uint,
     pub oinfo: *mut H5O_info2_t,
@@ -1244,6 +1349,7 @@ pub union H5VL_object_get_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_get_args_t {
     pub op_type: H5VL_object_get_t,
     pub args: H5VL_object_get_args_t_union,
@@ -1251,6 +1357,7 @@ pub struct H5VL_object_get_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_object_class_t {
     pub open: Option<
         extern "C" fn(
@@ -1305,6 +1412,7 @@ pub struct H5VL_object_class_t {
 }
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_get_conn_lvl_t {
     H5VL_GET_CONN_LVL_CURR,
     H5VL_GET_CONN_LVL_TERM,
@@ -1312,6 +1420,7 @@ pub enum H5VL_get_conn_lvl_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_introspect_class_t {
     pub get_conn_cls: Option<
         extern "C" fn(
@@ -1333,6 +1442,7 @@ pub struct H5VL_introspect_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_request_status_t {
     H5VL_REQUEST_STATUS_IN_PROGRESS,
     H5VL_REQUEST_STATUS_SUCCEED,
@@ -1343,6 +1453,7 @@ pub enum H5VL_request_status_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_request_specific_t {
     H5VL_REQUEST_GET_ERR_STACK,
     H5VL_REQUEST_GET_EXEC_TIME,
@@ -1350,12 +1461,14 @@ pub enum H5VL_request_specific_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_request_specific_args_t_union_get_err_stack {
     pub err_stack_id: hid_t,
 }
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_request_specific_args_t_union_get_exec_time {
     pub exec_ts: *mut u64,
     pub exec_time: *mut u64,
@@ -1370,6 +1483,7 @@ pub union H5VL_request_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_request_specific_args_t {
     pub op_type: H5VL_request_specific_t,
     pub args: H5VL_request_specific_args_t_union,
@@ -1381,6 +1495,7 @@ pub type H5VL_request_notify_t =
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_request_class_t {
     pub wait: Option<
         extern "C" fn(req: *mut c_void, timeout: u64, status: *mut H5VL_request_status_t) -> herr_t,
@@ -1398,7 +1513,7 @@ pub struct H5VL_request_class_t {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_blob_specific_t {
     H5VL_BLOB_DELETE,
     H5VL_BLOB_ISNULL,
@@ -1406,6 +1521,7 @@ pub enum H5VL_blob_specific_t {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_blob_specific_args_t_union_is_null {
     pub isnull: *mut hbool_t,
 }
@@ -1417,6 +1533,7 @@ pub union H5VL_blob_specific_args_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_blob_specific_args_t {
     pub op_type: H5VL_blob_specific_t,
     pub args: H5VL_blob_specific_args_t_union,
@@ -1424,6 +1541,7 @@ pub struct H5VL_blob_specific_args_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_blob_class_t {
     pub put: Option<
         extern "C" fn(
@@ -1461,6 +1579,7 @@ pub struct H5VL_blob_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_token_class_t {
     pub cmp: Option<
         extern "C" fn(
@@ -1490,6 +1609,7 @@ pub struct H5VL_token_class_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_class_t {
     pub version: c_uint,
     pub value: H5VL_class_value_t,
@@ -1543,7 +1663,7 @@ extern "C" {
 
 #[cfg(feature = "1.12.1")]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_subclass_t {
     H5VL_SUBCLS_NONE,
     H5VL_SUBCLS_INFO,
@@ -1569,7 +1689,7 @@ extern "C" {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_loc_type_t {
     H5VL_OBJECT_BY_SELF,
     H5VL_OBJECT_BY_NAME,
@@ -1579,6 +1699,7 @@ pub enum H5VL_loc_type_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_loc_by_name_t {
     pub name: *const c_char,
     pub lapl_id: hid_t,
@@ -1586,6 +1707,7 @@ pub struct H5VL_loc_by_name_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_loc_by_idx_t {
     pub name: *const c_char,
     pub idx_type: H5_index_t,
@@ -1596,6 +1718,7 @@ pub struct H5VL_loc_by_idx_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_loc_by_token_t {
     pub token: *mut H5O_token_t,
 }
@@ -1610,6 +1733,7 @@ pub union H5VL_loc_params_t_union {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_loc_params_t {
     pub obj_type: H5I_type_t,
     pub type_: H5VL_loc_type_t,
@@ -1618,6 +1742,7 @@ pub struct H5VL_loc_params_t {
 
 #[cfg(feature = "1.13.0")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct H5VL_optional_args_t {
     pub op_type: c_int,
     pub args: *mut c_void,

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -109,20 +109,19 @@ mod v1_13_0 {
     use super::*;
 
     macro_rules! impl_debug_args {
-        ($struct: ty, $($m: pat => $arg: expr),+) => {
-            paste::paste! {
-                impl Debug for $struct {
-                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                        let mut s = f.debug_struct(stringify!($struct));
-                        s.field("op_type", &self.op_type);
-                        match self.op_type {
-                            $($m => {
-                                let arg: &dyn for<'a> Fn(&'a [<$struct _union>]) -> &'a dyn Debug = $arg;
-                                s.field("args", arg(&self.args))
-                            }),+,
-                        };
-                        s.finish()
-                    }
+        ($ty:ty, $tag:ident, $args:ty, {$($variant:ident => $func:expr),+$(,)*}) => {
+            #[allow(unreachable_patterns)]
+            impl std::fmt::Debug for $ty {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let mut s = f.debug_struct(stringify!($ty));
+                    s.field("op_type", &self.op_type);
+                    match self.op_type {$(
+                        $tag::$variant => {
+                            s.field("args", &($func as fn($args) -> _)(self.args));
+                        }
+                        _ => {}
+                    )+}
+                    s.finish()
                 }
             }
         };
@@ -232,13 +231,18 @@ mod v1_13_0 {
         pub args: H5VL_attr_get_args_t_union,
     }
 
-    impl_debug_args!(H5VL_attr_get_args_t,
-        H5VL_attr_get_t::H5VL_ATTR_GET_ACPL => &|args| unsafe { &args.get_acpl },
-        H5VL_attr_get_t::H5VL_ATTR_GET_INFO => &|args| unsafe { &args.get_info },
-        H5VL_attr_get_t::H5VL_ATTR_GET_NAME => &|args| unsafe { &args.get_name },
-        H5VL_attr_get_t::H5VL_ATTR_GET_SPACE => &|args| unsafe { &args.get_space },
-        H5VL_attr_get_t::H5VL_ATTR_GET_STORAGE_SIZE => &|args| unsafe { &args.get_storage_size },
-        H5VL_attr_get_t::H5VL_ATTR_GET_TYPE => &|args| unsafe { &args.get_type }
+    impl_debug_args!(
+        H5VL_attr_get_args_t,
+        H5VL_attr_get_t,
+        H5VL_attr_get_args_t_union,
+        {
+            H5VL_ATTR_GET_ACPL => |args| unsafe { args.get_acpl },
+            H5VL_ATTR_GET_INFO => |args| unsafe { args.get_info },
+            H5VL_ATTR_GET_NAME => |args| unsafe { args.get_name },
+            H5VL_ATTR_GET_SPACE => |args| unsafe { args.get_space },
+            H5VL_ATTR_GET_STORAGE_SIZE => |args| unsafe { args.get_storage_size },
+            H5VL_ATTR_GET_TYPE => |args| unsafe { args.get_type },
+        }
     );
 
     #[repr(C)]
@@ -306,12 +310,17 @@ mod v1_13_0 {
         pub args: H5VL_attr_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_attr_specific_args_t,
-        H5VL_attr_specific_t::H5VL_ATTR_DELETE => &|args| unsafe { &args.del },
-        H5VL_attr_specific_t::H5VL_ATTR_DELETE_BY_IDX => &|args| unsafe { &args.delete_by_idx },
-        H5VL_attr_specific_t::H5VL_ATTR_EXISTS => &|args| unsafe { &args.exists },
-        H5VL_attr_specific_t::H5VL_ATTR_ITER => &|args| unsafe { &args.iterate },
-        H5VL_attr_specific_t::H5VL_ATTR_RENAME => &|args| unsafe { &args.rename }
+    impl_debug_args!(
+        H5VL_attr_specific_args_t,
+        H5VL_attr_specific_t,
+        H5VL_attr_specific_args_t_union,
+        {
+            H5VL_ATTR_DELETE => |args| unsafe { args.del },
+            H5VL_ATTR_DELETE_BY_IDX => |args| unsafe { args.delete_by_idx },
+            H5VL_ATTR_EXISTS => |args| unsafe { args.exists },
+            H5VL_ATTR_ITER => |args| unsafe { args.iterate },
+            H5VL_ATTR_RENAME => |args| unsafe { args.rename },
+        }
     );
 
     #[repr(C)]
@@ -429,10 +438,15 @@ mod v1_13_0 {
         pub args: H5VL_dataset_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_dataset_specific_args_t,
-        H5VL_dataset_specific_t::H5VL_DATASET_SET_EXTENT => &|args| unsafe { &args.set_extent },
-        H5VL_dataset_specific_t::H5VL_DATASET_FLUSH => &|args| unsafe { &args.flush },
-        H5VL_dataset_specific_t::H5VL_DATASET_REFRESH => &|args| unsafe { &args.refresh }
+    impl_debug_args!(
+        H5VL_dataset_specific_args_t,
+        H5VL_dataset_specific_t,
+        H5VL_dataset_specific_args_t_union,
+        {
+            H5VL_DATASET_SET_EXTENT => |args| unsafe { args.set_extent },
+            H5VL_DATASET_FLUSH => |args| unsafe { args.flush },
+            H5VL_DATASET_REFRESH => |args| unsafe { args.refresh },
+        }
     );
 
     #[repr(C)]
@@ -500,13 +514,18 @@ mod v1_13_0 {
         pub args: H5VL_dataset_get_args_t_union,
     }
 
-    impl_debug_args!(H5VL_dataset_get_args_t,
-        H5VL_dataset_get_t::H5VL_DATASET_GET_DAPL => &|args| unsafe { &args.get_dapl },
-        H5VL_dataset_get_t::H5VL_DATASET_GET_DCPL => &|args| unsafe { &args.get_dcpl },
-        H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE => &|args| unsafe { &args.get_space },
-        H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE_STATUS => &|args| unsafe { &args.get_space_status },
-        H5VL_dataset_get_t::H5VL_DATASET_GET_STORAGE_SIZE => &|args| unsafe { &args.get_storage_size },
-        H5VL_dataset_get_t::H5VL_DATASET_GET_TYPE => &|args| unsafe { &args.get_type }
+    impl_debug_args!(
+        H5VL_dataset_get_args_t,
+        H5VL_dataset_get_t,
+        H5VL_dataset_get_args_t_union,
+        {
+            H5VL_DATASET_GET_DAPL => |args| unsafe { args.get_dapl },
+            H5VL_DATASET_GET_DCPL => |args| unsafe { args.get_dcpl },
+            H5VL_DATASET_GET_SPACE => |args| unsafe { args.get_space },
+            H5VL_DATASET_GET_SPACE_STATUS => |args| unsafe { args.get_space_status },
+            H5VL_DATASET_GET_STORAGE_SIZE => |args| unsafe { args.get_storage_size },
+            H5VL_DATASET_GET_TYPE => |args| unsafe { args.get_type },
+        }
     );
 
     #[repr(C)]
@@ -630,9 +649,14 @@ mod v1_13_0 {
         pub args: H5VL_datatype_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_datatype_specific_args_t,
-        H5VL_datatype_specific_t::H5VL_DATATYPE_FLUSH => &|args| unsafe { &args.flush },
-        H5VL_datatype_specific_t::H5VL_DATATYPE_REFRESH => &|args| unsafe { &args.refresh }
+    impl_debug_args!(
+        H5VL_datatype_specific_args_t,
+        H5VL_datatype_specific_t,
+        H5VL_datatype_specific_args_t_union,
+        {
+            H5VL_DATATYPE_FLUSH => |args| unsafe { args.flush },
+            H5VL_DATATYPE_REFRESH => |args| unsafe { args.refresh },
+        }
     );
 
     #[repr(C)]
@@ -677,10 +701,15 @@ mod v1_13_0 {
         pub args: H5VL_datatype_get_args_t_union,
     }
 
-    impl_debug_args!(H5VL_datatype_get_args_t,
-        H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY_SIZE => &|args| unsafe { &args.get_binary_size },
-        H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY => &|args| unsafe { &args.get_binary },
-        H5VL_datatype_get_t::H5VL_DATATYPE_GET_TCPL => &|args| unsafe { &args.get_tcpl }
+    impl_debug_args!(
+        H5VL_datatype_get_args_t,
+        H5VL_datatype_get_t,
+        H5VL_datatype_get_args_t_union,
+        {
+            H5VL_DATATYPE_GET_BINARY_SIZE => |args| unsafe { args.get_binary_size },
+            H5VL_DATATYPE_GET_BINARY => |args| unsafe { args.get_binary },
+            H5VL_DATATYPE_GET_TCPL => |args| unsafe { args.get_tcpl },
+        }
     );
 
     #[repr(C)]
@@ -789,12 +818,17 @@ mod v1_13_0 {
         pub args: H5VL_file_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_file_specific_args_t,
-        H5VL_file_specific_t::H5VL_FILE_FLUSH => &|args| unsafe { &args.flush },
-        H5VL_file_specific_t::H5VL_FILE_REOPEN => &|args| unsafe { &args.reopen },
-        H5VL_file_specific_t::H5VL_FILE_IS_ACCESSIBLE => &|args| unsafe { &args.is_accessible },
-        H5VL_file_specific_t::H5VL_FILE_DELETE => &|args| unsafe { &args.del },
-        H5VL_file_specific_t::H5VL_FILE_IS_EQUAL => &|args| unsafe { &args.is_equal }
+    impl_debug_args!(
+        H5VL_file_specific_args_t,
+        H5VL_file_specific_t,
+        H5VL_file_specific_args_t_union,
+        {
+            H5VL_FILE_FLUSH => |args| unsafe { args.flush },
+            H5VL_FILE_REOPEN => |args| unsafe { args.reopen },
+            H5VL_FILE_IS_ACCESSIBLE => |args| unsafe { args.is_accessible },
+            H5VL_FILE_DELETE => |args| unsafe { args.del },
+            H5VL_FILE_IS_EQUAL => |args| unsafe { args.is_equal },
+        }
     );
 
     #[repr(C)]
@@ -894,15 +928,20 @@ mod v1_13_0 {
         pub args: H5VL_file_get_args_t_union,
     }
 
-    impl_debug_args!(H5VL_file_get_args_t,
-        H5VL_file_get_t::H5VL_FILE_GET_CONT_INFO => &|args| unsafe { &args.get_cont_info },
-        H5VL_file_get_t::H5VL_FILE_GET_FAPL => &|args| unsafe { &args.get_fapl },
-        H5VL_file_get_t::H5VL_FILE_GET_FCPL => &|args| unsafe { &args.get_fcpl },
-        H5VL_file_get_t::H5VL_FILE_GET_FILENO => &|args| unsafe { &args.get_fileno },
-        H5VL_file_get_t::H5VL_FILE_GET_INTENT => &|args| unsafe { &args.get_intent },
-        H5VL_file_get_t::H5VL_FILE_GET_NAME => &|args| unsafe { &args.get_name },
-        H5VL_file_get_t::H5VL_FILE_GET_OBJ_COUNT => &|args| unsafe { &args.get_obj_count },
-        H5VL_file_get_t::H5VL_FILE_GET_OBJ_IDS => &|args| unsafe { &args.get_obj_ids }
+    impl_debug_args!(
+        H5VL_file_get_args_t,
+        H5VL_file_get_t,
+        H5VL_file_get_args_t_union,
+        {
+            H5VL_FILE_GET_CONT_INFO => |args| unsafe { args.get_cont_info },
+            H5VL_FILE_GET_FAPL => |args| unsafe { args.get_fapl },
+            H5VL_FILE_GET_FCPL => |args| unsafe { args.get_fcpl },
+            H5VL_FILE_GET_FILENO => |args| unsafe { args.get_fileno },
+            H5VL_FILE_GET_INTENT => |args| unsafe { args.get_intent },
+            H5VL_FILE_GET_NAME => |args| unsafe { args.get_name },
+            H5VL_FILE_GET_OBJ_COUNT => |args| unsafe { args.get_obj_count },
+            H5VL_FILE_GET_OBJ_IDS => |args| unsafe { args.get_obj_ids },
+        }
     );
 
     #[repr(C)]
@@ -1007,11 +1046,16 @@ mod v1_13_0 {
         pub args: H5VL_group_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_group_specific_args_t,
-        H5VL_group_specific_t::H5VL_GROUP_MOUNT => &|args| unsafe { &args.mount },
-        H5VL_group_specific_t::H5VL_GROUP_UNMOUNT => &|args| unsafe { &args.unmount },
-        H5VL_group_specific_t::H5VL_GROUP_FLUSH => &|args| unsafe { &args.flush },
-        H5VL_group_specific_t::H5VL_GROUP_REFRESH => &|args| unsafe { &args.refresh }
+    impl_debug_args!(
+        H5VL_group_specific_args_t,
+        H5VL_group_specific_t,
+        H5VL_group_specific_args_t_union,
+        {
+            H5VL_GROUP_MOUNT => |args| unsafe { args.mount },
+            H5VL_GROUP_UNMOUNT => |args| unsafe { args.unmount },
+            H5VL_GROUP_FLUSH => |args| unsafe { args.flush },
+            H5VL_GROUP_REFRESH => |args| unsafe { args.refresh },
+        }
     );
 
     #[repr(C)]
@@ -1048,9 +1092,14 @@ mod v1_13_0 {
         pub args: H5VL_group_get_args_t_union,
     }
 
-    impl_debug_args!(H5VL_group_get_args_t,
-        H5VL_group_get_t::H5VL_GROUP_GET_GCPL => &|args| unsafe { &args.get_gcpl },
-        H5VL_group_get_t::H5VL_GROUP_GET_INFO => &|args| unsafe { &args.get_info }
+    impl_debug_args!(
+        H5VL_group_get_args_t,
+        H5VL_group_get_t,
+        H5VL_group_get_args_t_union,
+        {
+            H5VL_GROUP_GET_GCPL => |args| unsafe { args.get_gcpl },
+            H5VL_GROUP_GET_INFO => |args| unsafe { args.get_info },
+        }
     );
 
     #[repr(C)]
@@ -1147,10 +1196,14 @@ mod v1_13_0 {
         pub args: H5VL_link_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_link_specific_args_t,
-        H5VL_link_specific_t::H5VL_LINK_DELETE => &|_| &"delete",
-        H5VL_link_specific_t::H5VL_LINK_EXISTS => &|args| unsafe { &args.exists },
-        H5VL_link_specific_t::H5VL_LINK_ITER => &|args| unsafe { &args.iterate }
+    impl_debug_args!(
+        H5VL_link_specific_args_t,
+        H5VL_link_specific_t,
+        H5VL_link_specific_args_t_union,
+        {
+            H5VL_LINK_EXISTS => |args| unsafe { args.exists },
+            H5VL_LINK_ITER => |args| unsafe { args.iterate },
+        }
     );
 
     #[repr(C)]
@@ -1197,10 +1250,15 @@ mod v1_13_0 {
         pub args: H5VL_link_get_args_t_union,
     }
 
-    impl_debug_args!(H5VL_link_get_args_t,
-        H5VL_link_get_t::H5VL_LINK_GET_INFO => &|args| unsafe { &args.get_info },
-        H5VL_link_get_t::H5VL_LINK_GET_NAME => &|args| unsafe { &args.get_name },
-        H5VL_link_get_t::H5VL_LINK_GET_VAL => &|args| unsafe { &args.get_val }
+    impl_debug_args!(
+        H5VL_link_get_args_t,
+        H5VL_link_get_t,
+        H5VL_link_get_args_t_union,
+        {
+            H5VL_LINK_GET_INFO => |args| unsafe { args.get_info },
+            H5VL_LINK_GET_NAME => |args| unsafe { args.get_name },
+            H5VL_LINK_GET_VAL => |args| unsafe { args.get_val },
+        }
     );
 
     #[repr(C)]
@@ -1247,10 +1305,15 @@ mod v1_13_0 {
         pub args: H5VL_link_create_args_t_union,
     }
 
-    impl_debug_args!(H5VL_link_create_args_t,
-        H5VL_link_create_t::H5VL_LINK_CREATE_HARD => &|args| unsafe { &args.hard },
-        H5VL_link_create_t::H5VL_LINK_CREATE_SOFT => &|args| unsafe { &args.soft },
-        H5VL_link_create_t::H5VL_LINK_CREATE_UD => &|args| unsafe { &args.ud }
+    impl_debug_args!(
+        H5VL_link_create_args_t,
+        H5VL_link_create_t,
+        H5VL_link_create_args_t_union,
+        {
+            H5VL_LINK_CREATE_HARD => |args| unsafe { args.hard },
+            H5VL_LINK_CREATE_SOFT => |args| unsafe { args.soft },
+            H5VL_LINK_CREATE_UD => |args| unsafe { args.ud },
+        }
     );
 
     #[repr(C)]
@@ -1389,13 +1452,18 @@ mod v1_13_0 {
         pub args: H5VL_object_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_object_specific_args_t,
-        H5VL_object_specific_t::H5VL_OBJECT_CHANGE_REF_COUNT => &|args| unsafe { &args.change_rc },
-        H5VL_object_specific_t::H5VL_OBJECT_EXISTS => &|args| unsafe { &args.exists },
-        H5VL_object_specific_t::H5VL_OBJECT_LOOKUP => &|args| unsafe { &args.lookup },
-        H5VL_object_specific_t::H5VL_OBJECT_VISIT => &|args| unsafe { &args.visit },
-        H5VL_object_specific_t::H5VL_OBJECT_FLUSH => &|args| unsafe { &args.flush },
-        H5VL_object_specific_t::H5VL_OBJECT_REFRESH => &|args| unsafe { &args.refresh }
+    impl_debug_args!(
+        H5VL_object_specific_args_t,
+        H5VL_object_specific_t,
+        H5VL_object_specific_args_t_union,
+        {
+            H5VL_OBJECT_CHANGE_REF_COUNT => |args| unsafe { args.change_rc },
+            H5VL_OBJECT_EXISTS => |args| unsafe { args.exists },
+            H5VL_OBJECT_LOOKUP => |args| unsafe { args.lookup },
+            H5VL_OBJECT_VISIT => |args| unsafe { args.visit },
+            H5VL_OBJECT_FLUSH => |args| unsafe { args.flush },
+            H5VL_OBJECT_REFRESH => |args| unsafe { args.refresh },
+        }
     );
 
     #[repr(C)]
@@ -1450,11 +1518,16 @@ mod v1_13_0 {
         pub args: H5VL_object_get_args_t_union,
     }
 
-    impl_debug_args!(H5VL_object_get_args_t,
-        H5VL_object_get_t::H5VL_OBJECT_GET_FILE => &|args| unsafe { &args.get_file },
-        H5VL_object_get_t::H5VL_OBJECT_GET_NAME => &|args| unsafe { &args.get_name },
-        H5VL_object_get_t::H5VL_OBJECT_GET_TYPE => &|args| unsafe { &args.get_type },
-        H5VL_object_get_t::H5VL_OBJECT_GET_INFO => &|args| unsafe { &args.get_info }
+    impl_debug_args!(
+        H5VL_object_get_args_t,
+        H5VL_object_get_t,
+        H5VL_object_get_args_t_union,
+        {
+            H5VL_OBJECT_GET_FILE => |args| unsafe { args.get_file },
+            H5VL_OBJECT_GET_NAME => |args| unsafe { args.get_name },
+            H5VL_OBJECT_GET_TYPE => |args| unsafe { args.get_type },
+            H5VL_OBJECT_GET_INFO => |args| unsafe { args.get_info },
+        }
     );
 
     #[repr(C)]
@@ -1584,9 +1657,14 @@ mod v1_13_0 {
         pub args: H5VL_request_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_request_specific_args_t,
-        H5VL_request_specific_t::H5VL_REQUEST_GET_ERR_STACK => &|args| unsafe { &args.get_err_stack },
-        H5VL_request_specific_t::H5VL_REQUEST_GET_EXEC_TIME => &|args| unsafe { &args.get_exec_time }
+    impl_debug_args!(
+        H5VL_request_specific_args_t,
+        H5VL_request_specific_t,
+        H5VL_request_specific_args_t_union,
+        {
+            H5VL_REQUEST_GET_ERR_STACK => |args| unsafe { args.get_err_stack },
+            H5VL_REQUEST_GET_EXEC_TIME => |args| unsafe { args.get_exec_time },
+        }
     );
 
     pub type H5VL_request_notify_t =
@@ -1642,10 +1720,13 @@ mod v1_13_0 {
         pub args: H5VL_blob_specific_args_t_union,
     }
 
-    impl_debug_args!(H5VL_blob_specific_args_t,
-        H5VL_blob_specific_t::H5VL_BLOB_DELETE => &|_| &"delete",
-        H5VL_blob_specific_t::H5VL_BLOB_ISNULL => &|args| unsafe { &args.is_null },
-        H5VL_blob_specific_t::H5VL_BLOB_SETNULL => &|_| &"setnull"
+    impl_debug_args!(
+        H5VL_blob_specific_args_t,
+        H5VL_blob_specific_t,
+        H5VL_blob_specific_args_t_union,
+        {
+            H5VL_BLOB_ISNULL => |args| unsafe { args.is_null },
+        }
     );
 
     #[repr(C)]
@@ -1768,15 +1849,15 @@ mod v1_13_0 {
             s.field("obj_type", &self.obj_type).field("type", &self.type_);
             unsafe {
                 match self.type_ {
-                    H5VL_loc_type_t::H5VL_OBJECT_BY_SELF => s.field("loc_data", &"by_self"),
+                    H5VL_loc_type_t::H5VL_OBJECT_BY_SELF => {}
                     H5VL_loc_type_t::H5VL_OBJECT_BY_NAME => {
-                        s.field("loc_data", &self.loc_data.loc_by_name)
+                        s.field("loc_data", &self.loc_data.loc_by_name);
                     }
                     H5VL_loc_type_t::H5VL_OBJECT_BY_IDX => {
-                        s.field("loc_data", &self.loc_data.loc_by_idx)
+                        s.field("loc_data", &self.loc_data.loc_by_idx);
                     }
                     H5VL_loc_type_t::H5VL_OBJECT_BY_TOKEN => {
-                        s.field("loc_data", &self.loc_data.loc_by_token)
+                        s.field("loc_data", &self.loc_data.loc_by_token);
                     }
                 }
             };

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -1,1741 +1,17 @@
 //! Using the Virtual Object Layer
-#![cfg(feature = "1.13.0")]
-
-use std::fmt::{self, Debug};
-use std::mem::ManuallyDrop;
+#![cfg(feature = "1.12.0")]
 
 use crate::internal_prelude::*;
-use crate::{
-    h5a::{H5A_info_t, H5A_operator2_t},
-    h5d::H5D_space_status_t,
-    h5f::H5F_scope_t,
-    h5g::H5G_info_t,
-    h5i::H5I_type_t,
-    h5l::{H5L_info2_t, H5L_iterate2_t, H5L_type_t},
-    h5o::{H5O_info2_t, H5O_iterate2_t, H5O_token_t, H5O_type_t},
-};
 
 pub type H5VL_class_value_t = c_int;
 
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_info_class_t {
-    pub size: size_t,
-    pub copy: Option<extern "C" fn(info: *const c_void) -> *mut c_void>,
-    pub cmp: Option<
-        extern "C" fn(cmp_value: *mut c_int, info1: *const c_void, info2: *const c_void) -> herr_t,
-    >,
-    pub free: Option<extern "C" fn(info: *mut c_void) -> herr_t>,
-    pub to_str: Option<extern "C" fn(info: *const c_void, str: *mut *mut c_char) -> herr_t>,
-    pub from_str: Option<extern "C" fn(str: *const c_char, info: *mut *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_wrap_class_t {
-    pub get_object: Option<extern "C" fn(obj: *const c_void) -> *mut c_void>,
-    pub get_wrap_ctx:
-        Option<extern "C" fn(obj: *const c_void, wrap_ctx: *mut *mut c_void) -> herr_t>,
-    pub wrap_object: Option<
-        extern "C" fn(obj: *mut c_void, obj_type: H5I_type_t, wrap_ctx: *mut c_void) -> *mut c_void,
-    >,
-    pub unwrap_object: Option<extern "C" fn(obj: *mut c_void) -> *mut c_void>,
-    pub free_wrap_ctx: Option<extern "C" fn(wrap_ctx: *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_attr_get_t {
-    H5VL_ATTR_GET_ACPL,
-    H5VL_ATTR_GET_INFO,
-    H5VL_ATTR_GET_NAME,
-    H5VL_ATTR_GET_SPACE,
-    H5VL_ATTR_GET_STORAGE_SIZE,
-    H5VL_ATTR_GET_TYPE,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_get_args_t_union_get_acpl {
-    pub acpl_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_get_args_t_union_get_space {
-    pub space_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_get_args_t_union_get_storage_size {
-    pub data_size: *mut hsize_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_get_args_t_union_get_type {
-    pub type_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_get_name_args_t {
-    pub loc_params: H5VL_loc_params_t,
-    pub buf_size: size_t,
-    pub buf: *mut c_char,
-    pub attr_name_len: *mut size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_get_info_args_t {
-    pub loc_params: H5VL_loc_params_t,
-    pub attr_name: *const c_char,
-    pub ainfo: *mut H5A_info_t,
-}
-
-#[repr(C)]
-pub union H5VL_attr_get_args_t_union {
-    pub get_acpl: ManuallyDrop<H5VL_attr_get_args_t_union_get_acpl>,
-    pub get_info: ManuallyDrop<H5VL_attr_get_info_args_t>,
-    pub get_name: ManuallyDrop<H5VL_attr_get_name_args_t>,
-    pub get_space: ManuallyDrop<H5VL_attr_get_args_t_union_get_space>,
-    pub get_storage_size: ManuallyDrop<H5VL_attr_get_args_t_union_get_storage_size>,
-    pub get_type: ManuallyDrop<H5VL_attr_get_args_t_union_get_type>,
-}
-
-#[repr(C)]
-pub struct H5VL_attr_get_args_t {
-    pub op_type: H5VL_attr_get_t,
-    pub args: H5VL_attr_get_args_t_union,
-}
-
-impl Debug for H5VL_attr_get_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_attr_get_t::H5VL_ATTR_GET_ACPL => s.field("args", &self.args.get_acpl),
-                H5VL_attr_get_t::H5VL_ATTR_GET_INFO => s.field("args", &self.args.get_info),
-                H5VL_attr_get_t::H5VL_ATTR_GET_NAME => s.field("args", &self.args.get_name),
-                H5VL_attr_get_t::H5VL_ATTR_GET_SPACE => s.field("args", &self.args.get_space),
-                H5VL_attr_get_t::H5VL_ATTR_GET_STORAGE_SIZE => {
-                    s.field("args", &self.args.get_storage_size)
-                }
-                H5VL_attr_get_t::H5VL_ATTR_GET_TYPE => s.field("args", &self.args.get_type),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_attr_specific_t {
-    H5VL_ATTR_DELETE,
-    H5VL_ATTR_DELETE_BY_IDX,
-    H5VL_ATTR_EXISTS,
-    H5VL_ATTR_ITER,
-    H5VL_ATTR_RENAME,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_specific_args_t_union_del {
-    pub name: *const c_char,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_specific_args_t_union_exists {
-    pub name: *const c_char,
-    pub exists: *mut hbool_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_specific_args_t_union_rename {
-    pub old_name: *const c_char,
-    pub new_name: *const c_char,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_iterate_args_t {
-    pub idx_type: H5_index_t,
-    pub order: H5_iter_order_t,
-    pub idx: *mut hsize_t,
-    pub op: H5A_operator2_t,
-    pub op_data: *mut c_void,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_delete_by_idx_args_t {
-    pub idx_type: H5_index_t,
-    pub order: H5_iter_order_t,
-    pub n: hsize_t,
-}
-
-#[repr(C)]
-pub union H5VL_attr_specific_args_t_union {
-    pub del: ManuallyDrop<H5VL_attr_specific_args_t_union_del>,
-    pub delete_by_idx: ManuallyDrop<H5VL_attr_delete_by_idx_args_t>,
-    pub exists: ManuallyDrop<H5VL_attr_specific_args_t_union_exists>,
-    pub iterate: ManuallyDrop<H5VL_attr_iterate_args_t>,
-    pub rename: ManuallyDrop<H5VL_attr_specific_args_t_union_rename>,
-}
-
-#[repr(C)]
-pub struct H5VL_attr_specific_args_t {
-    pub op_type: H5VL_attr_specific_t,
-    pub args: H5VL_attr_specific_args_t_union,
-}
-
-impl Debug for H5VL_attr_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_attr_specific_t::H5VL_ATTR_DELETE => s.field("args", &self.args.del),
-                H5VL_attr_specific_t::H5VL_ATTR_DELETE_BY_IDX => {
-                    s.field("args", &self.args.delete_by_idx)
-                }
-                H5VL_attr_specific_t::H5VL_ATTR_EXISTS => s.field("args", &self.args.exists),
-                H5VL_attr_specific_t::H5VL_ATTR_ITER => s.field("args", &self.args.iterate),
-                H5VL_attr_specific_t::H5VL_ATTR_RENAME => s.field("args", &self.args.rename),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_attr_class_t {
-    pub create: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            attr_name: *const c_char,
-            type_id: hid_t,
-            space_id: hid_t,
-            acpl_id: hid_t,
-            aapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub open: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            attr_name: *const c_char,
-            aapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub read: Option<
-        extern "C" fn(
-            attr: *mut c_void,
-            mem_type_id: hid_t,
-            buf: *mut c_void,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub write: Option<
-        extern "C" fn(
-            attr: *mut c_void,
-            mem_type_id: hid_t,
-            buf: *const c_void,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_attr_get_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            args: *mut H5VL_attr_specific_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_optional_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub close:
-        Option<extern "C" fn(attr: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_dataset_specific_t {
-    H5VL_DATASET_SET_EXTENT,
-    H5VL_DATASET_FLUSH,
-    H5VL_DATASET_REFRESH,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_specific_args_t_union_set_extent {
-    pub size: *const hsize_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_specific_args_t_union_flush {
-    pub dset_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_specific_args_t_union_refresh {
-    pub dset_id: hid_t,
-}
-
-#[repr(C)]
-pub union H5VL_dataset_specific_args_t_union {
-    pub set_extent: ManuallyDrop<H5VL_dataset_specific_args_t_union_set_extent>,
-    pub flush: ManuallyDrop<H5VL_dataset_specific_args_t_union_flush>,
-    pub refresh: ManuallyDrop<H5VL_dataset_specific_args_t_union_refresh>,
-}
-
-#[repr(C)]
-pub struct H5VL_dataset_specific_args_t {
-    pub op_type: H5VL_dataset_specific_t,
-    pub args: H5VL_dataset_specific_args_t_union,
-}
-
-impl Debug for H5VL_dataset_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_dataset_specific_t::H5VL_DATASET_SET_EXTENT => {
-                    s.field("args", &self.args.set_extent)
-                }
-                H5VL_dataset_specific_t::H5VL_DATASET_FLUSH => s.field("args", &self.args.flush),
-                H5VL_dataset_specific_t::H5VL_DATASET_REFRESH => {
-                    s.field("args", &self.args.refresh)
-                }
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_dataset_get_t {
-    H5VL_DATASET_GET_DAPL,
-    H5VL_DATASET_GET_DCPL,
-    H5VL_DATASET_GET_SPACE,
-    H5VL_DATASET_GET_SPACE_STATUS,
-    H5VL_DATASET_GET_STORAGE_SIZE,
-    H5VL_DATASET_GET_TYPE,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_get_args_t_union_get_dapl {
-    pub dapl_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_get_args_t_union_get_dcpl {
-    pub dcpl_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_get_args_t_union_get_space {
-    pub space_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_get_args_t_union_get_space_status {
-    pub status: *mut H5D_space_status_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_get_args_t_union_get_storage_size {
-    pub storage_size: *mut hsize_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_get_args_t_union_get_type {
-    pub type_id: hid_t,
-}
-
-#[repr(C)]
-pub union H5VL_dataset_get_args_t_union {
-    pub get_dapl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dapl>,
-    pub get_dcpl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dcpl>,
-    pub get_space: ManuallyDrop<H5VL_dataset_get_args_t_union_get_space>,
-    pub get_space_status: ManuallyDrop<H5VL_dataset_get_args_t_union_get_space_status>,
-    pub get_storage_size: ManuallyDrop<H5VL_dataset_get_args_t_union_get_storage_size>,
-    pub get_type: ManuallyDrop<H5VL_dataset_get_args_t_union_get_type>,
-}
-
-#[repr(C)]
-pub struct H5VL_dataset_get_args_t {
-    pub op_type: H5VL_dataset_get_t,
-    pub args: H5VL_dataset_get_args_t_union,
-}
-
-impl Debug for H5VL_dataset_get_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_dataset_get_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_dataset_get_t::H5VL_DATASET_GET_DAPL => s.field("args", &self.args.get_dapl),
-                H5VL_dataset_get_t::H5VL_DATASET_GET_DCPL => s.field("args", &self.args.get_dcpl),
-                H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE => s.field("args", &self.args.get_space),
-                H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE_STATUS => {
-                    s.field("args", &self.args.get_space_status)
-                }
-                H5VL_dataset_get_t::H5VL_DATASET_GET_STORAGE_SIZE => {
-                    s.field("args", &self.args.get_storage_size)
-                }
-                H5VL_dataset_get_t::H5VL_DATASET_GET_TYPE => s.field("args", &self.args.get_type),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_dataset_class_t {
-    pub create: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            name: *const c_char,
-            lcpl_id: hid_t,
-            type_id: hid_t,
-            space_id: hid_t,
-            dcpl_id: hid_t,
-            dapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub open: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            name: *const c_char,
-            dapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub read: Option<
-        extern "C" fn(
-            dset: *mut c_void,
-            mem_type_id: hid_t,
-            mem_space_id: hid_t,
-            file_space_id: hid_t,
-            dxpl_id: hid_t,
-            buf: *mut c_void,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub write: Option<
-        extern "C" fn(
-            dset: *mut c_void,
-            mem_type_id: hid_t,
-            mem_space_id: hid_t,
-            file_space_id: hid_t,
-            dxpl_id: hid_t,
-            buf: *const c_void,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_dataset_get_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_dataset_specific_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_optional_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub close:
-        Option<extern "C" fn(dset: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_file_specific_t {
-    H5VL_FILE_FLUSH,
-    H5VL_FILE_REOPEN,
-    H5VL_FILE_IS_ACCESSIBLE,
-    H5VL_FILE_DELETE,
-    H5VL_FILE_IS_EQUAL,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_specific_args_t_union_flush {
-    pub type_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_specific_args_t_union_refresh {
-    pub type_id: hid_t,
-}
-
-#[repr(C)]
-pub union H5VL_datatype_specific_args_t_union {
-    pub flush: ManuallyDrop<H5VL_datatype_specific_args_t_union_flush>,
-    pub refresh: ManuallyDrop<H5VL_datatype_specific_args_t_union_refresh>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_datatype_specific_t {
-    H5VL_DATATYPE_FLUSH,
-    H5VL_DATATYPE_REFRESH,
-}
-
-#[repr(C)]
-pub struct H5VL_datatype_specific_args_t {
-    pub op_type: H5VL_datatype_specific_t,
-    pub args: H5VL_datatype_specific_args_t_union,
-}
-
-impl Debug for H5VL_datatype_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_datatype_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_datatype_specific_t::H5VL_DATATYPE_FLUSH => s.field("args", &self.args.flush),
-                H5VL_datatype_specific_t::H5VL_DATATYPE_REFRESH => {
-                    s.field("args", &self.args.refresh)
-                }
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_datatype_get_t {
-    H5VL_DATATYPE_GET_BINARY_SIZE,
-    H5VL_DATATYPE_GET_BINARY,
-    H5VL_DATATYPE_GET_TCPL,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_get_args_t_union_get_binary_size {
-    pub size: *mut size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_get_args_t_union_get_binary {
-    pub buf: *mut c_void,
-    pub buf_size: size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_get_args_t_union_get_tcpl {
-    pub tcpl_id: hid_t,
-}
-
-#[repr(C)]
-pub union H5VL_datatype_get_args_t_union {
-    pub get_binary_size: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary_size>,
-    pub get_binary: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary>,
-    pub get_tcpl: ManuallyDrop<H5VL_datatype_get_args_t_union_get_tcpl>,
-}
-
-#[repr(C)]
-pub struct H5VL_datatype_get_args_t {
-    pub op_type: H5VL_datatype_get_t,
-    pub args: H5VL_datatype_get_args_t_union,
-}
-
-impl Debug for H5VL_datatype_get_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_datatype_get_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY_SIZE => {
-                    s.field("args", &self.args.get_binary_size)
-                }
-                H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY => {
-                    s.field("args", &self.args.get_binary)
-                }
-                H5VL_datatype_get_t::H5VL_DATATYPE_GET_TCPL => s.field("args", &self.args.get_tcpl),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_datatype_class_t {
-    pub commit: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            name: *const c_char,
-            type_id: hid_t,
-            lcpl_id: hid_t,
-            tcpl_id: hid_t,
-            tapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub open: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            name: *const c_char,
-            tapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_datatype_get_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_datatype_specific_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_optional_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub close:
-        Option<extern "C" fn(dt: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_specific_args_t_union_flush {
-    pub obj_type: H5I_type_t,
-    pub scope: H5F_scope_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_specific_args_t_union_reopen {
-    pub file: *mut *mut c_void,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_specific_args_t_union_is_accessible {
-    pub filename: *const c_char,
-    pub fapl_id: hid_t,
-    pub accessible: *mut hbool_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_specific_args_t_union_del {
-    pub filename: *const c_char,
-    pub fapl_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_specific_args_t_union_is_equal {
-    pub obj2: *mut c_void,
-    pub same_file: *mut hbool_t,
-}
-
-#[repr(C)]
-pub union H5VL_file_specific_args_t_union {
-    pub flush: ManuallyDrop<H5VL_file_specific_args_t_union_flush>,
-    pub reopen: ManuallyDrop<H5VL_file_specific_args_t_union_reopen>,
-    pub is_accessible: ManuallyDrop<H5VL_file_specific_args_t_union_is_accessible>,
-    pub del: ManuallyDrop<H5VL_file_specific_args_t_union_del>,
-    pub is_equal: ManuallyDrop<H5VL_file_specific_args_t_union_is_equal>,
-}
-
-#[repr(C)]
-pub struct H5VL_file_specific_args_t {
-    pub op_type: H5VL_file_specific_t,
-    pub args: H5VL_file_specific_args_t_union,
-}
-
-impl Debug for H5VL_file_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_file_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_file_specific_t::H5VL_FILE_FLUSH => s.field("args", &self.args.flush),
-                H5VL_file_specific_t::H5VL_FILE_REOPEN => s.field("args", &self.args.reopen),
-                H5VL_file_specific_t::H5VL_FILE_IS_ACCESSIBLE => {
-                    s.field("args", &self.args.is_accessible)
-                }
-                H5VL_file_specific_t::H5VL_FILE_DELETE => s.field("args", &self.args.del),
-                H5VL_file_specific_t::H5VL_FILE_IS_EQUAL => s.field("args", &self.args.is_equal),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_cont_info_t {
-    pub version: c_uint,
-    pub feature_flags: u64,
-    pub token_size: size_t,
-    pub blob_id_size: size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_args_t_union_get_cont_info {
-    pub info: *mut H5VL_file_cont_info_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_args_t_union_get_fapl {
-    pub fapl_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_args_t_union_get_fcpl {
-    pub fcpl_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_args_t_union_get_fileno {
-    pub fileno: *mut c_ulong,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_args_t_union_get_intent {
-    pub flags: *mut c_uint,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_args_t_union_get_obj_count {
-    pub types: c_uint,
-    pub count: *mut size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_obj_ids_args_t {
-    pub types: c_uint,
-    pub max_objs: size_t,
-    pub old_list: *mut hid_t,
-    pub count: *mut size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_get_name_args_t {
-    pub r#type: H5I_type_t,
-    pub buf_size: size_t,
-    pub buf: *mut c_char,
-    pub file_name_len: *mut size_t,
-}
-
-#[repr(C)]
-pub union H5VL_file_get_args_t_union {
-    pub get_cont_info: ManuallyDrop<H5VL_file_get_args_t_union_get_cont_info>,
-    pub get_fapl: ManuallyDrop<H5VL_file_get_args_t_union_get_fapl>,
-    pub get_fcpl: ManuallyDrop<H5VL_file_get_args_t_union_get_fcpl>,
-    pub get_fileno: ManuallyDrop<H5VL_file_get_args_t_union_get_fileno>,
-    pub get_intent: ManuallyDrop<H5VL_file_get_args_t_union_get_intent>,
-    pub get_name: ManuallyDrop<H5VL_file_get_name_args_t>,
-    pub get_obj_count: ManuallyDrop<H5VL_file_get_args_t_union_get_obj_count>,
-    pub get_obj_ids: ManuallyDrop<H5VL_file_get_obj_ids_args_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_file_get_t {
-    H5VL_FILE_GET_CONT_INFO,
-    H5VL_FILE_GET_FAPL,
-    H5VL_FILE_GET_FCPL,
-    H5VL_FILE_GET_FILENO,
-    H5VL_FILE_GET_INTENT,
-    H5VL_FILE_GET_NAME,
-    H5VL_FILE_GET_OBJ_COUNT,
-    H5VL_FILE_GET_OBJ_IDS,
-}
-
-#[repr(C)]
-pub struct H5VL_file_get_args_t {
-    pub op_type: H5VL_file_get_t,
-    pub args: H5VL_file_get_args_t_union,
-}
-
-impl Debug for H5VL_file_get_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_file_get_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_file_get_t::H5VL_FILE_GET_CONT_INFO => {
-                    s.field("args", &self.args.get_cont_info)
-                }
-                H5VL_file_get_t::H5VL_FILE_GET_FAPL => s.field("args", &self.args.get_fapl),
-                H5VL_file_get_t::H5VL_FILE_GET_FCPL => s.field("args", &self.args.get_fcpl),
-                H5VL_file_get_t::H5VL_FILE_GET_FILENO => s.field("args", &self.args.get_fileno),
-                H5VL_file_get_t::H5VL_FILE_GET_INTENT => s.field("args", &self.args.get_intent),
-                H5VL_file_get_t::H5VL_FILE_GET_NAME => s.field("args", &self.args.get_name),
-                H5VL_file_get_t::H5VL_FILE_GET_OBJ_COUNT => {
-                    s.field("args", &self.args.get_obj_count)
-                }
-                H5VL_file_get_t::H5VL_FILE_GET_OBJ_IDS => s.field("args", &self.args.get_obj_ids),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_file_class_t {
-    pub create: Option<
-        extern "C" fn(
-            name: *const c_char,
-            flags: c_uint,
-            fcpl_id: hid_t,
-            fapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub open: Option<
-        extern "C" fn(
-            name: *const c_char,
-            flags: c_uint,
-            fapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_file_get_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_file_specific_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_optional_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub close:
-        Option<extern "C" fn(file: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_group_specific_t {
-    H5VL_GROUP_MOUNT,
-    H5VL_GROUP_UNMOUNT,
-    H5VL_GROUP_FLUSH,
-    H5VL_GROUP_REFRESH,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_group_spec_mount_args_t {
-    pub name: *const c_char,
-    pub child_file: *mut c_void,
-    pub fmpl_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_group_specific_args_t_union_unmount {
-    pub name: *const c_char,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_group_specific_args_t_union_flush {
-    pub grp_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_group_specific_args_t_union_refresh {
-    pub grp_id: hid_t,
-}
-
-#[repr(C)]
-pub union H5VL_group_specific_args_t_union {
-    pub mount: ManuallyDrop<H5VL_group_spec_mount_args_t>,
-    pub unmount: ManuallyDrop<H5VL_group_specific_args_t_union_unmount>,
-    pub flush: ManuallyDrop<H5VL_group_specific_args_t_union_flush>,
-    pub refresh: ManuallyDrop<H5VL_group_specific_args_t_union_refresh>,
-}
-
-#[repr(C)]
-pub struct H5VL_group_specific_args_t {
-    pub op_type: H5VL_group_specific_t,
-    pub args: H5VL_group_specific_args_t_union,
-}
-
-impl Debug for H5VL_group_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_group_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_group_specific_t::H5VL_GROUP_MOUNT => s.field("args", &self.args.mount),
-                H5VL_group_specific_t::H5VL_GROUP_UNMOUNT => s.field("args", &self.args.unmount),
-                H5VL_group_specific_t::H5VL_GROUP_FLUSH => s.field("args", &self.args.flush),
-                H5VL_group_specific_t::H5VL_GROUP_REFRESH => s.field("args", &self.args.refresh),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_group_get_info_args_t {
-    pub loc_params: H5VL_loc_params_t,
-    pub ginfo: *mut H5G_info_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_group_get_args_t_union_get_gcpl {
-    pub gcpl_id: hid_t,
-}
-
-#[repr(C)]
-pub union H5VL_group_get_args_t_union {
-    pub get_gcpl: ManuallyDrop<H5VL_group_get_args_t_union_get_gcpl>,
-    pub get_info: ManuallyDrop<H5VL_group_get_info_args_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_group_get_t {
-    H5VL_GROUP_GET_GCPL,
-    H5VL_GROUP_GET_INFO,
-}
-
-#[repr(C)]
-pub struct H5VL_group_get_args_t {
-    pub op_type: H5VL_group_get_t,
-    pub args: H5VL_group_get_args_t_union,
-}
-
-impl Debug for H5VL_group_get_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_group_get_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_group_get_t::H5VL_GROUP_GET_GCPL => s.field("args", &self.args.get_gcpl),
-                H5VL_group_get_t::H5VL_GROUP_GET_INFO => s.field("args", &self.args.get_info),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_group_class_t {
-    pub create: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            name: *const c_char,
-            lcpl_id: hid_t,
-            gcpl_id: hid_t,
-            gapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub open: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-
-            name: *const c_char,
-            gapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_group_get_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_group_specific_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            args: *mut H5VL_optional_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub close:
-        Option<extern "C" fn(grp: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_iterate_args_t {
-    pub recursive: hbool_t,
-    pub idx_type: H5_index_t,
-    pub order: H5_iter_order_t,
-    pub idx_p: *mut hsize_t,
-    pub op: H5L_iterate2_t,
-    pub op_data: *mut c_void,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_specific_args_t_union_exists {
-    pub exists: *mut hbool_t,
-}
-
-#[repr(C)]
-pub union H5VL_link_specific_args_t_union {
-    pub exists: ManuallyDrop<H5VL_link_specific_args_t_union_exists>,
-    pub iterate: ManuallyDrop<H5VL_link_iterate_args_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_link_specific_t {
-    H5VL_LINK_DELETE,
-    H5VL_LINK_EXISTS,
-    H5VL_LINK_ITER,
-}
-
-#[repr(C)]
-pub struct H5VL_link_specific_args_t {
-    pub op_type: H5VL_link_specific_t,
-    pub args: H5VL_link_specific_args_t_union,
-}
-
-impl Debug for H5VL_link_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_link_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_link_specific_t::H5VL_LINK_DELETE => s.field("args", &"delete"),
-                H5VL_link_specific_t::H5VL_LINK_EXISTS => s.field("args", &self.args.exists),
-                H5VL_link_specific_t::H5VL_LINK_ITER => s.field("args", &self.args.iterate),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_get_args_t_union_get_info {
-    pub linfo: *mut H5L_info2_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_get_args_t_union_get_name {
-    pub name_size: size_t,
-    pub name: *mut c_char,
-    pub name_len: *mut size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_get_args_t_union_get_val {
-    pub buf_size: size_t,
-    pub buf: *mut c_void,
-}
-
-#[repr(C)]
-pub union H5VL_link_get_args_t_union {
-    pub get_info: ManuallyDrop<H5VL_link_get_args_t_union_get_info>,
-    pub get_name: ManuallyDrop<H5VL_link_get_args_t_union_get_name>,
-    pub get_val: ManuallyDrop<H5VL_link_get_args_t_union_get_val>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_link_get_t {
-    H5VL_LINK_GET_INFO,
-    H5VL_LINK_GET_NAME,
-    H5VL_LINK_GET_VAL,
-}
-
-#[repr(C)]
-pub struct H5VL_link_get_args_t {
-    pub op_type: H5VL_link_get_t,
-    pub args: H5VL_link_get_args_t_union,
-}
-
-impl Debug for H5VL_link_get_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_link_get_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_link_get_t::H5VL_LINK_GET_INFO => s.field("args", &self.args.get_info),
-                H5VL_link_get_t::H5VL_LINK_GET_NAME => s.field("args", &self.args.get_name),
-                H5VL_link_get_t::H5VL_LINK_GET_VAL => s.field("args", &self.args.get_val),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_link_create_t {
-    H5VL_LINK_CREATE_HARD,
-    H5VL_LINK_CREATE_SOFT,
-    H5VL_LINK_CREATE_UD,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_create_args_t_union_hard {
-    pub curr_obj: *mut c_void,
-    pub curr_loc_params: H5VL_loc_params_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_create_args_t_union_soft {
-    pub target: *const c_char,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_create_args_t_union_ud {
-    pub r#type: H5L_type_t,
-    pub buf: *const c_void,
-    pub buf_size: size_t,
-}
-
-#[repr(C)]
-pub union H5VL_link_create_args_t_union {
-    pub hard: ManuallyDrop<H5VL_link_create_args_t_union_hard>,
-    pub soft: ManuallyDrop<H5VL_link_create_args_t_union_soft>,
-    pub ud: ManuallyDrop<H5VL_link_create_args_t_union_ud>,
-}
-
-#[repr(C)]
-pub struct H5VL_link_create_args_t {
-    pub op_type: H5VL_link_create_t,
-    pub args: H5VL_link_create_args_t_union,
-}
-
-impl Debug for H5VL_link_create_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_link_create_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_link_create_t::H5VL_LINK_CREATE_HARD => s.field("args", &self.args.hard),
-                H5VL_link_create_t::H5VL_LINK_CREATE_SOFT => s.field("args", &self.args.soft),
-                H5VL_link_create_t::H5VL_LINK_CREATE_UD => s.field("args", &self.args.ud),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_link_class_t {
-    pub create: Option<
-        extern "C" fn(
-            args: *mut H5VL_link_create_args_t,
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            lcpl_id: hid_t,
-            lapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub copy: Option<
-        extern "C" fn(
-            src_obj: *mut c_void,
-            loc_params1: *const H5VL_loc_params_t,
-            dest_obj: *mut c_void,
-            loc_params2: *const H5VL_loc_params_t,
-            lcpl_id: hid_t,
-            lapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub r#move: Option<
-        extern "C" fn(
-            src_obj: *mut c_void,
-            loc_params1: *const H5VL_loc_params_t,
-            dest_obj: *mut c_void,
-            loc_params2: *const H5VL_loc_params_t,
-            lcpl_id: hid_t,
-            lapl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            args: *mut H5VL_link_get_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            args: *mut H5VL_link_specific_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            args: *mut H5VL_optional_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_visit_args_t {
-    pub idx_type: H5_index_t,
-    pub order: H5_iter_order_t,
-    pub fields: c_uint,
-    pub op: H5O_iterate2_t,
-    pub op_data: *mut c_void,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_specific_args_t_union_change_rc {
-    pub delta: c_int,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_specific_args_t_union_exists {
-    pub exists: *mut hbool_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_specific_args_t_union_lookup {
-    pub token_ptr: *mut H5O_token_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_specific_args_t_union_flush {
-    pub obj_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_specific_args_t_union_refresh {
-    pub obj_id: hid_t,
-}
-
-#[repr(C)]
-pub union H5VL_object_specific_args_t_union {
-    pub change_rc: ManuallyDrop<H5VL_object_specific_args_t_union_change_rc>,
-    pub exists: ManuallyDrop<H5VL_object_specific_args_t_union_exists>,
-    pub lookup: ManuallyDrop<H5VL_object_specific_args_t_union_lookup>,
-    pub visit: ManuallyDrop<H5VL_object_visit_args_t>,
-    pub flush: ManuallyDrop<H5VL_object_specific_args_t_union_flush>,
-    pub refresh: ManuallyDrop<H5VL_object_specific_args_t_union_refresh>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_object_specific_t {
-    H5VL_OBJECT_CHANGE_REF_COUNT,
-    H5VL_OBJECT_EXISTS,
-    H5VL_OBJECT_LOOKUP,
-    H5VL_OBJECT_VISIT,
-    H5VL_OBJECT_FLUSH,
-    H5VL_OBJECT_REFRESH,
-}
-
-#[repr(C)]
-pub struct H5VL_object_specific_args_t {
-    pub op_type: H5VL_object_specific_t,
-    pub args: H5VL_object_specific_args_t_union,
-}
-
-impl Debug for H5VL_object_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_object_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_object_specific_t::H5VL_OBJECT_CHANGE_REF_COUNT => {
-                    s.field("args", &self.args.change_rc)
-                }
-                H5VL_object_specific_t::H5VL_OBJECT_EXISTS => s.field("args", &self.args.exists),
-                H5VL_object_specific_t::H5VL_OBJECT_LOOKUP => s.field("args", &self.args.lookup),
-                H5VL_object_specific_t::H5VL_OBJECT_VISIT => s.field("args", &self.args.visit),
-                H5VL_object_specific_t::H5VL_OBJECT_FLUSH => s.field("args", &self.args.flush),
-                H5VL_object_specific_t::H5VL_OBJECT_REFRESH => s.field("args", &self.args.refresh),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_object_get_t {
-    H5VL_OBJECT_GET_FILE,
-    H5VL_OBJECT_GET_NAME,
-    H5VL_OBJECT_GET_TYPE,
-    H5VL_OBJECT_GET_INFO,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_get_args_t_union_get_file {
-    pub file: *mut *mut c_void,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_get_args_t_union_get_name {
-    pub buf_size: size_t,
-    pub buf: *mut c_char,
-    pub name_len: *mut size_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_get_args_t_union_get_type {
-    pub obj_type: *mut H5O_type_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_get_args_t_union_get_info {
-    pub fields: c_uint,
-    pub oinfo: *mut H5O_info2_t,
-}
-
-#[repr(C)]
-pub union H5VL_object_get_args_t_union {
-    pub get_file: ManuallyDrop<H5VL_object_get_args_t_union_get_file>,
-    pub get_name: ManuallyDrop<H5VL_object_get_args_t_union_get_name>,
-    pub get_type: ManuallyDrop<H5VL_object_get_args_t_union_get_type>,
-    pub get_info: ManuallyDrop<H5VL_object_get_args_t_union_get_info>,
-}
-
-#[repr(C)]
-pub struct H5VL_object_get_args_t {
-    pub op_type: H5VL_object_get_t,
-    pub args: H5VL_object_get_args_t_union,
-}
-
-impl Debug for H5VL_object_get_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_object_get_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_object_get_t::H5VL_OBJECT_GET_FILE => s.field("args", &self.args.get_file),
-                H5VL_object_get_t::H5VL_OBJECT_GET_NAME => s.field("args", &self.args.get_name),
-                H5VL_object_get_t::H5VL_OBJECT_GET_TYPE => s.field("args", &self.args.get_type),
-                H5VL_object_get_t::H5VL_OBJECT_GET_INFO => s.field("args", &self.args.get_info),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_object_class_t {
-    pub open: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            opened_type: *mut H5I_type_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> *mut c_void,
-    >,
-    pub copy: Option<
-        extern "C" fn(
-            src_obj: *mut c_void,
-            loc_params1: *const H5VL_loc_params_t,
-            src_name: *const c_char,
-            dest_obj: *mut c_void,
-            loc_params2: *const H5VL_loc_params_t,
-            dst_name: *const c_char,
-            ocpypl_id: hid_t,
-            lcpl_id: hid_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            args: *mut H5VL_object_get_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            args: *mut H5VL_object_specific_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            loc_params: *const H5VL_loc_params_t,
-            args: *mut H5VL_optional_args_t,
-            dxpl_id: hid_t,
-            req: *mut *mut c_void,
-        ) -> herr_t,
-    >,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_get_conn_lvl_t {
-    H5VL_GET_CONN_LVL_CURR,
-    H5VL_GET_CONN_LVL_TERM,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_introspect_class_t {
-    pub get_conn_cls: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            lvl: H5VL_get_conn_lvl_t,
-            conn_cls: *const *const H5VL_class_t,
-        ) -> herr_t,
-    >,
-    pub get_cap_flags: Option<extern "C" fn(info: *const c_void, cap_flags: *mut c_uint) -> herr_t>,
-    pub opt_query: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            cls: H5VL_subclass_t,
-            opt_type: c_int,
-            flags: *mut u64,
-        ) -> herr_t,
-    >,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_request_status_t {
-    H5VL_REQUEST_STATUS_IN_PROGRESS,
-    H5VL_REQUEST_STATUS_SUCCEED,
-    H5VL_REQUEST_STATUS_FAIL,
-    H5VL_REQUEST_STATUS_CANT_CANCEL,
-    H5VL_REQUEST_STATUS_CANCELED,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_request_specific_t {
-    H5VL_REQUEST_GET_ERR_STACK,
-    H5VL_REQUEST_GET_EXEC_TIME,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_request_specific_args_t_union_get_err_stack {
-    pub err_stack_id: hid_t,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_request_specific_args_t_union_get_exec_time {
-    pub exec_ts: *mut u64,
-    pub exec_time: *mut u64,
-}
-
-#[repr(C)]
-pub union H5VL_request_specific_args_t_union {
-    pub get_err_stack: ManuallyDrop<H5VL_request_specific_args_t_union_get_err_stack>,
-    pub get_exec_time: ManuallyDrop<H5VL_request_specific_args_t_union_get_exec_time>,
-}
-
-#[repr(C)]
-pub struct H5VL_request_specific_args_t {
-    pub op_type: H5VL_request_specific_t,
-    pub args: H5VL_request_specific_args_t_union,
-}
-
-impl Debug for H5VL_request_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_blob_specific_args_t");
-        s.field("op_type", &self.op_type);
-        unsafe {
-            match self.op_type {
-                H5VL_request_specific_t::H5VL_REQUEST_GET_ERR_STACK => {
-                    s.field("args", &self.args.get_err_stack)
-                }
-                H5VL_request_specific_t::H5VL_REQUEST_GET_EXEC_TIME => {
-                    s.field("args", &self.args.get_exec_time)
-                }
-            }
-        };
-        s.finish()
-    }
-}
-
-pub type H5VL_request_notify_t =
-    Option<extern "C" fn(ctx: *mut c_void, status: H5VL_request_status_t) -> herr_t>;
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_request_class_t {
-    pub wait: Option<
-        extern "C" fn(req: *mut c_void, timeout: u64, status: *mut H5VL_request_status_t) -> herr_t,
-    >,
-    pub notify: Option<
-        extern "C" fn(req: *mut c_void, cb: H5VL_request_notify_t, ctx: *mut c_void) -> herr_t,
-    >,
-    pub cancel:
-        Option<extern "C" fn(req: *mut c_void, status: *mut H5VL_request_status_t) -> herr_t>,
-    pub specific:
-        Option<extern "C" fn(req: *mut c_void, args: *mut H5VL_request_specific_args_t) -> herr_t>,
-    pub optional:
-        Option<extern "C" fn(req: *mut c_void, args: *mut H5VL_optional_args_t) -> herr_t>,
-    pub free: Option<extern "C" fn(req: *mut c_void) -> herr_t>,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_blob_specific_t {
-    H5VL_BLOB_DELETE,
-    H5VL_BLOB_ISNULL,
-    H5VL_BLOB_SETNULL,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_blob_specific_args_t_union_is_null {
-    pub isnull: *mut hbool_t,
-}
-
-#[repr(C)]
-pub union H5VL_blob_specific_args_t_union {
-    pub is_null: ManuallyDrop<H5VL_blob_specific_args_t_union_is_null>,
-}
-
-#[repr(C)]
-pub struct H5VL_blob_specific_args_t {
-    pub op_type: H5VL_blob_specific_t,
-    pub args: H5VL_blob_specific_args_t_union,
-}
-
-impl Debug for H5VL_blob_specific_args_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_blob_specific_args_t");
-        s.field("op_type", &self.op_type);
-        let s = unsafe {
-            match self.op_type {
-                H5VL_blob_specific_t::H5VL_BLOB_DELETE => s.field("args", &"delete"),
-                H5VL_blob_specific_t::H5VL_BLOB_ISNULL => s.field("args", &self.args.is_null),
-                H5VL_blob_specific_t::H5VL_BLOB_SETNULL => s.field("args", &"setnull"),
-            }
-        };
-        s.finish()
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_blob_class_t {
-    pub put: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            buf: *const c_void,
-            size: size_t,
-            blob_id: *mut c_void,
-            ctx: *mut c_void,
-        ) -> herr_t,
-    >,
-    pub get: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            blob_id: *const c_void,
-            buf: *mut c_void,
-            size: size_t,
-            ctx: *mut c_void,
-        ) -> herr_t,
-    >,
-    pub specific: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            blob_id: *mut c_void,
-            args: *mut H5VL_blob_specific_args_t,
-        ) -> herr_t,
-    >,
-    pub optional: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            blob_id: *mut c_void,
-            args: *mut H5VL_optional_args_t,
-        ) -> herr_t,
-    >,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_token_class_t {
-    pub cmp: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            token1: *const H5O_token_t,
-            token2: *const H5O_token_t,
-            cmp_value: *mut c_int,
-        ) -> herr_t,
-    >,
-    pub to_str: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            obj_type: H5I_type_t,
-            token: *const H5O_token_t,
-            token_str: *mut *mut c_char,
-        ) -> herr_t,
-    >,
-    pub from_str: Option<
-        extern "C" fn(
-            obj: *mut c_void,
-            obj_type: H5I_type_t,
-            token_str: *const c_char,
-            token: *mut H5O_token_t,
-        ) -> herr_t,
-    >,
-}
+// Incomplete type
+#[cfg(all(feature = "1.12.0", not(feature = "1.13.0")))]
+pub type H5VL_class_t = c_void;
 
 #[repr(C)]
 #[derive(Debug)]
+#[cfg(feature = "1.13.0")]
 pub struct H5VL_class_t {
     pub version: c_uint,
     pub value: H5VL_class_value_t,
@@ -1787,6 +63,7 @@ extern "C" {
     pub fn H5VLunregister_connector(vol_id: hid_t) -> herr_t;
 }
 
+#[cfg(feature = "1.12.1")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum H5VL_subclass_t {
@@ -1805,138 +82,1924 @@ pub enum H5VL_subclass_t {
     H5VL_SUBCLS_TOKEN,
 }
 
+#[cfg(feature = "1.12.1")]
 extern "C" {
     pub fn H5VLquery_optional(
         obj_id: hid_t, subcls: H5VL_subclass_t, opt_type: c_int, supported: *mut hbool_t,
     ) -> herr_t;
 }
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum H5VL_loc_type_t {
-    H5VL_OBJECT_BY_SELF,
-    H5VL_OBJECT_BY_NAME,
-    H5VL_OBJECT_BY_IDX,
-    H5VL_OBJECT_BY_TOKEN,
-}
+#[cfg(feature = "1.13.0")]
+pub use v1_13_0::*;
+#[cfg(feature = "1.13.0")]
+mod v1_13_0 {
+    use std::fmt::{self, Debug};
+    use std::mem::ManuallyDrop;
 
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_loc_by_name_t {
-    pub name: *const c_char,
-    pub lapl_id: hid_t,
-}
+    use crate::{
+        h5a::{H5A_info_t, H5A_operator2_t},
+        h5d::H5D_space_status_t,
+        h5f::H5F_scope_t,
+        h5g::H5G_info_t,
+        h5i::H5I_type_t,
+        h5l::{H5L_info2_t, H5L_iterate2_t, H5L_type_t},
+        h5o::{H5O_info2_t, H5O_iterate2_t, H5O_token_t, H5O_type_t},
+    };
 
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_loc_by_idx_t {
-    pub name: *const c_char,
-    pub idx_type: H5_index_t,
-    pub order: H5_iter_order_t,
-    pub n: hsize_t,
-    pub lapl_id: hid_t,
-}
+    use super::*;
 
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_loc_by_token_t {
-    pub token: *mut H5O_token_t,
-}
-
-#[repr(C)]
-pub union H5VL_loc_params_t_union {
-    pub loc_by_token: ManuallyDrop<H5VL_loc_by_token_t>,
-    pub loc_by_name: ManuallyDrop<H5VL_loc_by_name_t>,
-    pub loc_by_idx: ManuallyDrop<H5VL_loc_by_idx_t>,
-}
-
-#[repr(C)]
-pub struct H5VL_loc_params_t {
-    pub obj_type: H5I_type_t,
-    pub type_: H5VL_loc_type_t,
-    pub loc_data: H5VL_loc_params_t_union,
-}
-
-impl Debug for H5VL_loc_params_t {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("H5VL_lov_params_t");
-        s.field("obj_type", &self.obj_type).field("type", &self.type_);
-        unsafe {
-            match self.type_ {
-                H5VL_loc_type_t::H5VL_OBJECT_BY_SELF => s.field("loc_data", &"by_self"),
-                H5VL_loc_type_t::H5VL_OBJECT_BY_NAME => {
-                    s.field("loc_data", &self.loc_data.loc_by_name)
-                }
-                H5VL_loc_type_t::H5VL_OBJECT_BY_IDX => {
-                    s.field("loc_data", &self.loc_data.loc_by_idx)
-                }
-                H5VL_loc_type_t::H5VL_OBJECT_BY_TOKEN => {
-                    s.field("loc_data", &self.loc_data.loc_by_token)
-                }
-            }
-        };
-        s.finish()
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_info_class_t {
+        pub size: size_t,
+        pub copy: Option<extern "C" fn(info: *const c_void) -> *mut c_void>,
+        pub cmp: Option<
+            extern "C" fn(
+                cmp_value: *mut c_int,
+                info1: *const c_void,
+                info2: *const c_void,
+            ) -> herr_t,
+        >,
+        pub free: Option<extern "C" fn(info: *mut c_void) -> herr_t>,
+        pub to_str: Option<extern "C" fn(info: *const c_void, str: *mut *mut c_char) -> herr_t>,
+        pub from_str: Option<extern "C" fn(str: *const c_char, info: *mut *mut c_void) -> herr_t>,
     }
-}
 
-#[repr(C)]
-#[derive(Debug)]
-pub struct H5VL_optional_args_t {
-    pub op_type: c_int,
-    pub args: *mut c_void,
-}
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_wrap_class_t {
+        pub get_object: Option<extern "C" fn(obj: *const c_void) -> *mut c_void>,
+        pub get_wrap_ctx:
+            Option<extern "C" fn(obj: *const c_void, wrap_ctx: *mut *mut c_void) -> herr_t>,
+        pub wrap_object: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                obj_type: H5I_type_t,
+                wrap_ctx: *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub unwrap_object: Option<extern "C" fn(obj: *mut c_void) -> *mut c_void>,
+        pub free_wrap_ctx: Option<extern "C" fn(wrap_ctx: *mut c_void) -> herr_t>,
+    }
 
-extern "C" {
-    pub fn H5VLattr_optional_op(
-        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,
-        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
-    ) -> herr_t;
-    pub fn H5VLdataset_optional_op(
-        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
-        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
-    ) -> herr_t;
-    pub fn H5VLdatatype_optional_op(
-        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, type_id: hid_t,
-        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
-    ) -> herr_t;
-    pub fn H5VLfile_optional_op(
-        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, file_id: hid_t,
-        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
-    ) -> herr_t;
-    pub fn H5VLfind_opt_operation(
-        subcls: H5VL_subclass_t, op_name: *const c_char, op_val: *mut c_int,
-    ) -> herr_t;
-    pub fn H5VLgroup_optional_op(
-        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, group_id: hid_t,
-        args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
-    ) -> herr_t;
-    pub fn H5VLlink_optional_op(
-        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
-        name: *const c_char, lapl_id: hid_t, args: *mut H5VL_optional_args_t, dxpl_id: hid_t,
-        es_id: hid_t,
-    ) -> herr_t;
-    pub fn H5VLobject_optional_op(
-        app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
-        name: *const c_char, lapl_id: hid_t, args: *mut H5VL_optional_args_t, dxpl_id: hid_t,
-        es_id: hid_t,
-    ) -> herr_t;
-    pub fn H5VLregister_opt_operation(
-        subcls: H5VL_subclass_t, op_name: *const c_char, op_val: *mut c_int,
-    ) -> herr_t;
-    pub fn H5VLrequest_optional_op(
-        req: *mut c_void, connector_id: hid_t, args: *mut H5VL_optional_args_t,
-    ) -> herr_t;
-    pub fn H5VLunregister_opt_operation(subcls: H5VL_subclass_t, op_name: *const c_char) -> herr_t;
-}
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_attr_get_t {
+        H5VL_ATTR_GET_ACPL,
+        H5VL_ATTR_GET_INFO,
+        H5VL_ATTR_GET_NAME,
+        H5VL_ATTR_GET_SPACE,
+        H5VL_ATTR_GET_STORAGE_SIZE,
+        H5VL_ATTR_GET_TYPE,
+    }
 
-extern "C" {
-    pub fn H5VLfinish_lib_state() -> herr_t;
-    pub fn H5VLintrospect_get_cap_flags(
-        info: *const c_void, connector_id: hid_t, cap_flags: *mut c_uint,
-    ) -> herr_t;
-    pub fn H5VLstart_lib_state() -> herr_t;
-}
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_get_args_t_union_get_acpl {
+        pub acpl_id: hid_t,
+    }
 
-extern "C" {
-    pub fn H5VLobject_is_native(obj_id: hid_t, is_native: *mut hbool_t) -> herr_t;
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_get_args_t_union_get_space {
+        pub space_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_get_args_t_union_get_storage_size {
+        pub data_size: *mut hsize_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_get_args_t_union_get_type {
+        pub type_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_get_name_args_t {
+        pub loc_params: H5VL_loc_params_t,
+        pub buf_size: size_t,
+        pub buf: *mut c_char,
+        pub attr_name_len: *mut size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_get_info_args_t {
+        pub loc_params: H5VL_loc_params_t,
+        pub attr_name: *const c_char,
+        pub ainfo: *mut H5A_info_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_attr_get_args_t_union {
+        pub get_acpl: ManuallyDrop<H5VL_attr_get_args_t_union_get_acpl>,
+        pub get_info: ManuallyDrop<H5VL_attr_get_info_args_t>,
+        pub get_name: ManuallyDrop<H5VL_attr_get_name_args_t>,
+        pub get_space: ManuallyDrop<H5VL_attr_get_args_t_union_get_space>,
+        pub get_storage_size: ManuallyDrop<H5VL_attr_get_args_t_union_get_storage_size>,
+        pub get_type: ManuallyDrop<H5VL_attr_get_args_t_union_get_type>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_attr_get_args_t {
+        pub op_type: H5VL_attr_get_t,
+        pub args: H5VL_attr_get_args_t_union,
+    }
+
+    impl Debug for H5VL_attr_get_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_attr_get_t::H5VL_ATTR_GET_ACPL => s.field("args", &self.args.get_acpl),
+                    H5VL_attr_get_t::H5VL_ATTR_GET_INFO => s.field("args", &self.args.get_info),
+                    H5VL_attr_get_t::H5VL_ATTR_GET_NAME => s.field("args", &self.args.get_name),
+                    H5VL_attr_get_t::H5VL_ATTR_GET_SPACE => s.field("args", &self.args.get_space),
+                    H5VL_attr_get_t::H5VL_ATTR_GET_STORAGE_SIZE => {
+                        s.field("args", &self.args.get_storage_size)
+                    }
+                    H5VL_attr_get_t::H5VL_ATTR_GET_TYPE => s.field("args", &self.args.get_type),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_attr_specific_t {
+        H5VL_ATTR_DELETE,
+        H5VL_ATTR_DELETE_BY_IDX,
+        H5VL_ATTR_EXISTS,
+        H5VL_ATTR_ITER,
+        H5VL_ATTR_RENAME,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_specific_args_t_union_del {
+        pub name: *const c_char,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_specific_args_t_union_exists {
+        pub name: *const c_char,
+        pub exists: *mut hbool_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_specific_args_t_union_rename {
+        pub old_name: *const c_char,
+        pub new_name: *const c_char,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_iterate_args_t {
+        pub idx_type: H5_index_t,
+        pub order: H5_iter_order_t,
+        pub idx: *mut hsize_t,
+        pub op: H5A_operator2_t,
+        pub op_data: *mut c_void,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_delete_by_idx_args_t {
+        pub idx_type: H5_index_t,
+        pub order: H5_iter_order_t,
+        pub n: hsize_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_attr_specific_args_t_union {
+        pub del: ManuallyDrop<H5VL_attr_specific_args_t_union_del>,
+        pub delete_by_idx: ManuallyDrop<H5VL_attr_delete_by_idx_args_t>,
+        pub exists: ManuallyDrop<H5VL_attr_specific_args_t_union_exists>,
+        pub iterate: ManuallyDrop<H5VL_attr_iterate_args_t>,
+        pub rename: ManuallyDrop<H5VL_attr_specific_args_t_union_rename>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_attr_specific_args_t {
+        pub op_type: H5VL_attr_specific_t,
+        pub args: H5VL_attr_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_attr_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_attr_specific_t::H5VL_ATTR_DELETE => s.field("args", &self.args.del),
+                    H5VL_attr_specific_t::H5VL_ATTR_DELETE_BY_IDX => {
+                        s.field("args", &self.args.delete_by_idx)
+                    }
+                    H5VL_attr_specific_t::H5VL_ATTR_EXISTS => s.field("args", &self.args.exists),
+                    H5VL_attr_specific_t::H5VL_ATTR_ITER => s.field("args", &self.args.iterate),
+                    H5VL_attr_specific_t::H5VL_ATTR_RENAME => s.field("args", &self.args.rename),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_attr_class_t {
+        pub create: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                attr_name: *const c_char,
+                type_id: hid_t,
+                space_id: hid_t,
+                acpl_id: hid_t,
+                aapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub open: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                attr_name: *const c_char,
+                aapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub read: Option<
+            extern "C" fn(
+                attr: *mut c_void,
+                mem_type_id: hid_t,
+                buf: *mut c_void,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub write: Option<
+            extern "C" fn(
+                attr: *mut c_void,
+                mem_type_id: hid_t,
+                buf: *const c_void,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_attr_get_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                args: *mut H5VL_attr_specific_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_optional_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub close: Option<
+            extern "C" fn(attr: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_dataset_specific_t {
+        H5VL_DATASET_SET_EXTENT,
+        H5VL_DATASET_FLUSH,
+        H5VL_DATASET_REFRESH,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_specific_args_t_union_set_extent {
+        pub size: *const hsize_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_specific_args_t_union_flush {
+        pub dset_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_specific_args_t_union_refresh {
+        pub dset_id: hid_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_dataset_specific_args_t_union {
+        pub set_extent: ManuallyDrop<H5VL_dataset_specific_args_t_union_set_extent>,
+        pub flush: ManuallyDrop<H5VL_dataset_specific_args_t_union_flush>,
+        pub refresh: ManuallyDrop<H5VL_dataset_specific_args_t_union_refresh>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_dataset_specific_args_t {
+        pub op_type: H5VL_dataset_specific_t,
+        pub args: H5VL_dataset_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_dataset_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_dataset_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_dataset_specific_t::H5VL_DATASET_SET_EXTENT => {
+                        s.field("args", &self.args.set_extent)
+                    }
+                    H5VL_dataset_specific_t::H5VL_DATASET_FLUSH => {
+                        s.field("args", &self.args.flush)
+                    }
+                    H5VL_dataset_specific_t::H5VL_DATASET_REFRESH => {
+                        s.field("args", &self.args.refresh)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_dataset_get_t {
+        H5VL_DATASET_GET_DAPL,
+        H5VL_DATASET_GET_DCPL,
+        H5VL_DATASET_GET_SPACE,
+        H5VL_DATASET_GET_SPACE_STATUS,
+        H5VL_DATASET_GET_STORAGE_SIZE,
+        H5VL_DATASET_GET_TYPE,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_get_args_t_union_get_dapl {
+        pub dapl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_get_args_t_union_get_dcpl {
+        pub dcpl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_get_args_t_union_get_space {
+        pub space_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_get_args_t_union_get_space_status {
+        pub status: *mut H5D_space_status_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_get_args_t_union_get_storage_size {
+        pub storage_size: *mut hsize_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_get_args_t_union_get_type {
+        pub type_id: hid_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_dataset_get_args_t_union {
+        pub get_dapl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dapl>,
+        pub get_dcpl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dcpl>,
+        pub get_space: ManuallyDrop<H5VL_dataset_get_args_t_union_get_space>,
+        pub get_space_status: ManuallyDrop<H5VL_dataset_get_args_t_union_get_space_status>,
+        pub get_storage_size: ManuallyDrop<H5VL_dataset_get_args_t_union_get_storage_size>,
+        pub get_type: ManuallyDrop<H5VL_dataset_get_args_t_union_get_type>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_dataset_get_args_t {
+        pub op_type: H5VL_dataset_get_t,
+        pub args: H5VL_dataset_get_args_t_union,
+    }
+
+    impl Debug for H5VL_dataset_get_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_dataset_get_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_dataset_get_t::H5VL_DATASET_GET_DAPL => {
+                        s.field("args", &self.args.get_dapl)
+                    }
+                    H5VL_dataset_get_t::H5VL_DATASET_GET_DCPL => {
+                        s.field("args", &self.args.get_dcpl)
+                    }
+                    H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE => {
+                        s.field("args", &self.args.get_space)
+                    }
+                    H5VL_dataset_get_t::H5VL_DATASET_GET_SPACE_STATUS => {
+                        s.field("args", &self.args.get_space_status)
+                    }
+                    H5VL_dataset_get_t::H5VL_DATASET_GET_STORAGE_SIZE => {
+                        s.field("args", &self.args.get_storage_size)
+                    }
+                    H5VL_dataset_get_t::H5VL_DATASET_GET_TYPE => {
+                        s.field("args", &self.args.get_type)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_dataset_class_t {
+        pub create: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                name: *const c_char,
+                lcpl_id: hid_t,
+                type_id: hid_t,
+                space_id: hid_t,
+                dcpl_id: hid_t,
+                dapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub open: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                name: *const c_char,
+                dapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub read: Option<
+            extern "C" fn(
+                dset: *mut c_void,
+                mem_type_id: hid_t,
+                mem_space_id: hid_t,
+                file_space_id: hid_t,
+                dxpl_id: hid_t,
+                buf: *mut c_void,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub write: Option<
+            extern "C" fn(
+                dset: *mut c_void,
+                mem_type_id: hid_t,
+                mem_space_id: hid_t,
+                file_space_id: hid_t,
+                dxpl_id: hid_t,
+                buf: *const c_void,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_dataset_get_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_dataset_specific_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_optional_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub close: Option<
+            extern "C" fn(dset: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_file_specific_t {
+        H5VL_FILE_FLUSH,
+        H5VL_FILE_REOPEN,
+        H5VL_FILE_IS_ACCESSIBLE,
+        H5VL_FILE_DELETE,
+        H5VL_FILE_IS_EQUAL,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_datatype_specific_args_t_union_flush {
+        pub type_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_datatype_specific_args_t_union_refresh {
+        pub type_id: hid_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_datatype_specific_args_t_union {
+        pub flush: ManuallyDrop<H5VL_datatype_specific_args_t_union_flush>,
+        pub refresh: ManuallyDrop<H5VL_datatype_specific_args_t_union_refresh>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_datatype_specific_t {
+        H5VL_DATATYPE_FLUSH,
+        H5VL_DATATYPE_REFRESH,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_datatype_specific_args_t {
+        pub op_type: H5VL_datatype_specific_t,
+        pub args: H5VL_datatype_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_datatype_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_datatype_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_datatype_specific_t::H5VL_DATATYPE_FLUSH => {
+                        s.field("args", &self.args.flush)
+                    }
+                    H5VL_datatype_specific_t::H5VL_DATATYPE_REFRESH => {
+                        s.field("args", &self.args.refresh)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_datatype_get_t {
+        H5VL_DATATYPE_GET_BINARY_SIZE,
+        H5VL_DATATYPE_GET_BINARY,
+        H5VL_DATATYPE_GET_TCPL,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_datatype_get_args_t_union_get_binary_size {
+        pub size: *mut size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_datatype_get_args_t_union_get_binary {
+        pub buf: *mut c_void,
+        pub buf_size: size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_datatype_get_args_t_union_get_tcpl {
+        pub tcpl_id: hid_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_datatype_get_args_t_union {
+        pub get_binary_size: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary_size>,
+        pub get_binary: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary>,
+        pub get_tcpl: ManuallyDrop<H5VL_datatype_get_args_t_union_get_tcpl>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_datatype_get_args_t {
+        pub op_type: H5VL_datatype_get_t,
+        pub args: H5VL_datatype_get_args_t_union,
+    }
+
+    impl Debug for H5VL_datatype_get_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_datatype_get_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY_SIZE => {
+                        s.field("args", &self.args.get_binary_size)
+                    }
+                    H5VL_datatype_get_t::H5VL_DATATYPE_GET_BINARY => {
+                        s.field("args", &self.args.get_binary)
+                    }
+                    H5VL_datatype_get_t::H5VL_DATATYPE_GET_TCPL => {
+                        s.field("args", &self.args.get_tcpl)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_datatype_class_t {
+        pub commit: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                name: *const c_char,
+                type_id: hid_t,
+                lcpl_id: hid_t,
+                tcpl_id: hid_t,
+                tapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub open: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                name: *const c_char,
+                tapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_datatype_get_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_datatype_specific_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_optional_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub close:
+            Option<extern "C" fn(dt: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_specific_args_t_union_flush {
+        pub obj_type: H5I_type_t,
+        pub scope: H5F_scope_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_specific_args_t_union_reopen {
+        pub file: *mut *mut c_void,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_specific_args_t_union_is_accessible {
+        pub filename: *const c_char,
+        pub fapl_id: hid_t,
+        pub accessible: *mut hbool_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_specific_args_t_union_del {
+        pub filename: *const c_char,
+        pub fapl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_specific_args_t_union_is_equal {
+        pub obj2: *mut c_void,
+        pub same_file: *mut hbool_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_file_specific_args_t_union {
+        pub flush: ManuallyDrop<H5VL_file_specific_args_t_union_flush>,
+        pub reopen: ManuallyDrop<H5VL_file_specific_args_t_union_reopen>,
+        pub is_accessible: ManuallyDrop<H5VL_file_specific_args_t_union_is_accessible>,
+        pub del: ManuallyDrop<H5VL_file_specific_args_t_union_del>,
+        pub is_equal: ManuallyDrop<H5VL_file_specific_args_t_union_is_equal>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_file_specific_args_t {
+        pub op_type: H5VL_file_specific_t,
+        pub args: H5VL_file_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_file_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_file_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_file_specific_t::H5VL_FILE_FLUSH => s.field("args", &self.args.flush),
+                    H5VL_file_specific_t::H5VL_FILE_REOPEN => s.field("args", &self.args.reopen),
+                    H5VL_file_specific_t::H5VL_FILE_IS_ACCESSIBLE => {
+                        s.field("args", &self.args.is_accessible)
+                    }
+                    H5VL_file_specific_t::H5VL_FILE_DELETE => s.field("args", &self.args.del),
+                    H5VL_file_specific_t::H5VL_FILE_IS_EQUAL => {
+                        s.field("args", &self.args.is_equal)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_cont_info_t {
+        pub version: c_uint,
+        pub feature_flags: u64,
+        pub token_size: size_t,
+        pub blob_id_size: size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_args_t_union_get_cont_info {
+        pub info: *mut H5VL_file_cont_info_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_args_t_union_get_fapl {
+        pub fapl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_args_t_union_get_fcpl {
+        pub fcpl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_args_t_union_get_fileno {
+        pub fileno: *mut c_ulong,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_args_t_union_get_intent {
+        pub flags: *mut c_uint,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_args_t_union_get_obj_count {
+        pub types: c_uint,
+        pub count: *mut size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_obj_ids_args_t {
+        pub types: c_uint,
+        pub max_objs: size_t,
+        pub old_list: *mut hid_t,
+        pub count: *mut size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_get_name_args_t {
+        pub r#type: H5I_type_t,
+        pub buf_size: size_t,
+        pub buf: *mut c_char,
+        pub file_name_len: *mut size_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_file_get_args_t_union {
+        pub get_cont_info: ManuallyDrop<H5VL_file_get_args_t_union_get_cont_info>,
+        pub get_fapl: ManuallyDrop<H5VL_file_get_args_t_union_get_fapl>,
+        pub get_fcpl: ManuallyDrop<H5VL_file_get_args_t_union_get_fcpl>,
+        pub get_fileno: ManuallyDrop<H5VL_file_get_args_t_union_get_fileno>,
+        pub get_intent: ManuallyDrop<H5VL_file_get_args_t_union_get_intent>,
+        pub get_name: ManuallyDrop<H5VL_file_get_name_args_t>,
+        pub get_obj_count: ManuallyDrop<H5VL_file_get_args_t_union_get_obj_count>,
+        pub get_obj_ids: ManuallyDrop<H5VL_file_get_obj_ids_args_t>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_file_get_t {
+        H5VL_FILE_GET_CONT_INFO,
+        H5VL_FILE_GET_FAPL,
+        H5VL_FILE_GET_FCPL,
+        H5VL_FILE_GET_FILENO,
+        H5VL_FILE_GET_INTENT,
+        H5VL_FILE_GET_NAME,
+        H5VL_FILE_GET_OBJ_COUNT,
+        H5VL_FILE_GET_OBJ_IDS,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_file_get_args_t {
+        pub op_type: H5VL_file_get_t,
+        pub args: H5VL_file_get_args_t_union,
+    }
+
+    impl Debug for H5VL_file_get_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_file_get_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_file_get_t::H5VL_FILE_GET_CONT_INFO => {
+                        s.field("args", &self.args.get_cont_info)
+                    }
+                    H5VL_file_get_t::H5VL_FILE_GET_FAPL => s.field("args", &self.args.get_fapl),
+                    H5VL_file_get_t::H5VL_FILE_GET_FCPL => s.field("args", &self.args.get_fcpl),
+                    H5VL_file_get_t::H5VL_FILE_GET_FILENO => s.field("args", &self.args.get_fileno),
+                    H5VL_file_get_t::H5VL_FILE_GET_INTENT => s.field("args", &self.args.get_intent),
+                    H5VL_file_get_t::H5VL_FILE_GET_NAME => s.field("args", &self.args.get_name),
+                    H5VL_file_get_t::H5VL_FILE_GET_OBJ_COUNT => {
+                        s.field("args", &self.args.get_obj_count)
+                    }
+                    H5VL_file_get_t::H5VL_FILE_GET_OBJ_IDS => {
+                        s.field("args", &self.args.get_obj_ids)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_file_class_t {
+        pub create: Option<
+            extern "C" fn(
+                name: *const c_char,
+                flags: c_uint,
+                fcpl_id: hid_t,
+                fapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub open: Option<
+            extern "C" fn(
+                name: *const c_char,
+                flags: c_uint,
+                fapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_file_get_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_file_specific_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_optional_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub close: Option<
+            extern "C" fn(file: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_group_specific_t {
+        H5VL_GROUP_MOUNT,
+        H5VL_GROUP_UNMOUNT,
+        H5VL_GROUP_FLUSH,
+        H5VL_GROUP_REFRESH,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_group_spec_mount_args_t {
+        pub name: *const c_char,
+        pub child_file: *mut c_void,
+        pub fmpl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_group_specific_args_t_union_unmount {
+        pub name: *const c_char,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_group_specific_args_t_union_flush {
+        pub grp_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_group_specific_args_t_union_refresh {
+        pub grp_id: hid_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_group_specific_args_t_union {
+        pub mount: ManuallyDrop<H5VL_group_spec_mount_args_t>,
+        pub unmount: ManuallyDrop<H5VL_group_specific_args_t_union_unmount>,
+        pub flush: ManuallyDrop<H5VL_group_specific_args_t_union_flush>,
+        pub refresh: ManuallyDrop<H5VL_group_specific_args_t_union_refresh>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_group_specific_args_t {
+        pub op_type: H5VL_group_specific_t,
+        pub args: H5VL_group_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_group_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_group_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_group_specific_t::H5VL_GROUP_MOUNT => s.field("args", &self.args.mount),
+                    H5VL_group_specific_t::H5VL_GROUP_UNMOUNT => {
+                        s.field("args", &self.args.unmount)
+                    }
+                    H5VL_group_specific_t::H5VL_GROUP_FLUSH => s.field("args", &self.args.flush),
+                    H5VL_group_specific_t::H5VL_GROUP_REFRESH => {
+                        s.field("args", &self.args.refresh)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_group_get_info_args_t {
+        pub loc_params: H5VL_loc_params_t,
+        pub ginfo: *mut H5G_info_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_group_get_args_t_union_get_gcpl {
+        pub gcpl_id: hid_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_group_get_args_t_union {
+        pub get_gcpl: ManuallyDrop<H5VL_group_get_args_t_union_get_gcpl>,
+        pub get_info: ManuallyDrop<H5VL_group_get_info_args_t>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_group_get_t {
+        H5VL_GROUP_GET_GCPL,
+        H5VL_GROUP_GET_INFO,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_group_get_args_t {
+        pub op_type: H5VL_group_get_t,
+        pub args: H5VL_group_get_args_t_union,
+    }
+
+    impl Debug for H5VL_group_get_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_group_get_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_group_get_t::H5VL_GROUP_GET_GCPL => s.field("args", &self.args.get_gcpl),
+                    H5VL_group_get_t::H5VL_GROUP_GET_INFO => s.field("args", &self.args.get_info),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_group_class_t {
+        pub create: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                name: *const c_char,
+                lcpl_id: hid_t,
+                gcpl_id: hid_t,
+                gapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub open: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+
+                name: *const c_char,
+                gapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_group_get_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_group_specific_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                args: *mut H5VL_optional_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub close: Option<
+            extern "C" fn(grp: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_iterate_args_t {
+        pub recursive: hbool_t,
+        pub idx_type: H5_index_t,
+        pub order: H5_iter_order_t,
+        pub idx_p: *mut hsize_t,
+        pub op: H5L_iterate2_t,
+        pub op_data: *mut c_void,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_specific_args_t_union_exists {
+        pub exists: *mut hbool_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_link_specific_args_t_union {
+        pub exists: ManuallyDrop<H5VL_link_specific_args_t_union_exists>,
+        pub iterate: ManuallyDrop<H5VL_link_iterate_args_t>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_link_specific_t {
+        H5VL_LINK_DELETE,
+        H5VL_LINK_EXISTS,
+        H5VL_LINK_ITER,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_link_specific_args_t {
+        pub op_type: H5VL_link_specific_t,
+        pub args: H5VL_link_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_link_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_link_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_link_specific_t::H5VL_LINK_DELETE => s.field("args", &"delete"),
+                    H5VL_link_specific_t::H5VL_LINK_EXISTS => s.field("args", &self.args.exists),
+                    H5VL_link_specific_t::H5VL_LINK_ITER => s.field("args", &self.args.iterate),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_get_args_t_union_get_info {
+        pub linfo: *mut H5L_info2_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_get_args_t_union_get_name {
+        pub name_size: size_t,
+        pub name: *mut c_char,
+        pub name_len: *mut size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_get_args_t_union_get_val {
+        pub buf_size: size_t,
+        pub buf: *mut c_void,
+    }
+
+    #[repr(C)]
+    pub union H5VL_link_get_args_t_union {
+        pub get_info: ManuallyDrop<H5VL_link_get_args_t_union_get_info>,
+        pub get_name: ManuallyDrop<H5VL_link_get_args_t_union_get_name>,
+        pub get_val: ManuallyDrop<H5VL_link_get_args_t_union_get_val>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_link_get_t {
+        H5VL_LINK_GET_INFO,
+        H5VL_LINK_GET_NAME,
+        H5VL_LINK_GET_VAL,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_link_get_args_t {
+        pub op_type: H5VL_link_get_t,
+        pub args: H5VL_link_get_args_t_union,
+    }
+
+    impl Debug for H5VL_link_get_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_link_get_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_link_get_t::H5VL_LINK_GET_INFO => s.field("args", &self.args.get_info),
+                    H5VL_link_get_t::H5VL_LINK_GET_NAME => s.field("args", &self.args.get_name),
+                    H5VL_link_get_t::H5VL_LINK_GET_VAL => s.field("args", &self.args.get_val),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_link_create_t {
+        H5VL_LINK_CREATE_HARD,
+        H5VL_LINK_CREATE_SOFT,
+        H5VL_LINK_CREATE_UD,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_create_args_t_union_hard {
+        pub curr_obj: *mut c_void,
+        pub curr_loc_params: H5VL_loc_params_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_create_args_t_union_soft {
+        pub target: *const c_char,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_create_args_t_union_ud {
+        pub r#type: H5L_type_t,
+        pub buf: *const c_void,
+        pub buf_size: size_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_link_create_args_t_union {
+        pub hard: ManuallyDrop<H5VL_link_create_args_t_union_hard>,
+        pub soft: ManuallyDrop<H5VL_link_create_args_t_union_soft>,
+        pub ud: ManuallyDrop<H5VL_link_create_args_t_union_ud>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_link_create_args_t {
+        pub op_type: H5VL_link_create_t,
+        pub args: H5VL_link_create_args_t_union,
+    }
+
+    impl Debug for H5VL_link_create_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_link_create_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_link_create_t::H5VL_LINK_CREATE_HARD => s.field("args", &self.args.hard),
+                    H5VL_link_create_t::H5VL_LINK_CREATE_SOFT => s.field("args", &self.args.soft),
+                    H5VL_link_create_t::H5VL_LINK_CREATE_UD => s.field("args", &self.args.ud),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_link_class_t {
+        pub create: Option<
+            extern "C" fn(
+                args: *mut H5VL_link_create_args_t,
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                lcpl_id: hid_t,
+                lapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub copy: Option<
+            extern "C" fn(
+                src_obj: *mut c_void,
+                loc_params1: *const H5VL_loc_params_t,
+                dest_obj: *mut c_void,
+                loc_params2: *const H5VL_loc_params_t,
+                lcpl_id: hid_t,
+                lapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub r#move: Option<
+            extern "C" fn(
+                src_obj: *mut c_void,
+                loc_params1: *const H5VL_loc_params_t,
+                dest_obj: *mut c_void,
+                loc_params2: *const H5VL_loc_params_t,
+                lcpl_id: hid_t,
+                lapl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                args: *mut H5VL_link_get_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                args: *mut H5VL_link_specific_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                args: *mut H5VL_optional_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_visit_args_t {
+        pub idx_type: H5_index_t,
+        pub order: H5_iter_order_t,
+        pub fields: c_uint,
+        pub op: H5O_iterate2_t,
+        pub op_data: *mut c_void,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_specific_args_t_union_change_rc {
+        pub delta: c_int,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_specific_args_t_union_exists {
+        pub exists: *mut hbool_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_specific_args_t_union_lookup {
+        pub token_ptr: *mut H5O_token_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_specific_args_t_union_flush {
+        pub obj_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_specific_args_t_union_refresh {
+        pub obj_id: hid_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_object_specific_args_t_union {
+        pub change_rc: ManuallyDrop<H5VL_object_specific_args_t_union_change_rc>,
+        pub exists: ManuallyDrop<H5VL_object_specific_args_t_union_exists>,
+        pub lookup: ManuallyDrop<H5VL_object_specific_args_t_union_lookup>,
+        pub visit: ManuallyDrop<H5VL_object_visit_args_t>,
+        pub flush: ManuallyDrop<H5VL_object_specific_args_t_union_flush>,
+        pub refresh: ManuallyDrop<H5VL_object_specific_args_t_union_refresh>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_object_specific_t {
+        H5VL_OBJECT_CHANGE_REF_COUNT,
+        H5VL_OBJECT_EXISTS,
+        H5VL_OBJECT_LOOKUP,
+        H5VL_OBJECT_VISIT,
+        H5VL_OBJECT_FLUSH,
+        H5VL_OBJECT_REFRESH,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_object_specific_args_t {
+        pub op_type: H5VL_object_specific_t,
+        pub args: H5VL_object_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_object_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_object_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_object_specific_t::H5VL_OBJECT_CHANGE_REF_COUNT => {
+                        s.field("args", &self.args.change_rc)
+                    }
+                    H5VL_object_specific_t::H5VL_OBJECT_EXISTS => {
+                        s.field("args", &self.args.exists)
+                    }
+                    H5VL_object_specific_t::H5VL_OBJECT_LOOKUP => {
+                        s.field("args", &self.args.lookup)
+                    }
+                    H5VL_object_specific_t::H5VL_OBJECT_VISIT => s.field("args", &self.args.visit),
+                    H5VL_object_specific_t::H5VL_OBJECT_FLUSH => s.field("args", &self.args.flush),
+                    H5VL_object_specific_t::H5VL_OBJECT_REFRESH => {
+                        s.field("args", &self.args.refresh)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_object_get_t {
+        H5VL_OBJECT_GET_FILE,
+        H5VL_OBJECT_GET_NAME,
+        H5VL_OBJECT_GET_TYPE,
+        H5VL_OBJECT_GET_INFO,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_get_args_t_union_get_file {
+        pub file: *mut *mut c_void,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_get_args_t_union_get_name {
+        pub buf_size: size_t,
+        pub buf: *mut c_char,
+        pub name_len: *mut size_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_get_args_t_union_get_type {
+        pub obj_type: *mut H5O_type_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_get_args_t_union_get_info {
+        pub fields: c_uint,
+        pub oinfo: *mut H5O_info2_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_object_get_args_t_union {
+        pub get_file: ManuallyDrop<H5VL_object_get_args_t_union_get_file>,
+        pub get_name: ManuallyDrop<H5VL_object_get_args_t_union_get_name>,
+        pub get_type: ManuallyDrop<H5VL_object_get_args_t_union_get_type>,
+        pub get_info: ManuallyDrop<H5VL_object_get_args_t_union_get_info>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_object_get_args_t {
+        pub op_type: H5VL_object_get_t,
+        pub args: H5VL_object_get_args_t_union,
+    }
+
+    impl Debug for H5VL_object_get_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_object_get_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_object_get_t::H5VL_OBJECT_GET_FILE => s.field("args", &self.args.get_file),
+                    H5VL_object_get_t::H5VL_OBJECT_GET_NAME => s.field("args", &self.args.get_name),
+                    H5VL_object_get_t::H5VL_OBJECT_GET_TYPE => s.field("args", &self.args.get_type),
+                    H5VL_object_get_t::H5VL_OBJECT_GET_INFO => s.field("args", &self.args.get_info),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_object_class_t {
+        pub open: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                opened_type: *mut H5I_type_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> *mut c_void,
+        >,
+        pub copy: Option<
+            extern "C" fn(
+                src_obj: *mut c_void,
+                loc_params1: *const H5VL_loc_params_t,
+                src_name: *const c_char,
+                dest_obj: *mut c_void,
+                loc_params2: *const H5VL_loc_params_t,
+                dst_name: *const c_char,
+                ocpypl_id: hid_t,
+                lcpl_id: hid_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                args: *mut H5VL_object_get_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                args: *mut H5VL_object_specific_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                loc_params: *const H5VL_loc_params_t,
+                args: *mut H5VL_optional_args_t,
+                dxpl_id: hid_t,
+                req: *mut *mut c_void,
+            ) -> herr_t,
+        >,
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_get_conn_lvl_t {
+        H5VL_GET_CONN_LVL_CURR,
+        H5VL_GET_CONN_LVL_TERM,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_introspect_class_t {
+        pub get_conn_cls: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                lvl: H5VL_get_conn_lvl_t,
+                conn_cls: *const *const H5VL_class_t,
+            ) -> herr_t,
+        >,
+        pub get_cap_flags:
+            Option<extern "C" fn(info: *const c_void, cap_flags: *mut c_uint) -> herr_t>,
+        pub opt_query: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                cls: H5VL_subclass_t,
+                opt_type: c_int,
+                flags: *mut u64,
+            ) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_request_status_t {
+        H5VL_REQUEST_STATUS_IN_PROGRESS,
+        H5VL_REQUEST_STATUS_SUCCEED,
+        H5VL_REQUEST_STATUS_FAIL,
+        H5VL_REQUEST_STATUS_CANT_CANCEL,
+        H5VL_REQUEST_STATUS_CANCELED,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_request_specific_t {
+        H5VL_REQUEST_GET_ERR_STACK,
+        H5VL_REQUEST_GET_EXEC_TIME,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_request_specific_args_t_union_get_err_stack {
+        pub err_stack_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_request_specific_args_t_union_get_exec_time {
+        pub exec_ts: *mut u64,
+        pub exec_time: *mut u64,
+    }
+
+    #[repr(C)]
+    pub union H5VL_request_specific_args_t_union {
+        pub get_err_stack: ManuallyDrop<H5VL_request_specific_args_t_union_get_err_stack>,
+        pub get_exec_time: ManuallyDrop<H5VL_request_specific_args_t_union_get_exec_time>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_request_specific_args_t {
+        pub op_type: H5VL_request_specific_t,
+        pub args: H5VL_request_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_request_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_blob_specific_args_t");
+            s.field("op_type", &self.op_type);
+            unsafe {
+                match self.op_type {
+                    H5VL_request_specific_t::H5VL_REQUEST_GET_ERR_STACK => {
+                        s.field("args", &self.args.get_err_stack)
+                    }
+                    H5VL_request_specific_t::H5VL_REQUEST_GET_EXEC_TIME => {
+                        s.field("args", &self.args.get_exec_time)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    pub type H5VL_request_notify_t =
+        Option<extern "C" fn(ctx: *mut c_void, status: H5VL_request_status_t) -> herr_t>;
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_request_class_t {
+        pub wait: Option<
+            extern "C" fn(
+                req: *mut c_void,
+                timeout: u64,
+                status: *mut H5VL_request_status_t,
+            ) -> herr_t,
+        >,
+        pub notify: Option<
+            extern "C" fn(req: *mut c_void, cb: H5VL_request_notify_t, ctx: *mut c_void) -> herr_t,
+        >,
+        pub cancel:
+            Option<extern "C" fn(req: *mut c_void, status: *mut H5VL_request_status_t) -> herr_t>,
+        pub specific: Option<
+            extern "C" fn(req: *mut c_void, args: *mut H5VL_request_specific_args_t) -> herr_t,
+        >,
+        pub optional:
+            Option<extern "C" fn(req: *mut c_void, args: *mut H5VL_optional_args_t) -> herr_t>,
+        pub free: Option<extern "C" fn(req: *mut c_void) -> herr_t>,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_blob_specific_t {
+        H5VL_BLOB_DELETE,
+        H5VL_BLOB_ISNULL,
+        H5VL_BLOB_SETNULL,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_blob_specific_args_t_union_is_null {
+        pub isnull: *mut hbool_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_blob_specific_args_t_union {
+        pub is_null: ManuallyDrop<H5VL_blob_specific_args_t_union_is_null>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_blob_specific_args_t {
+        pub op_type: H5VL_blob_specific_t,
+        pub args: H5VL_blob_specific_args_t_union,
+    }
+
+    impl Debug for H5VL_blob_specific_args_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_blob_specific_args_t");
+            s.field("op_type", &self.op_type);
+            let s = unsafe {
+                match self.op_type {
+                    H5VL_blob_specific_t::H5VL_BLOB_DELETE => s.field("args", &"delete"),
+                    H5VL_blob_specific_t::H5VL_BLOB_ISNULL => s.field("args", &self.args.is_null),
+                    H5VL_blob_specific_t::H5VL_BLOB_SETNULL => s.field("args", &"setnull"),
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_blob_class_t {
+        pub put: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                buf: *const c_void,
+                size: size_t,
+                blob_id: *mut c_void,
+                ctx: *mut c_void,
+            ) -> herr_t,
+        >,
+        pub get: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                blob_id: *const c_void,
+                buf: *mut c_void,
+                size: size_t,
+                ctx: *mut c_void,
+            ) -> herr_t,
+        >,
+        pub specific: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                blob_id: *mut c_void,
+                args: *mut H5VL_blob_specific_args_t,
+            ) -> herr_t,
+        >,
+        pub optional: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                blob_id: *mut c_void,
+                args: *mut H5VL_optional_args_t,
+            ) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_token_class_t {
+        pub cmp: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                token1: *const H5O_token_t,
+                token2: *const H5O_token_t,
+                cmp_value: *mut c_int,
+            ) -> herr_t,
+        >,
+        pub to_str: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                obj_type: H5I_type_t,
+                token: *const H5O_token_t,
+                token_str: *mut *mut c_char,
+            ) -> herr_t,
+        >,
+        pub from_str: Option<
+            extern "C" fn(
+                obj: *mut c_void,
+                obj_type: H5I_type_t,
+                token_str: *const c_char,
+                token: *mut H5O_token_t,
+            ) -> herr_t,
+        >,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum H5VL_loc_type_t {
+        H5VL_OBJECT_BY_SELF,
+        H5VL_OBJECT_BY_NAME,
+        H5VL_OBJECT_BY_IDX,
+        H5VL_OBJECT_BY_TOKEN,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_loc_by_name_t {
+        pub name: *const c_char,
+        pub lapl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_loc_by_idx_t {
+        pub name: *const c_char,
+        pub idx_type: H5_index_t,
+        pub order: H5_iter_order_t,
+        pub n: hsize_t,
+        pub lapl_id: hid_t,
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_loc_by_token_t {
+        pub token: *mut H5O_token_t,
+    }
+
+    #[repr(C)]
+    pub union H5VL_loc_params_t_union {
+        pub loc_by_token: ManuallyDrop<H5VL_loc_by_token_t>,
+        pub loc_by_name: ManuallyDrop<H5VL_loc_by_name_t>,
+        pub loc_by_idx: ManuallyDrop<H5VL_loc_by_idx_t>,
+    }
+
+    #[repr(C)]
+    pub struct H5VL_loc_params_t {
+        pub obj_type: H5I_type_t,
+        pub type_: H5VL_loc_type_t,
+        pub loc_data: H5VL_loc_params_t_union,
+    }
+
+    impl Debug for H5VL_loc_params_t {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct("H5VL_lov_params_t");
+            s.field("obj_type", &self.obj_type).field("type", &self.type_);
+            unsafe {
+                match self.type_ {
+                    H5VL_loc_type_t::H5VL_OBJECT_BY_SELF => s.field("loc_data", &"by_self"),
+                    H5VL_loc_type_t::H5VL_OBJECT_BY_NAME => {
+                        s.field("loc_data", &self.loc_data.loc_by_name)
+                    }
+                    H5VL_loc_type_t::H5VL_OBJECT_BY_IDX => {
+                        s.field("loc_data", &self.loc_data.loc_by_idx)
+                    }
+                    H5VL_loc_type_t::H5VL_OBJECT_BY_TOKEN => {
+                        s.field("loc_data", &self.loc_data.loc_by_token)
+                    }
+                }
+            };
+            s.finish()
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct H5VL_optional_args_t {
+        pub op_type: c_int,
+        pub args: *mut c_void,
+    }
+
+    extern "C" {
+        pub fn H5VLattr_optional_op(
+            app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,
+            args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+        ) -> herr_t;
+        pub fn H5VLdataset_optional_op(
+            app_file: *const c_char, app_func: *const c_char, app_line: c_uint, dset_id: hid_t,
+            args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+        ) -> herr_t;
+        pub fn H5VLdatatype_optional_op(
+            app_file: *const c_char, app_func: *const c_char, app_line: c_uint, type_id: hid_t,
+            args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+        ) -> herr_t;
+        pub fn H5VLfile_optional_op(
+            app_file: *const c_char, app_func: *const c_char, app_line: c_uint, file_id: hid_t,
+            args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+        ) -> herr_t;
+        pub fn H5VLfind_opt_operation(
+            subcls: H5VL_subclass_t, op_name: *const c_char, op_val: *mut c_int,
+        ) -> herr_t;
+        pub fn H5VLgroup_optional_op(
+            app_file: *const c_char, app_func: *const c_char, app_line: c_uint, group_id: hid_t,
+            args: *mut H5VL_optional_args_t, dxpl_id: hid_t, es_id: hid_t,
+        ) -> herr_t;
+        pub fn H5VLlink_optional_op(
+            app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+            name: *const c_char, lapl_id: hid_t, args: *mut H5VL_optional_args_t, dxpl_id: hid_t,
+            es_id: hid_t,
+        ) -> herr_t;
+        pub fn H5VLobject_optional_op(
+            app_file: *const c_char, app_func: *const c_char, app_line: c_uint, loc_id: hid_t,
+            name: *const c_char, lapl_id: hid_t, args: *mut H5VL_optional_args_t, dxpl_id: hid_t,
+            es_id: hid_t,
+        ) -> herr_t;
+        pub fn H5VLregister_opt_operation(
+            subcls: H5VL_subclass_t, op_name: *const c_char, op_val: *mut c_int,
+        ) -> herr_t;
+        pub fn H5VLrequest_optional_op(
+            req: *mut c_void, connector_id: hid_t, args: *mut H5VL_optional_args_t,
+        ) -> herr_t;
+        pub fn H5VLunregister_opt_operation(
+            subcls: H5VL_subclass_t, op_name: *const c_char,
+        ) -> herr_t;
+    }
+
+    extern "C" {
+        pub fn H5VLfinish_lib_state() -> herr_t;
+        pub fn H5VLintrospect_get_cap_flags(
+            info: *const c_void, connector_id: hid_t, cap_flags: *mut c_uint,
+        ) -> herr_t;
+        pub fn H5VLstart_lib_state() -> herr_t;
+    }
+
+    extern "C" {
+        pub fn H5VLobject_is_native(obj_id: hid_t, is_native: *mut hbool_t) -> herr_t;
+    }
 }

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -10,7 +10,7 @@ pub type H5VL_class_value_t = c_int;
 pub type H5VL_class_t = c_void;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[cfg(feature = "1.13.0")]
 pub struct H5VL_class_t {
     pub version: c_uint,
@@ -109,7 +109,7 @@ mod v1_13_0 {
     use super::*;
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_info_class_t {
         pub size: size_t,
         pub copy: Option<extern "C" fn(info: *const c_void) -> *mut c_void>,
@@ -126,7 +126,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_wrap_class_t {
         pub get_object: Option<extern "C" fn(obj: *const c_void) -> *mut c_void>,
         pub get_wrap_ctx:
@@ -154,31 +154,31 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_get_args_t_union_get_acpl {
         pub acpl_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_get_args_t_union_get_space {
         pub space_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_get_args_t_union_get_storage_size {
         pub data_size: *mut hsize_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_get_args_t_union_get_type {
         pub type_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_get_name_args_t {
         pub loc_params: H5VL_loc_params_t,
         pub buf_size: size_t,
@@ -187,7 +187,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_get_info_args_t {
         pub loc_params: H5VL_loc_params_t,
         pub attr_name: *const c_char,
@@ -195,6 +195,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_attr_get_args_t_union {
         pub get_acpl: ManuallyDrop<H5VL_attr_get_args_t_union_get_acpl>,
         pub get_info: ManuallyDrop<H5VL_attr_get_info_args_t>,
@@ -205,6 +206,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_attr_get_args_t {
         pub op_type: H5VL_attr_get_t,
         pub args: H5VL_attr_get_args_t_union,
@@ -241,27 +243,27 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_specific_args_t_union_del {
         pub name: *const c_char,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_specific_args_t_union_exists {
         pub name: *const c_char,
         pub exists: *mut hbool_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_specific_args_t_union_rename {
         pub old_name: *const c_char,
         pub new_name: *const c_char,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_iterate_args_t {
         pub idx_type: H5_index_t,
         pub order: H5_iter_order_t,
@@ -271,7 +273,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_delete_by_idx_args_t {
         pub idx_type: H5_index_t,
         pub order: H5_iter_order_t,
@@ -279,6 +281,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_attr_specific_args_t_union {
         pub del: ManuallyDrop<H5VL_attr_specific_args_t_union_del>,
         pub delete_by_idx: ManuallyDrop<H5VL_attr_delete_by_idx_args_t>,
@@ -288,6 +291,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_attr_specific_args_t {
         pub op_type: H5VL_attr_specific_t,
         pub args: H5VL_attr_specific_args_t_union,
@@ -313,7 +317,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_attr_class_t {
         pub create: Option<
             extern "C" fn(
@@ -395,24 +399,25 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub struct H5VL_dataset_specific_args_t_union_set_extent {
         pub size: *const hsize_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_specific_args_t_union_flush {
         pub dset_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_specific_args_t_union_refresh {
         pub dset_id: hid_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_dataset_specific_args_t_union {
         pub set_extent: ManuallyDrop<H5VL_dataset_specific_args_t_union_set_extent>,
         pub flush: ManuallyDrop<H5VL_dataset_specific_args_t_union_flush>,
@@ -420,6 +425,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_dataset_specific_args_t {
         pub op_type: H5VL_dataset_specific_t,
         pub args: H5VL_dataset_specific_args_t_union,
@@ -458,42 +464,43 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_get_args_t_union_get_dapl {
         pub dapl_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_get_args_t_union_get_dcpl {
         pub dcpl_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_get_args_t_union_get_space {
         pub space_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_get_args_t_union_get_space_status {
         pub status: *mut H5D_space_status_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_get_args_t_union_get_storage_size {
         pub storage_size: *mut hsize_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_get_args_t_union_get_type {
         pub type_id: hid_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_dataset_get_args_t_union {
         pub get_dapl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dapl>,
         pub get_dcpl: ManuallyDrop<H5VL_dataset_get_args_t_union_get_dcpl>,
@@ -504,6 +511,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_dataset_get_args_t {
         pub op_type: H5VL_dataset_get_t,
         pub args: H5VL_dataset_get_args_t_union,
@@ -540,7 +548,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_dataset_class_t {
         pub create: Option<
             extern "C" fn(
@@ -628,18 +636,19 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_datatype_specific_args_t_union_flush {
         pub type_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_datatype_specific_args_t_union_refresh {
         pub type_id: hid_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_datatype_specific_args_t_union {
         pub flush: ManuallyDrop<H5VL_datatype_specific_args_t_union_flush>,
         pub refresh: ManuallyDrop<H5VL_datatype_specific_args_t_union_refresh>,
@@ -653,6 +662,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_datatype_specific_args_t {
         pub op_type: H5VL_datatype_specific_t,
         pub args: H5VL_datatype_specific_args_t_union,
@@ -685,25 +695,26 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_datatype_get_args_t_union_get_binary_size {
         pub size: *mut size_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_datatype_get_args_t_union_get_binary {
         pub buf: *mut c_void,
         pub buf_size: size_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_datatype_get_args_t_union_get_tcpl {
         pub tcpl_id: hid_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_datatype_get_args_t_union {
         pub get_binary_size: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary_size>,
         pub get_binary: ManuallyDrop<H5VL_datatype_get_args_t_union_get_binary>,
@@ -711,6 +722,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_datatype_get_args_t {
         pub op_type: H5VL_datatype_get_t,
         pub args: H5VL_datatype_get_args_t_union,
@@ -738,7 +750,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_datatype_class_t {
         pub commit: Option<
             extern "C" fn(
@@ -792,20 +804,20 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_specific_args_t_union_flush {
         pub obj_type: H5I_type_t,
         pub scope: H5F_scope_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_specific_args_t_union_reopen {
         pub file: *mut *mut c_void,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_specific_args_t_union_is_accessible {
         pub filename: *const c_char,
         pub fapl_id: hid_t,
@@ -813,20 +825,21 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_specific_args_t_union_del {
         pub filename: *const c_char,
         pub fapl_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_specific_args_t_union_is_equal {
         pub obj2: *mut c_void,
         pub same_file: *mut hbool_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_file_specific_args_t_union {
         pub flush: ManuallyDrop<H5VL_file_specific_args_t_union_flush>,
         pub reopen: ManuallyDrop<H5VL_file_specific_args_t_union_reopen>,
@@ -836,6 +849,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_file_specific_args_t {
         pub op_type: H5VL_file_specific_t,
         pub args: H5VL_file_specific_args_t_union,
@@ -863,7 +877,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_cont_info_t {
         pub version: c_uint,
         pub feature_flags: u64,
@@ -872,44 +886,44 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_args_t_union_get_cont_info {
         pub info: *mut H5VL_file_cont_info_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_args_t_union_get_fapl {
         pub fapl_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_args_t_union_get_fcpl {
         pub fcpl_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_args_t_union_get_fileno {
         pub fileno: *mut c_ulong,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_args_t_union_get_intent {
         pub flags: *mut c_uint,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_args_t_union_get_obj_count {
         pub types: c_uint,
         pub count: *mut size_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_obj_ids_args_t {
         pub types: c_uint,
         pub max_objs: size_t,
@@ -918,7 +932,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_get_name_args_t {
         pub r#type: H5I_type_t,
         pub buf_size: size_t,
@@ -927,6 +941,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_file_get_args_t_union {
         pub get_cont_info: ManuallyDrop<H5VL_file_get_args_t_union_get_cont_info>,
         pub get_fapl: ManuallyDrop<H5VL_file_get_args_t_union_get_fapl>,
@@ -952,6 +967,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_file_get_args_t {
         pub op_type: H5VL_file_get_t,
         pub args: H5VL_file_get_args_t_union,
@@ -984,7 +1000,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_file_class_t {
         pub create: Option<
             extern "C" fn(
@@ -1044,7 +1060,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_group_spec_mount_args_t {
         pub name: *const c_char,
         pub child_file: *mut c_void,
@@ -1052,24 +1068,25 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_group_specific_args_t_union_unmount {
         pub name: *const c_char,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_group_specific_args_t_union_flush {
         pub grp_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_group_specific_args_t_union_refresh {
         pub grp_id: hid_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_group_specific_args_t_union {
         pub mount: ManuallyDrop<H5VL_group_spec_mount_args_t>,
         pub unmount: ManuallyDrop<H5VL_group_specific_args_t_union_unmount>,
@@ -1078,6 +1095,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_group_specific_args_t {
         pub op_type: H5VL_group_specific_t,
         pub args: H5VL_group_specific_args_t_union,
@@ -1104,19 +1122,20 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_group_get_info_args_t {
         pub loc_params: H5VL_loc_params_t,
         pub ginfo: *mut H5G_info_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_group_get_args_t_union_get_gcpl {
         pub gcpl_id: hid_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_group_get_args_t_union {
         pub get_gcpl: ManuallyDrop<H5VL_group_get_args_t_union_get_gcpl>,
         pub get_info: ManuallyDrop<H5VL_group_get_info_args_t>,
@@ -1130,6 +1149,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_group_get_args_t {
         pub op_type: H5VL_group_get_t,
         pub args: H5VL_group_get_args_t_union,
@@ -1150,7 +1170,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_group_class_t {
         pub create: Option<
             extern "C" fn(
@@ -1205,7 +1225,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_iterate_args_t {
         pub recursive: hbool_t,
         pub idx_type: H5_index_t,
@@ -1216,12 +1236,13 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_specific_args_t_union_exists {
         pub exists: *mut hbool_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_link_specific_args_t_union {
         pub exists: ManuallyDrop<H5VL_link_specific_args_t_union_exists>,
         pub iterate: ManuallyDrop<H5VL_link_iterate_args_t>,
@@ -1236,6 +1257,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_link_specific_args_t {
         pub op_type: H5VL_link_specific_t,
         pub args: H5VL_link_specific_args_t_union,
@@ -1257,13 +1279,13 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_get_args_t_union_get_info {
         pub linfo: *mut H5L_info2_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_get_args_t_union_get_name {
         pub name_size: size_t,
         pub name: *mut c_char,
@@ -1271,13 +1293,14 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_get_args_t_union_get_val {
         pub buf_size: size_t,
         pub buf: *mut c_void,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_link_get_args_t_union {
         pub get_info: ManuallyDrop<H5VL_link_get_args_t_union_get_info>,
         pub get_name: ManuallyDrop<H5VL_link_get_args_t_union_get_name>,
@@ -1293,6 +1316,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_link_get_args_t {
         pub op_type: H5VL_link_get_t,
         pub args: H5VL_link_get_args_t_union,
@@ -1322,20 +1346,20 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_create_args_t_union_hard {
         pub curr_obj: *mut c_void,
         pub curr_loc_params: H5VL_loc_params_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_create_args_t_union_soft {
         pub target: *const c_char,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_create_args_t_union_ud {
         pub r#type: H5L_type_t,
         pub buf: *const c_void,
@@ -1343,6 +1367,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_link_create_args_t_union {
         pub hard: ManuallyDrop<H5VL_link_create_args_t_union_hard>,
         pub soft: ManuallyDrop<H5VL_link_create_args_t_union_soft>,
@@ -1350,6 +1375,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_link_create_args_t {
         pub op_type: H5VL_link_create_t,
         pub args: H5VL_link_create_args_t_union,
@@ -1371,7 +1397,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_link_class_t {
         pub create: Option<
             extern "C" fn(
@@ -1438,7 +1464,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_visit_args_t {
         pub idx_type: H5_index_t,
         pub order: H5_iter_order_t,
@@ -1448,36 +1474,37 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_specific_args_t_union_change_rc {
         pub delta: c_int,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_specific_args_t_union_exists {
         pub exists: *mut hbool_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_specific_args_t_union_lookup {
         pub token_ptr: *mut H5O_token_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_specific_args_t_union_flush {
         pub obj_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_specific_args_t_union_refresh {
         pub obj_id: hid_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_object_specific_args_t_union {
         pub change_rc: ManuallyDrop<H5VL_object_specific_args_t_union_change_rc>,
         pub exists: ManuallyDrop<H5VL_object_specific_args_t_union_exists>,
@@ -1499,6 +1526,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_object_specific_args_t {
         pub op_type: H5VL_object_specific_t,
         pub args: H5VL_object_specific_args_t_union,
@@ -1540,13 +1568,13 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_get_args_t_union_get_file {
         pub file: *mut *mut c_void,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_get_args_t_union_get_name {
         pub buf_size: size_t,
         pub buf: *mut c_char,
@@ -1554,19 +1582,20 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_get_args_t_union_get_type {
         pub obj_type: *mut H5O_type_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_get_args_t_union_get_info {
         pub fields: c_uint,
         pub oinfo: *mut H5O_info2_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_object_get_args_t_union {
         pub get_file: ManuallyDrop<H5VL_object_get_args_t_union_get_file>,
         pub get_name: ManuallyDrop<H5VL_object_get_args_t_union_get_name>,
@@ -1575,6 +1604,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_object_get_args_t {
         pub op_type: H5VL_object_get_t,
         pub args: H5VL_object_get_args_t_union,
@@ -1597,7 +1627,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_object_class_t {
         pub open: Option<
             extern "C" fn(
@@ -1658,7 +1688,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_introspect_class_t {
         pub get_conn_cls: Option<
             extern "C" fn(
@@ -1697,25 +1727,27 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_request_specific_args_t_union_get_err_stack {
         pub err_stack_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_request_specific_args_t_union_get_exec_time {
         pub exec_ts: *mut u64,
         pub exec_time: *mut u64,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_request_specific_args_t_union {
         pub get_err_stack: ManuallyDrop<H5VL_request_specific_args_t_union_get_err_stack>,
         pub get_exec_time: ManuallyDrop<H5VL_request_specific_args_t_union_get_exec_time>,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_request_specific_args_t {
         pub op_type: H5VL_request_specific_t,
         pub args: H5VL_request_specific_args_t_union,
@@ -1743,7 +1775,7 @@ mod v1_13_0 {
         Option<extern "C" fn(ctx: *mut c_void, status: H5VL_request_status_t) -> herr_t>;
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_request_class_t {
         pub wait: Option<
             extern "C" fn(
@@ -1774,17 +1806,19 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_blob_specific_args_t_union_is_null {
         pub isnull: *mut hbool_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_blob_specific_args_t_union {
         pub is_null: ManuallyDrop<H5VL_blob_specific_args_t_union_is_null>,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_blob_specific_args_t {
         pub op_type: H5VL_blob_specific_t,
         pub args: H5VL_blob_specific_args_t_union,
@@ -1806,7 +1840,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_blob_class_t {
         pub put: Option<
             extern "C" fn(
@@ -1843,7 +1877,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_token_class_t {
         pub cmp: Option<
             extern "C" fn(
@@ -1881,14 +1915,14 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_loc_by_name_t {
         pub name: *const c_char,
         pub lapl_id: hid_t,
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_loc_by_idx_t {
         pub name: *const c_char,
         pub idx_type: H5_index_t,
@@ -1898,12 +1932,13 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_loc_by_token_t {
         pub token: *mut H5O_token_t,
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub union H5VL_loc_params_t_union {
         pub loc_by_token: ManuallyDrop<H5VL_loc_by_token_t>,
         pub loc_by_name: ManuallyDrop<H5VL_loc_by_name_t>,
@@ -1911,6 +1946,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct H5VL_loc_params_t {
         pub obj_type: H5I_type_t,
         pub type_: H5VL_loc_type_t,
@@ -1940,7 +1976,7 @@ mod v1_13_0 {
     }
 
     #[repr(C)]
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct H5VL_optional_args_t {
         pub op_type: c_int,
         pub args: *mut c_void,

--- a/hdf5-sys/src/lib.rs
+++ b/hdf5-sys/src/lib.rs
@@ -46,6 +46,9 @@ pub mod h5z;
 #[cfg(feature = "1.8.15")]
 pub mod h5pl;
 
+#[cfg(feature = "1.13.0")]
+pub mod h5es;
+
 #[allow(non_camel_case_types)]
 mod internal_prelude {
     pub use crate::h5::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -365,7 +365,7 @@ pub mod tests {
             "Error in H5Pclose(): can't close [Property lists: Unable to free object]"
         );
 
-        assert!(stack.len() >= 2 && stack.len() <= 3); // depending on HDF5 version
+        assert!(stack.len() >= 2 && stack.len() <= 4); // depending on HDF5 version
         assert!(!stack.is_empty());
 
         assert_eq!(stack[0].description(), "H5Pclose(): can't close");
@@ -375,12 +375,24 @@ pub mod tests {
              [Property lists: Unable to free object]"
         );
 
-        assert_eq!(stack[stack.len() - 1].description(), "H5I_dec_ref(): can't locate ID");
-        assert_eq!(
-            &stack[stack.len() - 1].detail().unwrap(),
-            "Error in H5I_dec_ref(): can't locate ID \
+        #[cfg(not(feature = "1.13.0"))]
+        {
+            assert_eq!(stack[stack.len() - 1].description(), "H5I_dec_ref(): can't locate ID");
+            assert_eq!(
+                &stack[stack.len() - 1].detail().unwrap(),
+                "Error in H5I_dec_ref(): can't locate ID \
              [Object atom: Unable to find atom information (already closed?)]"
-        );
+            );
+        }
+        #[cfg(feature = "1.13.0")]
+        {
+            assert_eq!(stack[stack.len() - 1].description(), "H5I__dec_ref(): can't locate ID");
+            assert_eq!(
+                &stack[stack.len() - 1].detail().unwrap(),
+                "Error in H5I__dec_ref(): can't locate ID \
+             [Object ID: Unable to find ID information (already closed?)]"
+            );
+        }
 
         let empty_stack = ExpandedErrorStack::new();
         assert!(empty_stack.is_empty());

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -190,6 +190,7 @@ link_hid!(H5E_DATATYPE, h5e::H5E_DATATYPE);
 link_hid!(H5E_RS, h5e::H5E_RS);
 link_hid!(H5E_HEAP, h5e::H5E_HEAP);
 link_hid!(H5E_OHDR, h5e::H5E_OHDR);
+#[cfg(not(feature = "1.13.0"))]
 link_hid!(H5E_ATOM, h5e::H5E_ATOM);
 link_hid!(H5E_ATTR, h5e::H5E_ATTR);
 link_hid!(H5E_NONE_MAJOR, h5e::H5E_NONE_MAJOR);
@@ -265,6 +266,7 @@ link_hid!(H5E_NOTHDF5, h5e::H5E_NOTHDF5);
 link_hid!(H5E_BADFILE, h5e::H5E_BADFILE);
 link_hid!(H5E_TRUNCATED, h5e::H5E_TRUNCATED);
 link_hid!(H5E_MOUNT, h5e::H5E_MOUNT);
+#[cfg(not(feature = "1.13.0"))]
 link_hid!(H5E_BADATOM, h5e::H5E_BADATOM);
 link_hid!(H5E_BADGROUP, h5e::H5E_BADGROUP);
 link_hid!(H5E_CANTREGISTER, h5e::H5E_CANTREGISTER);

--- a/src/hl/file.rs
+++ b/src/hl/file.rs
@@ -362,16 +362,16 @@ pub mod tests {
     #[test]
     pub fn test_unable_to_open() {
         with_tmp_dir(|dir| {
-            assert_err!(File::open(&dir), "unable to open file");
-            assert_err!(File::open_rw(&dir), "unable to open file");
-            assert_err!(File::create_excl(&dir), "unable to create file");
-            assert_err!(File::create(&dir), "unable to create file");
-            assert_err!(File::append(&dir), "unable to create file");
+            assert_err_re!(File::open(&dir), "unable to (?:synchronously )?open file");
+            assert_err_re!(File::open_rw(&dir), "unable to (?:synchronously )?open file");
+            assert_err_re!(File::create_excl(&dir), "unable to (?:synchronously )?create file");
+            assert_err_re!(File::create(&dir), "unable to (?:synchronously )?create file");
+            assert_err_re!(File::append(&dir), "unable to (?:synchronously )?create file");
         });
         with_tmp_path(|path| {
             fs::File::create(&path).unwrap().write_all(b"foo").unwrap();
             assert!(fs::metadata(&path).is_ok());
-            assert_err!(File::open(&path), "unable to open file");
+            assert_err_re!(File::open(&path), "unable to (?:synchronously )?open file");
         })
     }
 
@@ -379,7 +379,10 @@ pub mod tests {
     pub fn test_file_create() {
         with_tmp_path(|path| {
             File::create(&path).unwrap().create_group("foo").unwrap();
-            assert_err!(File::create(&path).unwrap().group("foo"), "unable to open group");
+            assert_err_re!(
+                File::create(&path).unwrap().group("foo"),
+                "unable to (?:synchronously )?open group"
+            );
         });
     }
 
@@ -387,7 +390,7 @@ pub mod tests {
     pub fn test_file_create_excl() {
         with_tmp_path(|path| {
             File::create_excl(&path).unwrap();
-            assert_err!(File::create_excl(&path), "unable to create file");
+            assert_err_re!(File::create_excl(&path), "unable to (?:synchronously )?create file");
         });
     }
 
@@ -405,9 +408,9 @@ pub mod tests {
             File::create(&path).unwrap().create_group("foo").unwrap();
             let file = File::open(&path).unwrap();
             file.group("foo").unwrap();
-            assert_err!(
+            assert_err_re!(
                 file.create_group("bar"),
-                "unable to create group: no write intent on file"
+                "unable to (?:synchronously )?create group: no write intent on file"
             );
             assert_err!(File::open("/foo/bar/baz"), "unable to open file");
         });

--- a/src/hl/group.rs
+++ b/src/hl/group.rs
@@ -436,7 +436,10 @@ pub mod tests {
     #[test]
     pub fn test_group() {
         with_tmp_file(|file| {
-            assert_err_re!(file.group("a"), "unable to open group: object.+doesn't exist");
+            assert_err_re!(
+                file.group("a"),
+                "unable to (?:synchronously )?open group: object.+doesn't exist"
+            );
             file.create_group("a").unwrap();
             let a = file.group("a").unwrap();
             assert_eq!(a.name(), "/a");
@@ -497,11 +500,11 @@ pub mod tests {
             file.group("/foo/hard/inner").unwrap();
             assert_err_re!(
                 file.link_hard("foo/test", "/foo/test/inner"),
-                "unable to create (?:hard )?link: name already exists"
+                "unable to (?:synchronously )?create (?:hard )?link: name already exists"
             );
             assert_err_re!(
                 file.link_hard("foo/bar", "/foo/baz"),
-                "unable to create (?:hard )?link: object.+doesn't exist"
+                "unable to (?:synchronously )?create (?:hard )?link: object.+doesn't exist"
             );
             file.relink("/foo/hard", "/foo/hard2").unwrap();
             file.group("/foo/hard2/inner").unwrap();
@@ -509,10 +512,13 @@ pub mod tests {
             file.group("/foo/baz/inner").unwrap();
             file.group("/foo/hard2/inner").unwrap();
             file.unlink("/foo/baz").unwrap();
-            assert_err!(file.group("/foo/baz"), "unable to open group");
+            assert_err_re!(file.group("/foo/baz"), "unable to (?:synchronously )?open group");
             file.group("/foo/hard2/inner").unwrap();
             file.unlink("/foo/hard2").unwrap();
-            assert_err!(file.group("/foo/hard2/inner"), "unable to open group");
+            assert_err_re!(
+                file.group("/foo/hard2/inner"),
+                "unable to (?:synchronously )?open group"
+            );
         })
     }
 
@@ -525,14 +531,14 @@ pub mod tests {
             file.relink("/a/soft", "/a/soft2").unwrap();
             file.group("/a/soft2/c").unwrap();
             file.relink("a/b", "/a/d").unwrap();
-            assert_err!(file.group("/a/soft2/c"), "unable to open group");
+            assert_err_re!(file.group("/a/soft2/c"), "unable to (?:synchronously )?open group");
             file.link_soft("/a/bar", "/a/baz").unwrap();
-            assert_err!(file.group("/a/baz"), "unable to open group");
+            assert_err_re!(file.group("/a/baz"), "unable to (?:synchronously )?open group");
             file.create_group("/a/bar").unwrap();
             file.group("/a/baz").unwrap();
             file.unlink("/a/bar").unwrap();
-            assert_err!(file.group("/a/bar"), "unable to open group");
-            assert_err!(file.group("/a/baz"), "unable to open group");
+            assert_err_re!(file.group("/a/bar"), "unable to (?:synchronously )?open group");
+            assert_err_re!(file.group("/a/baz"), "unable to (?:synchronously )?open group");
         })
     }
 
@@ -573,7 +579,10 @@ pub mod tests {
             assert_err!(file.relink("bar", "/baz"), "unable to move link: name doesn't exist");
             file.relink("test", "/foo/test").unwrap();
             file.group("/foo/test").unwrap();
-            assert_err_re!(file.group("test"), "unable to open group: object.+doesn't exist");
+            assert_err_re!(
+                file.group("test"),
+                "unable to (?:synchronously )?open group: object.+doesn't exist"
+            );
         })
     }
 
@@ -582,7 +591,7 @@ pub mod tests {
         with_tmp_file(|file| {
             file.create_group("/foo/bar").unwrap();
             file.unlink("foo/bar").unwrap();
-            assert_err!(file.group("/foo/bar"), "unable to open group");
+            assert_err_re!(file.group("/foo/bar"), "unable to (?:synchronously )?open group");
             assert!(file.group("foo").unwrap().is_empty());
         })
     }


### PR DESCRIPTION
This PR adds 1.13 as a supported version, but does not use any of the new functionality.

The list of changes are found here: https://confluence.hdfgroup.org/display/support/HDF5%201.13.0#compatibility1130