### PR TITLE
Add ByteReader implementing io::Read and io::Seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Support for HDF5 version 1.13.0.
 - Support field renaming via `#[hdf5(rename = "new_name")]` helper attribute.
+- Add a `ByteReader` which implements `std::io::{Read, Seek}` for 1D `u8`
+  datasets. Usage via `Dataset::as_byte_reader()`.
 
 ### Changed
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt;
+use std::io;
 use std::ops::Deref;
 use std::panic;
 use std::ptr;
@@ -265,6 +266,12 @@ impl StdError for Error {}
 impl From<ShapeError> for Error {
     fn from(err: ShapeError) -> Self {
         format!("shape error: {}", err).into()
+    }
+}
+
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        Self::new(io::ErrorKind::Other, err)
     }
 }
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -17,7 +17,7 @@ pub use self::{
         Attribute, AttributeBuilder, AttributeBuilderData, AttributeBuilderEmpty,
         AttributeBuilderEmptyShape,
     },
-    container::{Container, Reader, Writer},
+    container::{ByteReader, Container, Reader, Writer},
     dataset::{
         Dataset, DatasetBuilder, DatasetBuilderData, DatasetBuilderEmpty, DatasetBuilderEmptyShape,
     },

--- a/src/hl/container.rs
+++ b/src/hl/container.rs
@@ -505,7 +505,9 @@ impl Container {
         Writer::new(self)
     }
 
-    /// Convert into a ``ByteReader`` that implements ``std::io::{Read, Seek}``.
+    /// Creates a ``ByteReader`` which implements ``std::io::{Read, Seek}``.
+    /// ``ByteReader`` only supports 1D ``u8`` datasets. Attributes or datasets
+    /// with other dimensions or datatypes cannot be read with ``ByteReader``.
     pub fn as_byte_reader(&self) -> Result<ByteReader> {
         ByteReader::new(self)
     }

--- a/src/hl/container.rs
+++ b/src/hl/container.rs
@@ -505,9 +505,10 @@ impl Container {
         Writer::new(self)
     }
 
-    /// Creates a ``ByteReader`` which implements ``std::io::{Read, Seek}``.
-    /// ``ByteReader`` only supports 1D ``u8`` datasets. Attributes or datasets
-    /// with other dimensions or datatypes cannot be read with ``ByteReader``.
+    /// Creates `ByteReader` which implements [`Read`](std::io::Read)
+    /// and [`Seek`](std::io::Seek).
+    ///
+    /// ``ByteReader`` only supports 1-D `u8` datasets.
     pub fn as_byte_reader(&self) -> Result<ByteReader> {
         ByteReader::new(self)
     }

--- a/src/hl/container.rs
+++ b/src/hl/container.rs
@@ -347,19 +347,20 @@ impl<'a> Writer<'a> {
     }
 }
 
-#[derive(Debug)]
-pub struct ByteReader<'a> {
-    obj: &'a Container,
+#[derive(Debug, Clone)]
+pub struct ByteReader {
+    obj: Container,
     pos: u64,
     dt: Datatype,
     obj_space: Dataspace,
     xfer: PropertyList,
 }
 
