### PR TITLE
fix: Add Installation to Conda setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         with: {toolchain: '${{matrix.rust}}'}
       - name: Install conda
         uses: conda-incubator/setup-miniconda@v2
-        with: {auto-update-conda: false, activate-environment: testenv}
+        with: {auto-update-conda: false, activate-environment: testenv, miniconder-version: latest}
       - name: Install HDF5 (${{matrix.version}}${{matrix.mpi && '-' || ''}}${{matrix.mpi}})
         run: |
           [ "${{matrix.mpi}}" != "" ] && MPICC_PKG=${{matrix.mpi}}-mpicc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         with: {toolchain: '${{matrix.rust}}'}
       - name: Install conda
         uses: conda-incubator/setup-miniconda@v2
-        with: {auto-update-conda: false, activate-environment: testenv, miniconder-version: latest}
+        with: {auto-update-conda: false, activate-environment: testenv, miniconda-version: latest}
       - name: Install HDF5 (${{matrix.version}}${{matrix.mpi && '-' || ''}}${{matrix.mpi}})
         run: |
           [ "${{matrix.mpi}}" != "" ] && MPICC_PKG=${{matrix.mpi}}-mpicc


### PR DESCRIPTION
It seems from https://github.com/actions/runner-images/issues/9262 that miniconda was removed from Mac images.

This adds the configuration to the setup step to now install miniconda again.

I need to validate that this isn't having a significant impact on the Windows and Linux steps where this is not a concern.