### PR TITLE
Fix definition of `H5L_info2_t`

### DIFF
--- a/hdf5-sys/src/h5l.rs
+++ b/hdf5-sys/src/h5l.rs
@@ -1,4 +1,5 @@
 //! Creating and manipulating links within an HDF5 group
+#[cfg(feature = "1.12.0")]
 use std::fmt;
 use std::mem;
 

--- a/hdf5-sys/src/h5l.rs
+++ b/hdf5-sys/src/h5l.rs
@@ -1,4 +1,5 @@
 //! Creating and manipulating links within an HDF5 group
+use std::fmt;
 use std::mem;
 
 pub use self::H5L_type_t::*;
@@ -64,20 +65,43 @@ impl H5L_info1_t__u {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[cfg(feature = "1.12.0")]
 pub struct H5L_info2_t {
     pub type_: H5L_type_t,
     pub corder_valid: hbool_t,
     pub corder: int64_t,
     pub cset: H5T_cset_t,
-    pub u: H5L_info1_t__u,
+    pub u: H5L_info2_t__u,
 }
 
 #[cfg(feature = "1.12.0")]
 impl Default for H5L_info2_t {
     fn default() -> Self {
         unsafe { mem::zeroed() }
+    }
+}
+
+#[cfg(feature = "1.12.0")]
+impl fmt::Debug for H5L_info2_t {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut debug_struct = f.debug_struct("H5L_info2_t");
+        debug_struct
+            .field("type_", &self.type_)
+            .field("corder_valid", &self.corder_valid)
+            .field("corder", &self.corder)
+            .field("cset", &self.cset);
+
+        match self.type_ {
+            H5L_TYPE_HARD => {
+                debug_struct.field("token", unsafe { &self.u.token });
+            }
+            H5L_TYPE_SOFT | H5L_TYPE_EXTERNAL | H5L_TYPE_MAX => {
+                debug_struct.field("val_size", unsafe { &self.u.val_size });
+            }
+            H5L_TYPE_ERROR => {}
+        }
+        debug_struct.finish()
     }
 }
 
@@ -93,6 +117,16 @@ pub union H5L_info2_t__u {
 impl Default for H5L_info2_t__u {
     fn default() -> Self {
         unsafe { mem::zeroed() }
+    }
+}
+
+#[cfg(feature = "1.12.0")]
+impl H5L_info2_t__u {
+    pub unsafe fn token(&mut self) -> *mut H5O_token_t {
+        &mut self.token as *mut H5O_token_t
+    }
+    pub unsafe fn val_size(&mut self) -> *mut size_t {
+        &mut self.val_size as *mut size_t
     }
 }
 


### PR DESCRIPTION
Replace incorrect `H5L_info1_t__u` with `H5L_info2_t__u`. Since `H5L_info1_t__u` does not have the same size as `H5L_info2_t__u`, this bug resulted in 8 bytes of stack memory outside the allocated region being overwritten by the hdf5 C-library for example when using `H5Lget_info2`.

Since `Debug` can no longer be derived, add a manual implementation for the struct `H5L_info2_t` in order to correctly match the variant of `H5L_info2_t__u` to the link type.

Additionally, add methods to access the union fields of `H5L_info2_t__u`.