### PR TITLE
Mark various internal functions as unsafe

### DIFF
--- a/hdf5-sys/src/h5.rs
+++ b/hdf5-sys/src/h5.rs
@@ -117,7 +117,7 @@ extern "C" {
 }
 
 #[cfg(feature = "1.14.0")]
-type H5_atclose_func_t = Option<extern "C" fn(ctx: *mut c_void)>;
+type H5_atclose_func_t = Option<unsafe extern "C" fn(ctx: *mut c_void)>;
 
 #[cfg(feature = "1.14.0")]
 extern "C" {

--- a/hdf5-sys/src/h5a.rs
+++ b/hdf5-sys/src/h5a.rs
@@ -26,7 +26,7 @@ impl Default for H5A_info_t {
 
 #[deprecated(note = "deprecated in HDF5 1.8.0, use H5A_operator2_t")]
 pub type H5A_operator1_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         location_id: hid_t,
         attr_name: *const c_char,
         operator_data: *mut c_void,
@@ -34,7 +34,7 @@ pub type H5A_operator1_t = Option<
 >;
 
 pub type H5A_operator2_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         location_id: hid_t,
         attr_name: *const c_char,
         ainfo: *const H5A_info_t,

--- a/hdf5-sys/src/h5d.rs
+++ b/hdf5-sys/src/h5d.rs
@@ -125,7 +125,7 @@ pub enum H5D_mpio_no_collective_cause_t {
 }
 
 pub type H5D_operator_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         elem: *mut c_void,
         type_id: hid_t,
         ndim: c_uint,
@@ -136,7 +136,7 @@ pub type H5D_operator_t = Option<
 
 #[cfg(feature = "1.8.11")]
 pub type H5D_scatter_func_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         src_buf: *mut *const c_void,
         src_buf_bytes_used: *mut size_t,
         op_data: *mut c_void,
@@ -144,7 +144,7 @@ pub type H5D_scatter_func_t = Option<
 >;
 #[cfg(feature = "1.8.11")]
 pub type H5D_gather_func_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         dst_buf: *const c_void,
         dst_buf_bytes_used: size_t,
         op_data: *mut c_void,
@@ -289,7 +289,7 @@ extern "C" {
 
 #[cfg(feature = "1.14.0")]
 pub type H5D_chunk_iter_op_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         offset: *const hsize_t,
         filter_mask: c_uint,
         addr: haddr_t,

--- a/hdf5-sys/src/h5es.rs
+++ b/hdf5-sys/src/h5es.rs
@@ -45,7 +45,7 @@ pub enum H5ES_status_t {
 }
 
 pub type H5ES_event_complete_func_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         op_info: *mut H5ES_op_info_t,
         status: H5ES_status_t,
         err_stack: hid_t,
@@ -54,7 +54,7 @@ pub type H5ES_event_complete_func_t = Option<
 >;
 
 pub type H5ES_event_insert_func_t =
-    Option<extern "C" fn(op_info: *const H5ES_op_info_t, ctx: *mut c_void) -> c_int>;
+    Option<unsafe extern "C" fn(op_info: *const H5ES_op_info_t, ctx: *mut c_void) -> c_int>;
 
 extern "C" {
     pub fn H5ESinsert_request(es_id: hid_t, connector_id: hid_t, request: *mut c_void) -> herr_t;

--- a/hdf5-sys/src/h5fd.rs
+++ b/hdf5-sys/src/h5fd.rs
@@ -132,31 +132,33 @@ pub struct H5FD_class_t {
     pub fc_degree: H5F_close_degree_t,
     #[cfg(feature = "1.14.0")]
     pub terminate: Option<extern "C" fn() -> herr_t>,
-    pub sb_size: Option<extern "C" fn(file: *mut H5FD_t) -> hsize_t>,
-    pub sb_encode:
-        Option<extern "C" fn(file: *mut H5FD_t, name: *mut c_char, p: *mut c_uchar) -> herr_t>,
-    pub sb_decode:
-        Option<extern "C" fn(f: *mut H5FD_t, name: *const c_char, p: *const c_uchar) -> herr_t>,
+    pub sb_size: Option<unsafe extern "C" fn(file: *mut H5FD_t) -> hsize_t>,
+    pub sb_encode: Option<
+        unsafe extern "C" fn(file: *mut H5FD_t, name: *mut c_char, p: *mut c_uchar) -> herr_t,
+    >,
+    pub sb_decode: Option<
+        unsafe extern "C" fn(f: *mut H5FD_t, name: *const c_char, p: *const c_uchar) -> herr_t,
+    >,
     pub fapl_size: size_t,
-    pub fapl_get: Option<extern "C" fn(file: *mut H5FD_t) -> *mut c_void>,
-    pub fapl_copy: Option<extern "C" fn(fapl: *const c_void) -> *mut c_void>,
-    pub fapl_free: Option<extern "C" fn(fapl: *mut c_void) -> herr_t>,
+    pub fapl_get: Option<unsafe extern "C" fn(file: *mut H5FD_t) -> *mut c_void>,
+    pub fapl_copy: Option<unsafe extern "C" fn(fapl: *const c_void) -> *mut c_void>,
+    pub fapl_free: Option<unsafe extern "C" fn(fapl: *mut c_void) -> herr_t>,
     pub dxpl_size: size_t,
-    pub dxpl_copy: Option<extern "C" fn(dxpl: *const c_void) -> *mut c_void>,
-    pub dxpl_free: Option<extern "C" fn(dxpl: *mut c_void) -> herr_t>,
+    pub dxpl_copy: Option<unsafe extern "C" fn(dxpl: *const c_void) -> *mut c_void>,
+    pub dxpl_free: Option<unsafe extern "C" fn(dxpl: *mut c_void) -> herr_t>,
     pub open: Option<
-        extern "C" fn(
+        unsafe extern "C" fn(
             name: *const c_char,
             flags: c_uint,
             fapl: hid_t,
             maxaddr: haddr_t,
         ) -> *mut H5FD_t,
     >,
-    pub close: Option<extern "C" fn(file: *mut H5FD_t) -> herr_t>,
-    pub cmp: Option<extern "C" fn(f1: *const H5FD_t, f2: *const H5FD_t) -> c_int>,
-    pub query: Option<extern "C" fn(f1: *const H5FD_t, flags: *mut c_ulong) -> herr_t>,
+    pub close: Option<unsafe extern "C" fn(file: *mut H5FD_t) -> herr_t>,
+    pub cmp: Option<unsafe extern "C" fn(f1: *const H5FD_t, f2: *const H5FD_t) -> c_int>,
+    pub query: Option<unsafe extern "C" fn(f1: *const H5FD_t, flags: *mut c_ulong) -> herr_t>,
     pub get_type_map:
-        Option<extern "C" fn(file: *const H5FD_t, type_map: *mut H5FD_mem_t) -> herr_t>,
+        Option<unsafe extern "C" fn(file: *const H5FD_t, type_map: *mut H5FD_mem_t) -> herr_t>,
     pub alloc: Option<
         extern "C" fn(
             file: *mut H5FD_t,
@@ -174,10 +176,10 @@ pub struct H5FD_class_t {
             size: hsize_t,
         ) -> herr_t,
     >,
-    pub get_eoa: Option<extern "C" fn(file: *const H5FD_t, type_: H5FD_mem_t) -> haddr_t>,
+    pub get_eoa: Option<unsafe extern "C" fn(file: *const H5FD_t, type_: H5FD_mem_t) -> haddr_t>,
     pub set_eoa:
-        Option<extern "C" fn(file: *mut H5FD_t, type_: H5FD_mem_t, addr: haddr_t) -> herr_t>,
-    pub get_eof: Option<extern "C" fn(file: *const H5FD_t) -> haddr_t>,
+        Option<unsafe extern "C" fn(file: *mut H5FD_t, type_: H5FD_mem_t, addr: haddr_t) -> herr_t>,
+    pub get_eof: Option<unsafe extern "C" fn(file: *const H5FD_t) -> haddr_t>,
     pub get_handle: Option<
         extern "C" fn(file: *mut H5FD_t, fapl: hid_t, file_handle: *mut *mut c_void) -> herr_t,
     >,
@@ -201,9 +203,10 @@ pub struct H5FD_class_t {
             buffer: *const c_void,
         ) -> herr_t,
     >,
-    pub flush: Option<extern "C" fn(file: *mut H5FD_t, dxpl_id: hid_t, closing: c_uint) -> herr_t>,
+    pub flush:
+        Option<unsafe extern "C" fn(file: *mut H5FD_t, dxpl_id: hid_t, closing: c_uint) -> herr_t>,
     pub truncate:
-        Option<extern "C" fn(file: *mut H5FD_t, dxpl_id: hid_t, closing: hbool_t) -> herr_t>,
+        Option<unsafe extern "C" fn(file: *mut H5FD_t, dxpl_id: hid_t, closing: hbool_t) -> herr_t>,
     pub lock: Option<
         extern "C" fn(
             file: *mut H5FD_t,
@@ -213,9 +216,9 @@ pub struct H5FD_class_t {
         ) -> herr_t,
     >,
     pub unlock:
-        Option<extern "C" fn(file: *mut H5FD_t, oid: *mut c_uchar, last: hbool_t) -> herr_t>,
+        Option<unsafe extern "C" fn(file: *mut H5FD_t, oid: *mut c_uchar, last: hbool_t) -> herr_t>,
     #[cfg(feature = "1.14.0")]
-    pub del: Option<extern "C" fn(name: *const c_char, fapl: hid_t) -> herr_t>,
+    pub del: Option<unsafe extern "C" fn(name: *const c_char, fapl: hid_t) -> herr_t>,
     #[cfg(feature = "1.14.0")]
     pub ctl: Option<
         extern "C" fn(
@@ -316,8 +319,8 @@ pub struct H5FD_file_image_callbacks_t {
             udata: *mut c_void,
         ) -> herr_t,
     >,
-    pub udata_copy: Option<extern "C" fn(udata: *mut c_void) -> *mut c_void>,
-    pub udata_free: Option<extern "C" fn(udata: *mut c_void) -> herr_t>,
+    pub udata_copy: Option<unsafe extern "C" fn(udata: *mut c_void) -> *mut c_void>,
+    pub udata_free: Option<unsafe extern "C" fn(udata: *mut c_void) -> herr_t>,
     pub udata: *mut c_void,
 }
 

--- a/hdf5-sys/src/h5i.rs
+++ b/hdf5-sys/src/h5i.rs
@@ -43,14 +43,14 @@ pub type hid_t = c_int;
 pub const H5I_INVALID_HID: hid_t = -1;
 
 #[cfg(not(feature = "1.14.0"))]
-pub type H5I_free_t = Option<extern "C" fn(arg1: *mut c_void) -> herr_t>;
+pub type H5I_free_t = Option<unsafe extern "C" fn(arg1: *mut c_void) -> herr_t>;
 #[cfg(feature = "1.14.0")]
-pub type H5I_free_t = Option<extern "C" fn(*mut c_void, *mut *mut c_void) -> herr_t>;
+pub type H5I_free_t = Option<unsafe extern "C" fn(*mut c_void, *mut *mut c_void) -> herr_t>;
 
 pub type H5I_search_func_t =
-    Option<extern "C" fn(obj: *mut c_void, id: hid_t, key: *mut c_void) -> c_int>;
+    Option<unsafe extern "C" fn(obj: *mut c_void, id: hid_t, key: *mut c_void) -> c_int>;
 #[cfg(feature = "1.12.0")]
-pub type H5I_iterate_func_t = Option<extern "C" fn(id: hid_t, udata: *mut c_void) -> herr_t>;
+pub type H5I_iterate_func_t = Option<unsafe extern "C" fn(id: hid_t, udata: *mut c_void) -> herr_t>;
 
 extern "C" {
     pub fn H5Iregister(type_: H5I_type_t, object: *const c_void) -> hid_t;
@@ -79,11 +79,13 @@ extern "C" {
 }
 
 #[cfg(feature = "1.14.0")]
-pub type H5I_future_realize_func_t =
-    Option<extern "C" fn(future_object: *mut c_void, actual_object_id: *mut hid_t) -> herr_t>;
+pub type H5I_future_realize_func_t = Option<
+    unsafe extern "C" fn(future_object: *mut c_void, actual_object_id: *mut hid_t) -> herr_t,
+>;
 
 #[cfg(feature = "1.14.0")]
-pub type H5I_future_discard_func_t = Option<extern "C" fn(future_object: *mut c_void) -> herr_t>;
+pub type H5I_future_discard_func_t =
+    Option<unsafe extern "C" fn(future_object: *mut c_void) -> herr_t>;
 
 #[cfg(feature = "1.14.0")]
 extern "C" {

--- a/hdf5-sys/src/h5l.rs
+++ b/hdf5-sys/src/h5l.rs
@@ -169,7 +169,7 @@ impl Default for H5L_class_t {
 }
 
 pub type H5L_iterate1_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         group: hid_t,
         name: *const c_char,
         info: *const H5L_info1_t,
@@ -178,7 +178,7 @@ pub type H5L_iterate1_t = Option<
 >;
 #[cfg(feature = "1.12.0")]
 pub type H5L_iterate2_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         group: hid_t,
         name: *const c_char,
         info: *const H5L_info2_t,

--- a/hdf5-sys/src/h5mm.rs
+++ b/hdf5-sys/src/h5mm.rs
@@ -2,5 +2,5 @@
 use crate::internal_prelude::*;
 
 pub type H5MM_allocate_t =
-    Option<extern "C" fn(size: size_t, alloc_info: *mut c_void) -> *mut c_void>;
-pub type H5MM_free_t = Option<extern "C" fn(mem: *mut c_void, free_info: *mut c_void)>;
+    Option<unsafe extern "C" fn(size: size_t, alloc_info: *mut c_void) -> *mut c_void>;
+pub type H5MM_free_t = Option<unsafe extern "C" fn(mem: *mut c_void, free_info: *mut c_void)>;

--- a/hdf5-sys/src/h5o.rs
+++ b/hdf5-sys/src/h5o.rs
@@ -204,7 +204,7 @@ pub enum H5O_mcdt_search_ret_t {
 
 #[cfg(feature = "1.8.9")]
 pub type H5O_mcdt_search_cb_t =
-    Option<extern "C" fn(op_data: *mut c_void) -> H5O_mcdt_search_ret_t>;
+    Option<unsafe extern "C" fn(op_data: *mut c_void) -> H5O_mcdt_search_ret_t>;
 
 #[cfg(not(feature = "1.10.3"))]
 extern "C" {

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -26,13 +26,14 @@ pub const H5P_CRT_ORDER_INDEXED: c_uint = 0x0002;
 pub const H5P_DEFAULT: hid_t = 0;
 
 pub type H5P_cls_create_func_t =
-    Option<extern "C" fn(prop_id: hid_t, create_data: *mut c_void) -> herr_t>;
-pub type H5P_cls_copy_func_t =
-    Option<extern "C" fn(new_prop_id: hid_t, old_prop_id: hid_t, copy_data: *mut c_void) -> herr_t>;
+    Option<unsafe extern "C" fn(prop_id: hid_t, create_data: *mut c_void) -> herr_t>;
+pub type H5P_cls_copy_func_t = Option<
+    unsafe extern "C" fn(new_prop_id: hid_t, old_prop_id: hid_t, copy_data: *mut c_void) -> herr_t,
+>;
 pub type H5P_cls_close_func_t =
-    Option<extern "C" fn(prop_id: hid_t, close_data: *mut c_void) -> herr_t>;
+    Option<unsafe extern "C" fn(prop_id: hid_t, close_data: *mut c_void) -> herr_t>;
 pub type H5P_prp_cb1_t =
-    Option<extern "C" fn(name: *const c_char, size: size_t, value: *mut c_void) -> herr_t>;
+    Option<unsafe extern "C" fn(name: *const c_char, size: size_t, value: *mut c_void) -> herr_t>;
 pub type H5P_prp_cb2_t = Option<
     extern "C" fn(prop_id: hid_t, name: *const c_char, size: size_t, value: *mut c_void) -> herr_t,
 >;
@@ -41,11 +42,12 @@ pub type H5P_prp_set_func_t = H5P_prp_cb2_t;
 pub type H5P_prp_get_func_t = H5P_prp_cb2_t;
 pub type H5P_prp_delete_func_t = H5P_prp_cb2_t;
 pub type H5P_prp_copy_func_t = H5P_prp_cb1_t;
-pub type H5P_prp_compare_func_t =
-    Option<extern "C" fn(value1: *const c_void, value2: *const c_void, size: size_t) -> c_int>;
+pub type H5P_prp_compare_func_t = Option<
+    unsafe extern "C" fn(value1: *const c_void, value2: *const c_void, size: size_t) -> c_int,
+>;
 pub type H5P_prp_close_func_t = H5P_prp_cb1_t;
 pub type H5P_iterate_t =
-    Option<extern "C" fn(id: hid_t, name: *const c_char, iter_data: *mut c_void) -> herr_t>;
+    Option<unsafe extern "C" fn(id: hid_t, name: *const c_char, iter_data: *mut c_void) -> herr_t>;
 
 pub use self::globals::*;
 

--- a/hdf5-sys/src/h5vl.rs
+++ b/hdf5-sys/src/h5vl.rs
@@ -131,7 +131,7 @@ mod v1_14_0 {
     #[derive(Debug, Copy, Clone)]
     pub struct H5VL_info_class_t {
         pub size: size_t,
-        pub copy: Option<extern "C" fn(info: *const c_void) -> *mut c_void>,
+        pub copy: Option<unsafe extern "C" fn(info: *const c_void) -> *mut c_void>,
         pub cmp: Option<
             extern "C" fn(
                 cmp_value: *mut c_int,
@@ -139,17 +139,19 @@ mod v1_14_0 {
                 info2: *const c_void,
             ) -> herr_t,
         >,
-        pub free: Option<extern "C" fn(info: *mut c_void) -> herr_t>,
-        pub to_str: Option<extern "C" fn(info: *const c_void, str: *mut *mut c_char) -> herr_t>,
-        pub from_str: Option<extern "C" fn(str: *const c_char, info: *mut *mut c_void) -> herr_t>,
+        pub free: Option<unsafe extern "C" fn(info: *mut c_void) -> herr_t>,
+        pub to_str:
+            Option<unsafe extern "C" fn(info: *const c_void, str: *mut *mut c_char) -> herr_t>,
+        pub from_str:
+            Option<unsafe extern "C" fn(str: *const c_char, info: *mut *mut c_void) -> herr_t>,
     }
 
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
     pub struct H5VL_wrap_class_t {
-        pub get_object: Option<extern "C" fn(obj: *const c_void) -> *mut c_void>,
+        pub get_object: Option<unsafe extern "C" fn(obj: *const c_void) -> *mut c_void>,
         pub get_wrap_ctx:
-            Option<extern "C" fn(obj: *const c_void, wrap_ctx: *mut *mut c_void) -> herr_t>,
+            Option<unsafe extern "C" fn(obj: *const c_void, wrap_ctx: *mut *mut c_void) -> herr_t>,
         pub wrap_object: Option<
             extern "C" fn(
                 obj: *mut c_void,
@@ -157,8 +159,8 @@ mod v1_14_0 {
                 wrap_ctx: *mut c_void,
             ) -> *mut c_void,
         >,
-        pub unwrap_object: Option<extern "C" fn(obj: *mut c_void) -> *mut c_void>,
-        pub free_wrap_ctx: Option<extern "C" fn(wrap_ctx: *mut c_void) -> herr_t>,
+        pub unwrap_object: Option<unsafe extern "C" fn(obj: *mut c_void) -> *mut c_void>,
+        pub free_wrap_ctx: Option<unsafe extern "C" fn(wrap_ctx: *mut c_void) -> herr_t>,
     }
 
     #[repr(C)]
@@ -762,8 +764,9 @@ mod v1_14_0 {
                 req: *mut *mut c_void,
             ) -> herr_t,
         >,
-        pub close:
-            Option<extern "C" fn(dt: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t>,
+        pub close: Option<
+            unsafe extern "C" fn(dt: *mut c_void, dxpl_id: hid_t, req: *mut *mut c_void) -> herr_t,
+        >,
     }
 
     #[repr(C)]
@@ -1602,7 +1605,7 @@ mod v1_14_0 {
             ) -> herr_t,
         >,
         pub get_cap_flags:
-            Option<extern "C" fn(info: *const c_void, cap_flags: *mut c_uint) -> herr_t>,
+            Option<unsafe extern "C" fn(info: *const c_void, cap_flags: *mut c_uint) -> herr_t>,
         pub opt_query: Option<
             extern "C" fn(
                 obj: *mut c_void,
@@ -1668,7 +1671,7 @@ mod v1_14_0 {
     );
 
     pub type H5VL_request_notify_t =
-        Option<extern "C" fn(ctx: *mut c_void, status: H5VL_request_status_t) -> herr_t>;
+        Option<unsafe extern "C" fn(ctx: *mut c_void, status: H5VL_request_status_t) -> herr_t>;
 
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
@@ -1683,14 +1686,16 @@ mod v1_14_0 {
         pub notify: Option<
             extern "C" fn(req: *mut c_void, cb: H5VL_request_notify_t, ctx: *mut c_void) -> herr_t,
         >,
-        pub cancel:
-            Option<extern "C" fn(req: *mut c_void, status: *mut H5VL_request_status_t) -> herr_t>,
+        pub cancel: Option<
+            unsafe extern "C" fn(req: *mut c_void, status: *mut H5VL_request_status_t) -> herr_t,
+        >,
         pub specific: Option<
             extern "C" fn(req: *mut c_void, args: *mut H5VL_request_specific_args_t) -> herr_t,
         >,
-        pub optional:
-            Option<extern "C" fn(req: *mut c_void, args: *mut H5VL_optional_args_t) -> herr_t>,
-        pub free: Option<extern "C" fn(req: *mut c_void) -> herr_t>,
+        pub optional: Option<
+            unsafe extern "C" fn(req: *mut c_void, args: *mut H5VL_optional_args_t) -> herr_t,
+        >,
+        pub free: Option<unsafe extern "C" fn(req: *mut c_void) -> herr_t>,
     }
 
     #[repr(C)]

--- a/hdf5-sys/src/h5z.rs
+++ b/hdf5-sys/src/h5z.rs
@@ -114,7 +114,7 @@ pub type H5Z_can_apply_func_t =
 pub type H5Z_set_local_func_t =
     Option<extern "C" fn(dcpl_id: hid_t, type_id: hid_t, space_id: hid_t) -> herr_t>;
 pub type H5Z_func_t = Option<
-    extern "C" fn(
+    unsafe extern "C" fn(
         flags: c_uint,
         cd_nelmts: size_t,
         cd_values: *const c_uint,

--- a/hdf5/src/error.rs
+++ b/hdf5/src/error.rs
@@ -68,7 +68,7 @@ impl ErrorStack {
             stack: ExpandedErrorStack,
             err: Option<Error>,
         }
-        extern "C" fn callback(
+        unsafe extern "C" fn callback(
             _: c_uint, err_desc: *const H5E_error2_t, data: *mut c_void,
         ) -> herr_t {
             panic::catch_unwind(|| unsafe {

--- a/hdf5/src/hl/attribute.rs
+++ b/hdf5/src/hl/attribute.rs
@@ -48,13 +48,14 @@ impl Deref for Attribute {
 impl Attribute {
     /// Returns names of all the members in the group, non-recursively.
     pub fn attr_names(obj: &Location) -> Result<Vec<String>> {
-        extern "C" fn attributes_callback(
+        unsafe extern "C" fn attributes_callback(
             _id: hid_t, attr_name: *const c_char, _info: *const H5A_info_t, op_data: *mut c_void,
         ) -> herr_t {
             std::panic::catch_unwind(|| {
                 let other_data: &mut Vec<String> =
                     unsafe { &mut *(op_data.cast::<std::vec::Vec<std::string::String>>()) };
-                other_data.push(string_from_cstr(attr_name));
+                // SAFETY: caller guarantees attr_name points to valid UTF-8 C string
+                other_data.push(unsafe { string_from_cstr(attr_name) });
                 0 // Continue iteration
             })
             .unwrap_or(-1)

--- a/hdf5/src/hl/chunks.rs
+++ b/hdf5/src/hl/chunks.rs
@@ -105,7 +105,7 @@ mod v1_14_0 {
         pub callback: F,
     }
 
-    extern "C" fn chunks_callback<F>(
+    unsafe extern "C" fn chunks_callback<F>(
         offset: *const hsize_t, filter_mask: c_uint, addr: haddr_t, size: hsize_t,
         op_data: *mut c_void,
     ) -> herr_t

--- a/hdf5/src/hl/filters/blosc.rs
+++ b/hdf5/src/hl/filters/blosc.rs
@@ -160,13 +160,13 @@ fn parse_blosc_cdata(cd_nelmts: size_t, cd_values: *const c_uint) -> Option<Blos
     if cdata.len() >= 7 {
         let r = unsafe { blosc_compcode_to_compname(cdata[6] as _, addr_of_mut!(cfg.compname)) };
         if r == -1 {
-            let complist = string_from_cstr(unsafe { blosc_list_compressors() });
+            let complist = unsafe { string_from_cstr(blosc_list_compressors()) };
             let errmsg = format!(
                 concat!(
                     "This Blosc library does not have support for the '{}' compressor, ",
                     "but only for: {}"
                 ),
-                string_from_cstr(cfg.compname),
+                unsafe { string_from_cstr(cfg.compname) },
                 complist
             );
             h5err!(errmsg, H5E_PLIST, H5E_CALLBACK);
@@ -176,7 +176,7 @@ fn parse_blosc_cdata(cd_nelmts: size_t, cd_values: *const c_uint) -> Option<Blos
     Some(cfg)
 }
 
-extern "C" fn filter_blosc(
+unsafe extern "C" fn filter_blosc(
     flags: c_uint, cd_nelmts: size_t, cd_values: *const c_uint, nbytes: size_t,
     buf_size: *mut size_t, buf: *mut *mut c_void,
 ) -> size_t {

--- a/hdf5/src/hl/filters/lzf.rs
+++ b/hdf5/src/hl/filters/lzf.rs
@@ -92,7 +92,7 @@ extern "C" fn set_local_lzf(dcpl_id: hid_t, type_id: hid_t, _space_id: hid_t) ->
     }
 }
 
-extern "C" fn filter_lzf(
+unsafe extern "C" fn filter_lzf(
     flags: c_uint, cd_nelmts: size_t, cd_values: *const c_uint, nbytes: size_t,
     buf_size: *mut size_t, buf: *mut *mut c_void,
 ) -> size_t {

--- a/hdf5/src/hl/group.rs
+++ b/hdf5/src/hl/group.rs
@@ -312,7 +312,7 @@ impl Group {
         // Maps a closure to a C callback
         //
         // This function will be called multiple times, but never concurrently
-        extern "C" fn callback<F, G>(
+        unsafe extern "C" fn callback<F, G>(
             id: hid_t, name: *const c_char, info: *const H5L_info_t, op_data: *mut c_void,
         ) -> herr_t
         where


### PR DESCRIPTION
Found various functions that should be `unsafe` since they take raw pointer arguments and must assume they point to valid data.

Made `string_from_fixed_bytes` panic on invalid UTF-8 instead of marking it unsafe, but marking it unsafe is a valid alternative if the `unwrap` call significantly reduces performance.