### PR TITLE
Move catch-all in match after variants

### DIFF
--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -115,12 +115,12 @@ mod v1_13_0 {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let mut s = f.debug_struct(stringify!($ty));
                     s.field("op_type", &self.op_type);
-                    match self.op_type {$(
-                        $tag::$variant => {
+                    match self.op_type {
+                        $($tag::$variant => {
                             s.field("args", &($func as fn($args) -> _)(self.args));
-                        }
+                        })+
                         _ => {}
-                    )+}
+                    }
                     s.finish()
                 }
             }


### PR DESCRIPTION
The previous macro would always match on the second item even if more than one variant was present