-impl<'a> ByteReader<'a> {
-    pub fn new(obj: &'a Container) -> Result<Self> {
+impl ByteReader {
+    pub fn new(obj: &Container) -> Result<Self> {
         ensure!(!obj.is_attr(), "ByteReader cannot be used on attribute datasets");
 
+        let obj = obj.clone();
         let file_dtype = obj.dtype()?;
         let mem_dtype = Datatype::from_type::<u8>()?;
         file_dtype.ensure_convertible(&mem_dtype, Conversion::NoOp)?;
@@ -386,7 +387,7 @@ impl<'a> ByteReader<'a> {
     }
 }
 
-impl<'a> io::Read for ByteReader<'a> {
+impl io::Read for ByteReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let pos = self.pos as usize;
         let amt = std::cmp::min(buf.len(), self.remaining_len());
@@ -407,7 +408,7 @@ impl<'a> io::Read for ByteReader<'a> {
     }
 }
 
-impl<'a> io::Seek for ByteReader<'a> {
+impl io::Seek for ByteReader {
     fn seek(&mut self, style: io::SeekFrom) -> io::Result<u64> {
         let (base_pos, offset) = match style {
             io::SeekFrom::Start(n) => {
@@ -493,7 +494,7 @@ impl Container {
     ///
     /// ``ByteReader`` only supports 1-D `u8` datasets.
     pub fn as_byte_reader(&self) -> Result<ByteReader> {
-        ByteReader::new(self)
+        ByteReader::new(&self)
     }
 
     /// Returns the datatype of the dataset/attribute.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ mod export {
         hl::selection::{Hyperslab, Selection, SliceOrIndex},
         hl::{
             Attribute, AttributeBuilder, AttributeBuilderData, AttributeBuilderEmpty,
-            AttributeBuilderEmptyShape, Container, Conversion, Dataset, DatasetBuilder,
+            AttributeBuilderEmptyShape, ByteReader, Container, Conversion, Dataset, DatasetBuilder,
             DatasetBuilderData, DatasetBuilderEmpty, DatasetBuilderEmptyShape, Dataspace, Datatype,
             File, FileBuilder, Group, LinkInfo, LinkType, Location, LocationInfo, LocationToken,
             LocationType, Object, PropertyList, Reader, Writer,

--- a/tests/test_dataset.rs
+++ b/tests/test_dataset.rs
@@ -183,7 +183,7 @@ fn test_byte_read_seek_impl(ds: &hdf5::Dataset, arr: &ArrayD<u8>, ndim: usize) -
         return Ok(());
     } else {
         let mut out_bytes = vec![0u8; arr.len()];
-        reader?.read(&mut out_bytes.as_mut_slice()).expect("io::Read faild");
+        reader?.read(&mut out_bytes.as_mut_slice()).expect("io::Read failed");
         assert_eq!(out_bytes.as_slice(), arr.as_slice().unwrap());
     }
 
@@ -193,7 +193,7 @@ fn test_byte_read_seek_impl(ds: &hdf5::Dataset, arr: &ArrayD<u8>, ndim: usize) -
     while pos < arr.len() {
         let chunk_len: usize = rng.gen_range(1..arr.len() + 1);
         let mut chunk = vec![0u8; chunk_len];
-        let n_read = reader.read(&mut chunk).expect("io::Read faild");
+        let n_read = reader.read(&mut chunk).expect("io::Read failed");
         if pos + chunk_len < arr.len() {
             // We did not read until end. Thus, the chunk should be fully filled.
             assert_eq!(chunk_len, n_read);
@@ -202,10 +202,10 @@ fn test_byte_read_seek_impl(ds: &hdf5::Dataset, arr: &ArrayD<u8>, ndim: usize) -
         pos += chunk_len;
     }
 
-    // Seek to begining and read again
+    // Seek to the begining and read again
     reader.seek(SeekFrom::Start(0)).expect("io::Seek failed");
     let mut out_bytes = vec![0u8; arr.len()];
-    reader.read(&mut out_bytes.as_mut_slice()).expect("io::Read faild");
+    reader.read(&mut out_bytes.as_mut_slice()).expect("io::Read failed");
     assert_eq!(out_bytes.as_slice(), arr.as_slice().unwrap());
 
     // Seek to a random position from start
@@ -240,7 +240,7 @@ fn test_byte_read_seek_impl(ds: &hdf5::Dataset, arr: &ArrayD<u8>, ndim: usize) -
     // Seek before start
     assert!(reader.seek(SeekFrom::End(-(arr.len() as i64) - 1)).is_err());
 
-    // Test strem position start
+    // Test stream position start
     // Requires Rust 1.55.0: reader.rewind().expect("io::Seek::rewind failed");
     assert_eq!(0, reader.seek(SeekFrom::Start(0)).unwrap());
     assert_eq!(0, reader.stream_position().unwrap());
@@ -366,8 +366,7 @@ fn test_byte_read_seek() -> hdf5::Result<()> {
         for _ in 0..=20 {
             let arr: ArrayD<u8> = gen_arr(&mut rng, ndim);
 
-            let ds: hdf5::Dataset =
-                file.new_dataset::<u8>().packed(*packed).shape(arr.shape()).create("x")?;
+            let ds: hdf5::Dataset = file.new_dataset::<u8>().shape(arr.shape()).create("x")?;
             let ds = scopeguard::guard(ds, |ds| {
                 drop(ds);
                 drop(file.unlink("x"));

--- a/tests/test_dataset.rs
+++ b/tests/test_dataset.rs
@@ -359,29 +359,21 @@ fn test_read_write_rename_fields() -> hdf5::Result<()> {
 
 #[test]
 fn test_byte_read_seek() -> hdf5::Result<()> {
-    let td = u8::type_descriptor();
-    let mut packed = vec![false];
-    if let TypeDescriptor::Compound(_) = td {
-        packed.push(true);
-    }
-
     let mut rng = SmallRng::seed_from_u64(42);
     let file = new_in_memory_file()?;
 
-    for packed in &packed {
-        for ndim in 0..=2 {
-            for _ in 0..=20 {
-                let arr: ArrayD<u8> = gen_arr(&mut rng, ndim);
+    for ndim in 0..=2 {
+        for _ in 0..=20 {
+            let arr: ArrayD<u8> = gen_arr(&mut rng, ndim);
 
-                let ds: hdf5::Dataset =
-                    file.new_dataset::<u8>().packed(*packed).shape(arr.shape()).create("x")?;
-                let ds = scopeguard::guard(ds, |ds| {
-                    drop(ds);
-                    drop(file.unlink("x"));
-                });
+            let ds: hdf5::Dataset =
+                file.new_dataset::<u8>().packed(*packed).shape(arr.shape()).create("x")?;
+            let ds = scopeguard::guard(ds, |ds| {
+                drop(ds);
+                drop(file.unlink("x"));
+            });
 
-                test_byte_read_seek_impl(&ds, &arr, ndim)?;
-            }
+            test_byte_read_seek_impl(&ds, &arr, ndim)?;
         }
     }
     Ok(())

--- a/tests/test_dataset.rs
+++ b/tests/test_dataset.rs
@@ -1,10 +1,11 @@
 use std::convert::TryFrom;
 use std::fmt;
+use std::io::{Read, Seek, SeekFrom};
 
 use ndarray::{s, Array1, Array2, ArrayD, IxDyn, SliceInfo};
 use rand::prelude::{Rng, SeedableRng, SmallRng};
 
-use hdf5_types::TypeDescriptor;
+use hdf5_types::{H5Type, TypeDescriptor};
 
 mod common;
 
@@ -171,6 +172,83 @@ where
     Ok(())
 }
 
+fn test_byte_read_seek_impl(ds: &hdf5::Dataset, arr: &ArrayD<u8>, ndim: usize) -> hdf5::Result<()> {
+    let mut rng = SmallRng::seed_from_u64(42);
+    ds.write(arr)?;
+
+    // Read whole
+    let reader = ds.as_byte_reader();
+    if ndim != 1 {
+        assert!(reader.is_err());
+        return Ok(());
+    } else {
+        let mut out_bytes = vec![0u8; arr.len()];
+        reader?.read(&mut out_bytes.as_mut_slice()).expect("io::Read faild");
+        assert_eq!(out_bytes.as_slice(), arr.as_slice().unwrap());
+    }
+
+    // Read in chunks
+    let mut reader = ds.as_byte_reader()?;
+    let mut pos = 0;
+    while pos < arr.len() {
+        let chunk_len: usize = rng.gen_range(1..arr.len() + 1);
+        let mut chunk = vec![0u8; chunk_len];
+        let n_read = reader.read(&mut chunk).expect("io::Read faild");
+        if pos + chunk_len < arr.len() {
+            // We did not read until end. Thus, the chunk should be fully filled.
+            assert_eq!(chunk_len, n_read);
+        }
+        assert_eq!(&chunk[..n_read], arr.slice(s![pos..pos + n_read]).as_slice().unwrap());
+        pos += chunk_len;
+    }
+
+    // Seek to begining and read again
+    reader.seek(SeekFrom::Start(0)).expect("io::Seek failed");
+    let mut out_bytes = vec![0u8; arr.len()];
+    reader.read(&mut out_bytes.as_mut_slice()).expect("io::Read faild");
+    assert_eq!(out_bytes.as_slice(), arr.as_slice().unwrap());
+
+    // Seek to a random position from start
+    let pos = rng.gen_range(0..arr.len() + 1) as u64;
+    let seeked_pos = reader.seek(SeekFrom::Start(pos)).expect("io::Seek failed") as usize;
+    let mut out_bytes = vec![0u8; arr.len() - seeked_pos];
+    reader.read(&mut out_bytes.as_mut_slice()).expect("io::Read failed");
+    assert_eq!(out_bytes.as_slice(), arr.slice(s![seeked_pos..]).as_slice().unwrap());
+
+    // Seek from current position
+    let orig_pos = reader.seek(SeekFrom::Start(pos)).expect("io::Seek failed") as i64;
+    let rel_pos = rng.gen_range(-(arr.len() as i64)..arr.len() as i64 + 1);
+    let pos_res = reader.seek(SeekFrom::Current(rel_pos));
+    if (rel_pos + orig_pos) < 0 {
+        assert!(pos_res.is_err()) // We cannot seek before start
+    } else {
+        let seeked_pos = pos_res.unwrap() as usize;
+        assert_eq!(rel_pos + orig_pos, seeked_pos as i64);
+        let mut out_bytes = vec![0u8; arr.len() - seeked_pos];
+        reader.read(&mut out_bytes.as_mut_slice()).expect("io::Read failed");
+        assert_eq!(out_bytes.as_slice(), arr.slice(s![seeked_pos..]).as_slice().unwrap());
+    }
+
+    // Seek to a random position from end
+    let pos = -(rng.gen_range(0..arr.len() + 1) as i64);
+    let seeked_pos = reader.seek(SeekFrom::End(pos)).expect("io::Seek failed") as usize;
+    assert_eq!(pos, seeked_pos as i64 - arr.len() as i64);
+    let mut out_bytes = vec![0u8; arr.len() - seeked_pos];
+    reader.read(&mut out_bytes.as_mut_slice()).expect("io::Read failed");
+    assert_eq!(out_bytes.as_slice(), arr.slice(s![seeked_pos..]).as_slice().unwrap());
+
+    // Seek before start
+    assert!(reader.seek(SeekFrom::End(-(arr.len() as i64) - 1)).is_err());
+
+    // Test strem position start
+    // Requires Rust 1.55.0: reader.rewind().expect("io::Seek::rewind failed");
+    assert_eq!(0, reader.seek(SeekFrom::Start(0)).unwrap());
+    assert_eq!(0, reader.stream_position().unwrap());
+    assert_eq!(0, reader.seek(SeekFrom::End(-(arr.len() as i64))).unwrap());
+    assert_eq!(0, reader.stream_position().unwrap());
+    Ok(())
+}
+
 fn test_read_write<T>() -> hdf5::Result<()>
 where
     T: hdf5::H5Type + fmt::Debug + PartialEq + Gen + Clone,
@@ -276,5 +354,35 @@ fn test_read_write_rename_fields() -> hdf5::Result<()> {
     test_read_write::<RenameStruct>()?;
     test_read_write::<RenameTupleStruct>()?;
     test_read_write::<RenameEnum>()?;
+    Ok(())
+}
+
+#[test]
+fn test_byte_read_seek() -> hdf5::Result<()> {
+    let td = u8::type_descriptor();
+    let mut packed = vec![false];
+    if let TypeDescriptor::Compound(_) = td {
+        packed.push(true);
+    }
+
+    let mut rng = SmallRng::seed_from_u64(42);
+    let file = new_in_memory_file()?;
+
+    for packed in &packed {
+        for ndim in 0..=2 {
+            for _ in 0..=20 {
+                let arr: ArrayD<u8> = gen_arr(&mut rng, ndim);
+
+                let ds: hdf5::Dataset =
+                    file.new_dataset::<u8>().packed(*packed).shape(arr.shape()).create("x")?;
+                let ds = scopeguard::guard(ds, |ds| {
+                    drop(ds);
+                    drop(file.unlink("x"));
+                });
+
+                test_byte_read_seek_impl(&ds, &arr, ndim)?;
+            }
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
The design is based on io::Cursor. This PR only addresses datasets. I don't think it makes sense to also support io::Read for attributes since the whole advantage of io::Read is to only read the relevant part and not all bytes at once.

Currently I get the following error during H5DRead:
```
Error: IoError(Custom { kind: Other, error: "H5Dread(): can't read data: not a datatype" })
```
Closes #193 