### PR TITLE
Remove 1.13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Added
 
-- Support for HDF5 version 1.13.0.
 - Support for HDF5 version 1.14.0.
 - Support field renaming via `#[hdf5(rename = "new_name")]` helper attribute.
 - Add a `ByteReader` which implements `std::io::{Read, Seek}` for 1D `u8`

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -656,8 +656,8 @@ impl Config {
     pub fn emit_cfg_flags(&self) {
         let version = self.header.version;
         assert!(version >= Version::new(1, 8, 4), "required HDF5 version: >=1.8.4");
-        let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-21]
-        vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-8]
+        let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-23]
+        vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-10]
         vs.extend((0..=2).map(|v| Version::new(1, 12, v))); // 1.12.[0-2]
         vs.extend((0..=1).map(|v| Version::new(1, 14, v))); // 1.14.[0-1]
         for v in vs.into_iter().filter(|&v| version >= v) {

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -659,7 +659,7 @@ impl Config {
         let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-21]
         vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-8]
         vs.extend((0..=2).map(|v| Version::new(1, 12, v))); // 1.12.[0-2]
-        vs.extend((0..=0).map(|v| Version::new(1, 14, v))); // 1.14.[0-0]
+        vs.extend((0..=1).map(|v| Version::new(1, 14, v))); // 1.14.[0-1]
         for v in vs.into_iter().filter(|&v| version >= v) {
             println!("cargo:rustc-cfg=feature=\"{}.{}.{}\"", v.major, v.minor, v.micro);
             println!("cargo:version_{}_{}_{}=1", v.major, v.minor, v.micro);

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -29,7 +29,7 @@ impl Version {
     }
 
     pub fn parse(s: &str) -> Option<Self> {
-        let re = Regex::new(r"^(1)\.(8|10|12|13|14)\.(\d\d?)(_\d+)?((-|.)(patch)?\d+)?$").ok()?;
+        let re = Regex::new(r"^(1)\.(8|10|12|14)\.(\d\d?)(_\d+)?((-|.)(patch)?\d+)?$").ok()?;
         let captures = re.captures(s)?;
         Some(Self {
             major: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
@@ -659,7 +659,6 @@ impl Config {
         let mut vs: Vec<_> = (5..=21).map(|v| Version::new(1, 8, v)).collect(); // 1.8.[5-21]
         vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-8]
         vs.extend((0..=2).map(|v| Version::new(1, 12, v))); // 1.12.[0-2]
-        vs.extend((0..=0).map(|v| Version::new(1, 13, v))); // 1.13.[0-0]
         vs.extend((0..=0).map(|v| Version::new(1, 14, v))); // 1.14.[0-0]
         for v in vs.into_iter().filter(|&v| version >= v) {
             println!("cargo:rustc-cfg=feature=\"{}.{}.{}\"", v.major, v.minor, v.micro);

--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -9,21 +9,21 @@ use crate::internal_prelude::*;
 pub type herr_t = c_int;
 pub type htri_t = c_int;
 
-#[cfg(not(feature = "1.13.0"))]
+#[cfg(not(feature = "1.14.0"))]
 pub type hsize_t = c_ulonglong;
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub type hsize_t = u64;
 
-#[cfg(not(feature = "1.13.0"))]
+#[cfg(not(feature = "1.14.0"))]
 pub type hssize_t = c_longlong;
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub type hssize_t = i64;
 
 pub type haddr_t = u64;
 
-#[cfg(any(all(feature = "1.10.0", have_stdbool_h), feature = "1.13.0"))]
+#[cfg(any(all(feature = "1.10.0", have_stdbool_h), feature = "1.14.0"))]
 pub type hbool_t = u8;
-#[cfg(not(any(all(feature = "1.10.0", have_stdbool_h), feature = "1.13.0")))]
+#[cfg(not(any(all(feature = "1.10.0", have_stdbool_h), feature = "1.14.0")))]
 pub type hbool_t = c_uint;
 
 #[repr(C)]
@@ -116,10 +116,10 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 type H5_atclose_func_t = Option<extern "C" fn(ctx: *mut c_void)>;
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5atclose(func: H5_atclose_func_t, ctx: *mut c_void) -> herr_t;
     pub fn H5is_library_terminating(is_terminating: *mut hbool_t) -> herr_t;

--- a/hdf5-sys/src/h5a.rs
+++ b/hdf5-sys/src/h5a.rs
@@ -123,7 +123,7 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Aclose_async(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint, attr_id: hid_t,

--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -287,20 +287,18 @@ extern "C" {
     pub fn H5Dget_num_chunks(dset_id: hid_t, fspace_id: hid_t, nchunks: *mut hsize_t) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub type H5D_chunk_iter_op_t = Option<
     extern "C" fn(
         offset: *const hsize_t,
-        #[cfg(feature = "1.14.0")] filter_mask: c_uint,
-        #[cfg(not(feature = "1.14.0"))] filter_mask: u32,
+        filter_mask: c_uint,
         addr: haddr_t,
-        #[cfg(not(feature = "1.14.0"))] nbytes: u32,
-        #[cfg(feature = "1.14.0")] size: hsize_t,
+        size: hsize_t,
         op_data: *mut c_void,
     ) -> c_int,
 >;
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Dchunk_iter(
         dset_id: hid_t, dxpl: hid_t, cb: H5D_chunk_iter_op_t, op_data: *mut c_void,

--- a/hdf5-sys/src/h5e.rs
+++ b/hdf5-sys/src/h5e.rs
@@ -131,7 +131,7 @@ extern "C" {
     #[deprecated(note = "deprecated in HDF5 1.8.0")]
     pub fn H5Eget_minor(min: H5E_minor_t) -> *mut c_char;
 
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     pub fn H5Eappend_stack(
         dst_stack_id: hid_t, src_stack_id: hid_t, close_source_stack: hbool_t,
     ) -> herr_t;
@@ -166,7 +166,7 @@ mod globals {
     extern_static!(H5E_RS, H5E_RS_g);
     extern_static!(H5E_HEAP, H5E_HEAP_g);
     extern_static!(H5E_OHDR, H5E_OHDR_g);
-    #[cfg(not(feature = "1.13.0"))]
+    #[cfg(not(feature = "1.14.0"))]
     extern_static!(H5E_ATOM, H5E_ATOM_g);
     extern_static!(H5E_ATTR, H5E_ATTR_g);
     extern_static!(H5E_NONE_MAJOR, H5E_NONE_MAJOR_g);
@@ -242,7 +242,7 @@ mod globals {
     extern_static!(H5E_BADFILE, H5E_BADFILE_g);
     extern_static!(H5E_TRUNCATED, H5E_TRUNCATED_g);
     extern_static!(H5E_MOUNT, H5E_MOUNT_g);
-    #[cfg(not(feature = "1.13.0"))]
+    #[cfg(not(feature = "1.14.0"))]
     extern_static!(H5E_BADATOM, H5E_BADATOM_g);
     extern_static!(H5E_BADGROUP, H5E_BADGROUP_g);
     extern_static!(H5E_CANTREGISTER, H5E_CANTREGISTER_g);
@@ -302,21 +302,21 @@ mod globals {
     extern_static!(H5E_CANTUNLOCKFILE, H5E_CANTUNLOCKFILE_g);
     #[cfg(feature = "1.12.1")]
     extern_static!(H5E_LIB, H5E_LIB_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_BADID, H5E_BADID_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTCANCEL, H5E_CANTCANCEL_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTFIND, H5E_CANTFIND_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTPUT, H5E_CANTPUT_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTWAIT, H5E_CANTWAIT_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_EVENTSET, H5E_EVENTSET_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_ID, H5E_ID_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_UNMOUNT, H5E_UNMOUNT_g);
 }
 
@@ -348,7 +348,7 @@ mod globals {
     extern_static!(H5E_RS, __imp_H5E_RS_g);
     extern_static!(H5E_HEAP, __imp_H5E_HEAP_g);
     extern_static!(H5E_OHDR, __imp_H5E_OHDR_g);
-    #[cfg(not(feature = "1.13.0"))]
+    #[cfg(not(feature = "1.14.0"))]
     extern_static!(H5E_ATOM, __imp_H5E_ATOM_g);
     extern_static!(H5E_ATTR, __imp_H5E_ATTR_g);
     extern_static!(H5E_NONE_MAJOR, __imp_H5E_NONE_MAJOR_g);
@@ -424,7 +424,7 @@ mod globals {
     extern_static!(H5E_BADFILE, __imp_H5E_BADFILE_g);
     extern_static!(H5E_TRUNCATED, __imp_H5E_TRUNCATED_g);
     extern_static!(H5E_MOUNT, __imp_H5E_MOUNT_g);
-    #[cfg(not(feature = "1.13.0"))]
+    #[cfg(not(feature = "1.14.0"))]
     extern_static!(H5E_BADATOM, __imp_H5E_BADATOM_g);
     extern_static!(H5E_BADGROUP, __imp_H5E_BADGROUP_g);
     extern_static!(H5E_CANTREGISTER, __imp_H5E_CANTREGISTER_g);
@@ -484,20 +484,20 @@ mod globals {
     extern_static!(H5E_CANTUNLOCKFILE, __imp_H5E_CANTUNLOCKFILE_g);
     #[cfg(feature = "1.12.1")]
     extern_static!(H5E_LIB, __imp_H5E_LIB_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_BADID, __imp_H5E_BADID_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTCANCEL, __imp_H5E_CANTCANCEL_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTFIND, __imp_H5E_CANTFIND_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTPUT, __imp_H5E_CANTPUT_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_CANTWAIT, __imp_H5E_CANTWAIT_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_EVENTSET, __imp_H5E_EVENTSET_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_ID, __imp_H5E_ID_g);
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     extern_static!(H5E_UNMOUNT, __imp_H5E_UNMOUNT_g);
 }

--- a/hdf5-sys/src/h5f.rs
+++ b/hdf5-sys/src/h5f.rs
@@ -128,7 +128,7 @@ pub enum H5F_libver_t {
     H5F_LIBVER_V110 = 2,
     #[cfg(feature = "1.12.0")]
     H5F_LIBVER_V112 = 3,
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     H5F_LIBVER_V114 = 4,
     H5F_LIBVER_NBOUNDS,
 }
@@ -175,9 +175,9 @@ extern "C" {
     pub fn H5Fget_freespace(file_id: hid_t) -> hssize_t;
     pub fn H5Fget_filesize(file_id: hid_t, size: *mut hsize_t) -> herr_t;
     pub fn H5Fget_mdc_config(file_id: hid_t, config_ptr: *mut H5AC_cache_config_t) -> herr_t;
-    #[cfg(not(feature = "1.13.0"))]
+    #[cfg(not(feature = "1.14.0"))]
     pub fn H5Fset_mdc_config(file_id: hid_t, config_ptr: *mut H5AC_cache_config_t) -> herr_t;
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     pub fn H5Fset_mdc_config(file_id: hid_t, config_ptr: *const H5AC_cache_config_t) -> herr_t;
     pub fn H5Fget_mdc_hit_rate(file_id: hid_t, hit_rate_ptr: *mut c_double) -> herr_t;
     pub fn H5Fget_mdc_size(
@@ -374,7 +374,7 @@ extern "C" {
     pub fn H5Fset_dset_no_attrs_hint(file_id: hid_t, minimize: hbool_t) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Fclose_async(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint, file_id: hid_t,

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -8,7 +8,7 @@ use crate::internal_prelude::*;
 
 use crate::h5f::{H5F_close_degree_t, H5F_mem_t};
 
-#[cfg(not(feature = "1.13.0"))]
+#[cfg(not(feature = "1.14.0"))]
 pub const H5_HAVE_VFL: c_uint = 1;
 
 pub const H5FD_VFD_DEFAULT: c_uint = 0;
@@ -125,12 +125,12 @@ pub type H5FD_class_value_t = c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct H5FD_class_t {
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     pub value: H5FD_class_value_t,
     pub name: *const c_char,
     pub maxaddr: haddr_t,
     pub fc_degree: H5F_close_degree_t,
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     pub terminate: Option<extern "C" fn() -> herr_t>,
     pub sb_size: Option<extern "C" fn(file: *mut H5FD_t) -> hsize_t>,
     pub sb_encode:
@@ -214,9 +214,9 @@ pub struct H5FD_class_t {
     >,
     pub unlock:
         Option<extern "C" fn(file: *mut H5FD_t, oid: *mut c_uchar, last: hbool_t) -> herr_t>,
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     pub del: Option<extern "C" fn(name: *const c_char, fapl: hid_t) -> herr_t>,
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     pub ctl: Option<
         extern "C" fn(
             file: *mut H5FD_t,
@@ -387,7 +387,7 @@ extern "C" {
     pub fn H5FDunlock(file: *mut H5FD_t) -> herr_t;
 }
 
-#[cfg(all(feature = "1.10.6", not(feature = "1.13.0")))]
+#[cfg(all(feature = "1.10.6", not(feature = "1.14.0")))]
 pub mod hdfs {
     use super::*;
     pub const H5FD__CURR_HDFS_FAPL_T_VERSION: c_uint = 1;
@@ -471,10 +471,10 @@ extern "C" {
     pub fn H5FDdriver_query(driver_id: hid_t, flags: *mut c_ulong) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 type H5FD_perform_init_func_t = Option<extern "C" fn() -> hid_t>;
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5FDctl(
         file: *mut H5FD_t, op_cod: u64, flags: u64, input: *const c_void, output: *mut *mut c_void,

--- a/hdf5-sys/src/h5g.rs
+++ b/hdf5-sys/src/h5g.rs
@@ -138,7 +138,7 @@ pub struct H5G_stat_t {
     ohdr: H5O_stat_t,
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Gclose_async(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint, group_id: hid_t,

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -29,7 +29,7 @@ pub enum H5I_type_t {
     H5I_ERROR_STACK,
     #[cfg(feature = "1.12.0")]
     H5I_SPACE_SEL_ITER,
-    #[cfg(feature = "1.13.0")]
+    #[cfg(feature = "1.14.0")]
     H5I_EVENTSET,
     H5I_NTYPES,
 }
@@ -42,9 +42,9 @@ pub type hid_t = c_int;
 
 pub const H5I_INVALID_HID: hid_t = -1;
 
-#[cfg(not(feature = "1.13.0"))]
+#[cfg(not(feature = "1.14.0"))]
 pub type H5I_free_t = Option<extern "C" fn(arg1: *mut c_void) -> herr_t>;
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub type H5I_free_t = Option<extern "C" fn(*mut c_void, *mut *mut c_void) -> herr_t>;
 
 pub type H5I_search_func_t =
@@ -78,14 +78,14 @@ extern "C" {
     pub fn H5Iis_valid(id: hid_t) -> htri_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub type H5I_future_realize_func_t =
     Option<extern "C" fn(future_object: *mut c_void, actual_object_id: *mut hid_t) -> herr_t>;
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub type H5I_future_discard_func_t = Option<extern "C" fn(future_object: *mut c_void) -> herr_t>;
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Iregister_future(
         type_: H5I_type_t, object: *const c_void, realize_cb: H5I_future_realize_func_t,

--- a/hdf5-sys/src/h5l.rs
+++ b/hdf5-sys/src/h5l.rs
@@ -336,7 +336,7 @@ pub use self::{
     H5L_info2_t as H5L_info_t, H5L_iterate2_t as H5L_iterate_t, H5Literate2 as H5Literate,
 };
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Lcreate_hard_async(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint, cur_loc_id: hid_t,

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -476,7 +476,7 @@ mod globals {
     extern_static!(H5O_TOKEN_UNDEF, __imp_H5O_TOKEN_UNDEF_g);
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Oclose_async(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint, object_id: hid_t,

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -17,7 +17,7 @@ use crate::h5o::H5O_mcdt_search_cb_t;
 #[cfg(feature = "1.10.1")]
 use crate::{h5ac::H5AC_cache_image_config_t, h5f::H5F_fspace_strategy_t};
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 use crate::{h5fd::H5FD_class_value_t, h5s::H5S_seloper_t};
 
 pub const H5P_CRT_ORDER_TRACKED: c_uint = 0x0001;
@@ -792,7 +792,7 @@ extern "C" {
     pub fn H5Pset_vol(plist_id: hid_t, new_vol_id: hid_t, new_vol_id: *const c_void) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Pget_driver_config_str(
         fapl_id: hid_t, config_buf: *mut c_char, buf_size: size_t,

--- a/hdf5-sys/src/h5pl.rs
+++ b/hdf5-sys/src/h5pl.rs
@@ -12,7 +12,7 @@ mod hdf5_1_8_15 {
         H5PL_TYPE_FILTER = 0,
         #[cfg(feature = "1.12.0")]
         H5PL_TYPE_VOL,
-        #[cfg(feature = "1.13.0")]
+        #[cfg(feature = "1.14.0")]
         H5PL_TYPE_VFD,
         #[cfg(feature = "1.12.0")]
         H5PL_TYPE_NONE,

--- a/hdf5-sys/src/h5r.rs
+++ b/hdf5-sys/src/h5r.rs
@@ -120,7 +120,7 @@ extern "C" {
     pub fn H5Ropen_region(ref_ptr: *const H5R_ref_t, rapl_id: hid_t, oapl_id: hid_t) -> hid_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Ropen_attr_async(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint,

--- a/hdf5-sys/src/h5t.rs
+++ b/hdf5-sys/src/h5t.rs
@@ -551,7 +551,7 @@ extern "C" {
     pub fn H5Treclaim(type_id: hid_t, space_id: hid_t, dxpl_id: hid_t, buf: *mut c_void) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 extern "C" {
     pub fn H5Tclose_async(
         app_file: *const c_char, app_func: *const c_char, app_line: c_uint, type_id: hid_t,

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -6,12 +6,12 @@ use crate::internal_prelude::*;
 pub type H5VL_class_value_t = c_int;
 
 // Incomplete type
-#[cfg(all(feature = "1.12.0", not(feature = "1.13.0")))]
+#[cfg(all(feature = "1.12.0", not(feature = "1.14.0")))]
 pub type H5VL_class_t = c_void;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub struct H5VL_class_t {
     pub version: c_uint,
     pub value: H5VL_class_value_t,
@@ -89,10 +89,10 @@ extern "C" {
     ) -> herr_t;
 }
 
-#[cfg(feature = "1.13.0")]
-pub use v1_13_0::*;
-#[cfg(feature = "1.13.0")]
-mod v1_13_0 {
+#[cfg(feature = "1.14.0")]
+pub use v1_14_0::*;
+#[cfg(feature = "1.14.0")]
+mod v1_14_0 {
     use std::fmt::{self, Debug};
     use std::mem::ManuallyDrop;
 

--- a/hdf5-sys/src/lib.rs
+++ b/hdf5-sys/src/lib.rs
@@ -46,7 +46,7 @@ pub mod h5z;
 #[cfg(feature = "1.8.15")]
 pub mod h5pl;
 
-#[cfg(feature = "1.13.0")]
+#[cfg(feature = "1.14.0")]
 pub mod h5es;
 
 #[allow(non_camel_case_types)]

--- a/hdf5/src/error.rs
+++ b/hdf5/src/error.rs
@@ -382,7 +382,7 @@ pub mod tests {
              [Property lists: Unable to free object]"
         );
 
-        #[cfg(not(feature = "1.13.0"))]
+        #[cfg(not(feature = "1.14.0"))]
         {
             assert_eq!(stack[stack.len() - 1].description(), "H5I_dec_ref(): can't locate ID");
             assert_eq!(
@@ -391,7 +391,7 @@ pub mod tests {
              [Object atom: Unable to find atom information (already closed?)]"
             );
         }
-        #[cfg(feature = "1.13.0")]
+        #[cfg(feature = "1.14.0")]
         {
             assert_eq!(stack[stack.len() - 1].description(), "H5I__dec_ref(): can't locate ID");
             assert_eq!(

--- a/hdf5/src/globals.rs
+++ b/hdf5/src/globals.rs
@@ -190,7 +190,7 @@ link_hid!(H5E_DATATYPE, h5e::H5E_DATATYPE);
 link_hid!(H5E_RS, h5e::H5E_RS);
 link_hid!(H5E_HEAP, h5e::H5E_HEAP);
 link_hid!(H5E_OHDR, h5e::H5E_OHDR);
-#[cfg(not(feature = "1.13.0"))]
+#[cfg(not(feature = "1.14.0"))]
 link_hid!(H5E_ATOM, h5e::H5E_ATOM);
 link_hid!(H5E_ATTR, h5e::H5E_ATTR);
 link_hid!(H5E_NONE_MAJOR, h5e::H5E_NONE_MAJOR);
@@ -266,7 +266,7 @@ link_hid!(H5E_NOTHDF5, h5e::H5E_NOTHDF5);
 link_hid!(H5E_BADFILE, h5e::H5E_BADFILE);
 link_hid!(H5E_TRUNCATED, h5e::H5E_TRUNCATED);
 link_hid!(H5E_MOUNT, h5e::H5E_MOUNT);
-#[cfg(not(feature = "1.13.0"))]
+#[cfg(not(feature = "1.14.0"))]
 link_hid!(H5E_BADATOM, h5e::H5E_BADATOM);
 link_hid!(H5E_BADGROUP, h5e::H5E_BADGROUP);
 link_hid!(H5E_CANTREGISTER, h5e::H5E_CANTREGISTER);

--- a/hdf5/src/hl/chunks.rs
+++ b/hdf5/src/hl/chunks.rs
@@ -15,7 +15,7 @@ pub struct ChunkInfo {
     /// A zero value indicates that all enabled filters are applied on the chunk.
     /// A filter is skipped if the bit corresponding to the filter’s position in
     /// the pipeline (0 ≤ position < 32) is turned on.
-    pub filter_mask: u32,
+    pub filter_mask: c_uint,
     /// Chunk address in the file.
     pub addr: haddr_t,
     /// Chunk size in bytes.
@@ -76,7 +76,7 @@ mod v1_14_0 {
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct ChunkInfoRef<'a> {
         pub offset: &'a [hsize_t],
-        pub filter_mask: u32,
+        pub filter_mask: c_uint,
         pub addr: haddr_t,
         pub size: hsize_t,
     }


### PR DESCRIPTION
The HDF5 1.13 series was only a preview and requires some workarounds. Simplify by only supporting 1.14.

Adds 1.14.1 as supported since only a couple of new functions were added. These have not been included, but we are not aiming to cover all of HDF5 (already missing VFD etc.)

Fixed a small bug in `ChunkInfo`