### PR TITLE
Use proc-macro-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Support for HDF5 version 1.13.0.
+
+### Changed
+
+- The `H5Type` derive macro now uses `proc-macro-error` to emit error messages.
+
 ### Fixed
 
 - Fixed a bug where `H5Pget_fapl_direct` was only included when HDF5 was compiled

--- a/hdf5-derive/Cargo.toml
+++ b/hdf5-derive/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["procedural-macro-helpers"]
 proc-macro = true
 
 [dependencies]
+proc-macro-error = { version = "1.0.4", default-features = false }
 proc-macro2 = "1.0"
 quote = "^1.0.2"
 syn = { version = "^1.0.5", features = ["derive", "extra-traits"]}

--- a/hdf5-derive/tests/compile-fail/empty-enum.stderr
+++ b/hdf5-derive/tests/compile-fail/empty-enum.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/empty-enum.rs:4:10
+error: cannot derive `H5Type` for empty enums
+ --> $DIR/empty-enum.rs:7:6
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: Cannot derive H5Type for empty enums
+7 | enum Foo {}
+  |      ^^^

--- a/hdf5-derive/tests/compile-fail/empty-struct.stderr
+++ b/hdf5-derive/tests/compile-fail/empty-struct.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/empty-struct.rs:4:10
+error: cannot derive `H5Type` for empty structs
+ --> $DIR/empty-struct.rs:7:8
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: Cannot derive H5Type for empty structs
+7 | struct Foo {}
+  |        ^^^

--- a/hdf5-derive/tests/compile-fail/empty-tuple-struct.stderr
+++ b/hdf5-derive/tests/compile-fail/empty-tuple-struct.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/empty-tuple-struct.rs:4:10
+error: cannot derive `H5Type` for empty tuple structs
+ --> $DIR/empty-tuple-struct.rs:7:8
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: Cannot derive H5Type for empty tuple structs
+7 | struct Foo();
+  |        ^^^

--- a/hdf5-derive/tests/compile-fail/enum-no-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/enum-no-repr.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/enum-no-repr.rs:4:10
+error: `H5Type` can only be derived for enums with explicit representation
+ --> $DIR/enum-no-repr.rs:7:6
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: H5Type can only be derived for enums with explicit representation
+7 | enum Foo {
+  |      ^^^

--- a/hdf5-derive/tests/compile-fail/enum-non-scalar.stderr
+++ b/hdf5-derive/tests/compile-fail/enum-non-scalar.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/enum-non-scalar.rs:4:10
+error: `H5Type` can only be derived for enums with scalar discriminants
+ --> $DIR/enum-non-scalar.rs:7:6
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: H5Type can only be derived for enums with scalar discriminants
+7 | enum Foo {
+  |      ^^^

--- a/hdf5-derive/tests/compile-fail/pd-empty-struct.stderr
+++ b/hdf5-derive/tests/compile-fail/pd-empty-struct.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/pd-empty-struct.rs:6:10
+error: cannot derive `H5Type` for empty structs
+ --> $DIR/pd-empty-struct.rs:9:8
   |
-6 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: Cannot derive H5Type for empty structs
+9 | struct Foo<T> {
+  |        ^^^

--- a/hdf5-derive/tests/compile-fail/pd-empty-tuple-struct.stderr
+++ b/hdf5-derive/tests/compile-fail/pd-empty-tuple-struct.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/pd-empty-tuple-struct.rs:6:10
+error: cannot derive `H5Type` for empty tuple structs
+ --> $DIR/pd-empty-tuple-struct.rs:9:8
   |
-6 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: Cannot derive H5Type for empty tuple structs
+9 | struct Foo<T>(PhantomData<T>);
+  |        ^^^

--- a/hdf5-derive/tests/compile-fail/struct-no-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/struct-no-repr.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/struct-no-repr.rs:4:10
+error: `H5Type` requires repr(C), repr(packed) or repr(transparent) for structs
+ --> $DIR/struct-no-repr.rs:7:8
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: H5Type requires repr(C), repr(packed) or repr(transparent) for structs
+7 | struct Foo {
+  |        ^^^

--- a/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.stderr
+++ b/hdf5-derive/tests/compile-fail/tuple-struct-no-repr.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/tuple-struct-no-repr.rs:4:10
+error: `H5Type` requires repr(C), repr(packed) or repr(transparent) for tuple structs
+ --> $DIR/tuple-struct-no-repr.rs:7:8
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: H5Type requires repr(C), repr(packed) or repr(transparent) for tuple structs
+7 | struct Foo(i64);
+  |        ^^^

--- a/hdf5-derive/tests/compile-fail/unit-struct.stderr
+++ b/hdf5-derive/tests/compile-fail/unit-struct.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/unit-struct.rs:4:10
+error: cannot derive `H5Type` for unit structs
+ --> $DIR/unit-struct.rs:7:8
   |
-4 | #[derive(H5Type)]
-  |          ^^^^^^
-  |
-  = help: message: Cannot derive H5Type for unit structs
+7 | struct Foo;
+  |        ^^^


### PR DESCRIPTION
As mentioned in #191 it would improve on the error messages to include the span. This highlights the struct/enum instead of giving the general `proc_macro panicked` and the message in the help section.