### PR TITLE
Add check for chunking of dataset for filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - The `H5Type` derive macro now uses `proc-macro-error` to emit error messages.
 - MSRV is now `1.64.0` and Rust edition has now been bumped to 2021.
-- Types in ChunkInfo has been changed to match HDF5
+- Types in ChunkInfo has been changed to match HDF5.
 
 ### Fixed
 
@@ -25,6 +25,7 @@
 - Fixed a bug where errors were only silenced on the main thread.
 - Fixed a memory leak when opening datasets.
 - Avoid creating unaligned references in `H5Type` derive macro.
+- Applying filters without chunking will now produce an explicit error.
 
 ## 0.8.1
 

--- a/hdf5/src/hl/dataset.rs
+++ b/hdf5/src/hl/dataset.rs
@@ -1066,4 +1066,22 @@ mod tests {
         let e = SimpleExtents::new(&[1, 1, 100]);
         assert_eq!(compute_chunk_shape(&e, 51), vec![1, 1, 100]);
     }
+
+    #[test]
+    fn test_read_write_scalar() {
+        use crate::internal_prelude::*;
+        with_tmp_file(|file| {
+            if !crate::filters::deflate_available() {
+                return;
+            }
+            let val: f64 = 0.2;
+            let dataset = file.new_dataset::<f64>().deflate(3).create("foo");
+            assert_err_re!(dataset, "Filter requires dataset to be chunked");
+
+            let dataset = file.new_dataset::<f64>().create("foo").unwrap();
+            dataset.write_scalar(&val).unwrap();
+            let val_back = dataset.read_scalar().unwrap();
+            assert_eq!(val, val_back);
+        })
+    }
 }

--- a/hdf5/src/hl/filters.rs
+++ b/hdf5/src/hl/filters.rs
@@ -517,11 +517,15 @@ impl Filter {
             Ok(filters)
         })
     }
+
+    pub(crate) fn requires_chunking(&self) -> bool {
+        COMP_FILTER_IDS.contains(&self.id())
+    }
 }
 
-pub(crate) fn validate_filters(filters: &[Filter], type_class: H5T_class_t) -> Result<()> {
-    const COMP_FILTER_IDS: &[H5Z_filter_t] = &[H5Z_FILTER_DEFLATE, H5Z_FILTER_SZIP, 32000, 32001];
+const COMP_FILTER_IDS: &[H5Z_filter_t] = &[H5Z_FILTER_DEFLATE, H5Z_FILTER_SZIP, 32000, 32001];
 
+pub(crate) fn validate_filters(filters: &[Filter], type_class: H5T_class_t) -> Result<()> {
     let mut map: HashMap<H5Z_filter_t, &Filter> = HashMap::new();
     let mut comp_filter: Option<&Filter> = None;
 
@@ -627,6 +631,7 @@ mod tests {
 
             let mut b = DatasetCreate::build();
             b.set_filters(&pipeline);
+            b.chunk(10);
             let plist = b.finish()?;
             assert_eq!(Filter::extract_pipeline(plist.id())?, pipeline);
 

--- a/hdf5/src/hl/filters.rs
+++ b/hdf5/src/hl/filters.rs
@@ -517,10 +517,6 @@ impl Filter {
             Ok(filters)
         })
     }
-
-    pub(crate) fn requires_chunking(&self) -> bool {
-        COMP_FILTER_IDS.contains(&self.id())
-    }
 }
 
 const COMP_FILTER_IDS: &[H5Z_filter_t] = &[H5Z_FILTER_DEFLATE, H5Z_FILTER_SZIP, 32000, 32001];

--- a/hdf5/src/hl/plist/dataset_create.rs
+++ b/hdf5/src/hl/plist/dataset_create.rs
@@ -582,10 +582,10 @@ impl DatasetCreateBuilder {
     }
 
     fn populate_plist(&self, id: hid_t) -> Result<()> {
+        if !self.filters.is_empty() {
+            ensure!(self.chunk.is_some(), "Filter requires dataset to be chunked");
+        }
         for filter in &self.filters {
-            if filter.requires_chunking() {
-                ensure!(self.chunk.is_some(), "Filter requires dataset to be chunked");
-            }
             filter.apply_to_plist(id)?;
         }
         if let Some(v) = self.alloc_time {

--- a/hdf5/src/hl/plist/dataset_create.rs
+++ b/hdf5/src/hl/plist/dataset_create.rs
@@ -583,6 +583,9 @@ impl DatasetCreateBuilder {
 
     fn populate_plist(&self, id: hid_t) -> Result<()> {
         for filter in &self.filters {
+            if filter.requires_chunking() {
+                ensure!(self.chunk.is_some(), "Filter requires dataset to be chunked");
+            }
             filter.apply_to_plist(id)?;
         }
         if let Some(v) = self.alloc_time {


### PR DESCRIPTION
The behaviour in `h5py` is to raise an error when trying to apply chunking/compression filters to dataset. This PR adds the same behaviour.

Fixes #212 